### PR TITLE
feat: replace panic!() with BridgeError returns (#6)

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -70,10 +70,11 @@ fn mark_initialized(env: &Env) {
         .set(&DataKey::Initialized, &true);
 }
 
-fn check_initialized(env: &Env) {
+fn check_initialized(env: &Env) -> Result<(), BridgeError> {
     if !read_initialized(env) {
-        panic!("not initialized");
+        return Err(BridgeError::NotInitialized);
     }
+    Ok(())
 }
 
 fn calculate_fee(amount: i128, fee_bps: u32) -> i128 {
@@ -85,18 +86,19 @@ pub struct OnboardingBridge;
 
 #[contractimpl]
 impl OnboardingBridge {
-    pub fn initialize(env: Env, admin: Address, fee_collector: Address, fee_bps: u32) {
+    pub fn initialize(env: Env, admin: Address, fee_collector: Address, fee_bps: u32) -> Result<(), BridgeError> {
         if read_initialized(&env) {
-            panic!("already initialized");
+            return Err(BridgeError::AlreadyInitialized);
         }
         if fee_bps > MAX_FEE_BPS {
-            panic!("fee too high");
+            return Err(BridgeError::FeeTooHigh);
         }
         admin.require_auth();
         save_admin(&env, &admin);
         save_fee_collector(&env, &fee_collector);
         save_fee_bps(&env, &fee_bps);
         mark_initialized(&env);
+        Ok(())
     }
 
     pub fn fund_c_address(
@@ -105,10 +107,10 @@ impl OnboardingBridge {
         target: Address,
         asset: Address,
         amount: i128,
-    ) {
-        check_initialized(&env);
+    ) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
         if amount <= 0 {
-            panic!("invalid amount");
+            return Err(BridgeError::InvalidAmount);
         }
         source.require_auth();
 
@@ -127,6 +129,7 @@ impl OnboardingBridge {
             ("CAddressFunded", source, target),
             (amount, fee, asset),
         );
+        Ok(())
     }
 
     pub fn batch_fund_c_address(
@@ -135,13 +138,13 @@ impl OnboardingBridge {
         targets: Vec<Address>,
         amounts: Vec<i128>,
         asset: Address,
-    ) {
-        check_initialized(&env);
+    ) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
         if targets.len() != amounts.len() {
-            panic!("mismatched arrays");
+            return Err(BridgeError::MismatchedArrays);
         }
         if targets.len() == 0 {
-            return;
+            return Ok(());
         }
         source.require_auth();
 
@@ -149,7 +152,7 @@ impl OnboardingBridge {
         for i in 0..targets.len() {
             let amount = amounts.get(i).unwrap();
             if amount <= 0 {
-                panic!("invalid amount");
+                return Err(BridgeError::InvalidAmount);
             }
             total += amount;
         }
@@ -175,36 +178,40 @@ impl OnboardingBridge {
                 (amount, fee, asset.clone()),
             );
         }
+        Ok(())
     }
 
-    pub fn set_fee_bps(env: Env, new_fee_bps: u32) {
-        check_initialized(&env);
+    pub fn set_fee_bps(env: Env, new_fee_bps: u32) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
         if new_fee_bps > MAX_FEE_BPS {
-            panic!("fee too high");
+            return Err(BridgeError::FeeTooHigh);
         }
         let admin = read_admin(&env);
         admin.require_auth();
         save_fee_bps(&env, &new_fee_bps);
+        Ok(())
     }
 
-    pub fn set_fee_collector(env: Env, new_fee_collector: Address) {
-        check_initialized(&env);
+    pub fn set_fee_collector(env: Env, new_fee_collector: Address) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
         save_fee_collector(&env, &new_fee_collector);
+        Ok(())
     }
 
-    pub fn set_admin(env: Env, new_admin: Address) {
-        check_initialized(&env);
+    pub fn set_admin(env: Env, new_admin: Address) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
         save_admin(&env, &new_admin);
+        Ok(())
     }
 
-    pub fn withdraw_fees(env: Env, asset: Address, amount: i128) {
-        check_initialized(&env);
+    pub fn withdraw_fees(env: Env, asset: Address, amount: i128) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
         if amount <= 0 {
-            panic!("invalid amount");
+            return Err(BridgeError::InvalidAmount);
         }
         let fee_collector = read_fee_collector(&env);
         fee_collector.require_auth();
@@ -214,21 +221,22 @@ impl OnboardingBridge {
 
         env.events()
             .publish(("FeesWithdrawn", fee_collector), (amount, asset));
+        Ok(())
     }
 
-    pub fn query_fee_bps(env: Env) -> u32 {
-        check_initialized(&env);
-        read_fee_bps(&env)
+    pub fn query_fee_bps(env: Env) -> Result<u32, BridgeError> {
+        check_initialized(&env)?;
+        Ok(read_fee_bps(&env))
     }
 
-    pub fn query_fee_collector(env: Env) -> Address {
-        check_initialized(&env);
-        read_fee_collector(&env)
+    pub fn query_fee_collector(env: Env) -> Result<Address, BridgeError> {
+        check_initialized(&env)?;
+        Ok(read_fee_collector(&env))
     }
 
-    pub fn query_admin(env: Env) -> Address {
-        check_initialized(&env);
-        read_admin(&env)
+    pub fn query_admin(env: Env) -> Result<Address, BridgeError> {
+        check_initialized(&env)?;
+        Ok(read_admin(&env))
     }
 
     pub fn query_balance(env: Env, c_address: Address, asset: Address) -> i128 {

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::OnboardingBridge;
+use crate::{BridgeError, OnboardingBridge};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
@@ -55,7 +55,6 @@ fn test_initialize() {
 }
 
 #[test]
-#[should_panic(expected = "already initialized")]
 fn test_initialize_twice() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
@@ -63,18 +62,23 @@ fn test_initialize_twice() {
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    assert_eq!(
+        bridge.try_initialize(&admin, &fee_collector, &50u32),
+        Err(Ok(BridgeError::AlreadyInitialized))
+    );
 }
 
 #[test]
-#[should_panic(expected = "fee too high")]
 fn test_initialize_fee_too_high() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &2000u32);
+    assert_eq!(
+        bridge.try_initialize(&admin, &fee_collector, &2000u32),
+        Err(Ok(BridgeError::FeeTooHigh))
+    );
 }
 
 #[test]
@@ -98,7 +102,6 @@ fn test_fund_c_address() {
 }
 
 #[test]
-#[should_panic(expected = "not initialized")]
 fn test_fund_without_initialize() {
     let env = Env::default();
     let (_admin, user, _fee_collector) = create_test_users(&env);
@@ -110,7 +113,10 @@ fn test_fund_without_initialize() {
     let b2_id = env.register(OnboardingBridge, ());
     let b2 = crate::OnboardingBridgeClient::new(&env, &b2_id);
     let target = Address::generate(&env);
-    b2.fund_c_address(&user, &target, &token_id, &100i128);
+    assert_eq!(
+        b2.try_fund_c_address(&user, &target, &token_id, &100i128),
+        Err(Ok(BridgeError::NotInitialized))
+    );
 }
 
 #[test]
@@ -173,7 +179,6 @@ fn test_set_fee_bps() {
 }
 
 #[test]
-#[should_panic(expected = "fee too high")]
 fn test_set_fee_bps_too_high() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
@@ -181,7 +186,10 @@ fn test_set_fee_bps_too_high() {
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.set_fee_bps(&2000u32);
+    assert_eq!(
+        bridge.try_set_fee_bps(&2000u32),
+        Err(Ok(BridgeError::FeeTooHigh))
+    );
 }
 
 #[test]
@@ -286,12 +294,14 @@ fn test_fund_events() {
 }
 
 #[test]
-#[should_panic(expected = "not initialized")]
 fn test_query_fee_bps_uninitialized() {
     let env = Env::default();
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
-    bridge.query_fee_bps();
+    assert_eq!(
+        bridge.try_query_fee_bps(),
+        Err(Ok(BridgeError::NotInitialized))
+    );
 }
 
 /********** Minimal Test Token **********/


### PR DESCRIPTION
- check_initialized() now returns Result<(), BridgeError> and propagates via ? in all callers instead of panicking
- initialize() returns Result<(), BridgeError>: AlreadyInitialized instead of panic!("already initialized") FeeTooHigh instead of panic!("fee too high")
- fund_c_address() returns Result<(), BridgeError>: NotInitialized (via check_initialized) InvalidAmount instead of panic!("invalid amount")
- batch_fund_c_address() returns Result<(), BridgeError>: NotInitialized (via check_initialized) MismatchedArrays instead of panic!("mismatched arrays") InvalidAmount instead of panic!("invalid amount")
- set_fee_bps() returns Result<(), BridgeError>: NotInitialized / FeeTooHigh
- set_fee_collector() returns Result<(), BridgeError>: NotInitialized
- set_admin() returns Result<(), BridgeError>: NotInitialized
- withdraw_fees() returns Result<(), BridgeError>: NotInitialized / InvalidAmount
- query_fee_bps() returns Result<u32, BridgeError>: NotInitialized
- query_fee_collector() returns Result<Address, BridgeError>: NotInitialized
- query_admin() returns Result<Address, BridgeError>: NotInitialized
- query_balance / query_is_initialized are infallible, unchanged
- tests.rs: all #[should_panic] tests replaced with try_ client assertions using Err(Ok(BridgeError::Variant)) pattern; import BridgeError added
closes #6