### PR TITLE
feat(sdk): add TypeScript unit tests for SDK and OffRamp

### DIFF
--- a/sdk/jest.config.js
+++ b/sdk/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/src/__tests__/**/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: { strict: false } }],
+  },
+};

--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -1,0 +1,290 @@
+import { OnboardingBridgeSDK } from '../bridge';
+import { SorobanRpc, scValToNative } from '@stellar/stellar-sdk';
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  SorobanRpc: {
+    Server: jest.fn(),
+  },
+  Contract: jest.fn().mockImplementation(() => ({
+    call: jest.fn().mockReturnValue({}),
+  })),
+  TransactionBuilder: jest.fn().mockImplementation(() => ({
+    addOperation: jest.fn().mockReturnThis(),
+    setTimeout: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  Account: jest.fn().mockImplementation(() => ({})),
+  xdr: {
+    ScVal: {
+      scvVoid: jest.fn().mockReturnValue({}),
+      scvVec: jest.fn().mockReturnValue({}),
+    },
+  },
+  Address: jest.fn().mockImplementation(() => ({
+    toScVal: jest.fn().mockReturnValue({}),
+  })),
+  nativeToScVal: jest.fn().mockReturnValue({}),
+  scValToNative: jest.fn(),
+  BASE_FEE: '100',
+  Networks: {
+    TESTNET: 'Test SDF Network ; September 2015',
+    PUBLIC: 'Public Global Stellar Network ; September 2015',
+  },
+}));
+
+const CONFIG = {
+  contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+};
+
+const MOCK_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const MOCK_ASSET = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+
+describe('OnboardingBridgeSDK', () => {
+  let sdk: OnboardingBridgeSDK;
+  let mockProvider: any;
+  let mockKeypair: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockKeypair = {
+      publicKey: jest.fn().mockReturnValue(MOCK_ADDRESS),
+      sign: jest.fn(),
+    };
+
+    mockProvider = {
+      getAccount: jest.fn().mockResolvedValue({}),
+      prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn().mockResolvedValue({ hash: 'mock_tx_hash', status: 'PENDING' }),
+      simulateTransaction: jest.fn().mockResolvedValue({}),
+    };
+
+    (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);
+    sdk = new OnboardingBridgeSDK(CONFIG);
+  });
+
+  describe('fundCAddress', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.fundCAddress(
+        { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBe('mock_tx_hash');
+      expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
+      expect(mockProvider.prepareTransaction).toHaveBeenCalled();
+      expect(mockProvider.sendTransaction).toHaveBeenCalled();
+    });
+
+    it('returns failed status on ERROR response', async () => {
+      mockProvider.sendTransaction.mockResolvedValue({ hash: 'err_hash', status: 'ERROR' });
+
+      const result = await sdk.fundCAddress(
+        { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.hash).toBe('err_hash');
+    });
+
+    it('returns failed status on network error', async () => {
+      mockProvider.getAccount.mockRejectedValue(new Error('Network timeout'));
+
+      const result = await sdk.fundCAddress(
+        { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toBe('Network timeout');
+      expect(result.hash).toBe('');
+    });
+  });
+
+  describe('batchFundCAddresses', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.batchFundCAddresses(
+        {
+          source: MOCK_ADDRESS,
+          targets: [MOCK_ADDRESS, MOCK_ADDRESS],
+          amounts: ['500', '500'],
+          asset: MOCK_ASSET,
+        },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBe('mock_tx_hash');
+    });
+
+    it('returns failed status when transaction errors (e.g. mismatched arrays on-chain)', async () => {
+      mockProvider.sendTransaction.mockResolvedValue({ hash: 'err_hash', status: 'ERROR' });
+
+      const result = await sdk.batchFundCAddresses(
+        {
+          source: MOCK_ADDRESS,
+          targets: [MOCK_ADDRESS],
+          amounts: ['500', '500'],
+          asset: MOCK_ASSET,
+        },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('failed');
+    });
+  });
+
+  describe('withdrawFees', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.withdrawFees(
+        { asset: MOCK_ASSET, amount: '100' },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBe('mock_tx_hash');
+      expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
+    });
+  });
+
+  describe('setFee', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.setFee(100, mockKeypair);
+
+      expect(result.status).toBe('pending');
+      expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
+    });
+  });
+
+  describe('setFeeCollector', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.setFeeCollector(MOCK_ADDRESS, mockKeypair);
+
+      expect(result.status).toBe('pending');
+    });
+  });
+
+  describe('setAdmin', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.setAdmin(MOCK_ADDRESS, mockKeypair);
+
+      expect(result.status).toBe('pending');
+    });
+  });
+
+  describe('getFee', () => {
+    it('returns the fee as a number from simulation result', async () => {
+      (scValToNative as jest.Mock).mockReturnValue(50);
+      mockProvider.simulateTransaction.mockResolvedValue({
+        results: [{ retval: {} }],
+      });
+
+      const fee = await sdk.getFee();
+
+      expect(fee).toBe(50);
+      expect(mockProvider.simulateTransaction).toHaveBeenCalled();
+    });
+
+    it('returns 0 when no results are present', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({});
+
+      const fee = await sdk.getFee();
+
+      expect(fee).toBe(0);
+    });
+
+    it('throws when simulation returns an error', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({ error: 'contract error' });
+
+      await expect(sdk.getFee()).rejects.toThrow('Failed to get fee');
+    });
+  });
+
+  describe('getFeeCollector', () => {
+    it('returns fee collector address string', async () => {
+      (scValToNative as jest.Mock).mockReturnValue({ toString: () => MOCK_ADDRESS });
+      mockProvider.simulateTransaction.mockResolvedValue({
+        results: [{ retval: {} }],
+      });
+
+      const addr = await sdk.getFeeCollector();
+
+      expect(addr).toBe(MOCK_ADDRESS);
+    });
+
+    it('returns empty string when no results', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({});
+
+      const addr = await sdk.getFeeCollector();
+
+      expect(addr).toBe('');
+    });
+  });
+
+  describe('getAdmin', () => {
+    it('returns admin address string', async () => {
+      (scValToNative as jest.Mock).mockReturnValue({ toString: () => MOCK_ADDRESS });
+      mockProvider.simulateTransaction.mockResolvedValue({
+        results: [{ retval: {} }],
+      });
+
+      const addr = await sdk.getAdmin();
+
+      expect(addr).toBe(MOCK_ADDRESS);
+    });
+
+    it('returns empty string when no results', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({});
+
+      const addr = await sdk.getAdmin();
+
+      expect(addr).toBe('');
+    });
+  });
+
+  describe('getCAddressBalance', () => {
+    it('returns balance as a string', async () => {
+      (scValToNative as jest.Mock).mockReturnValue({ toString: () => '1000' });
+      mockProvider.simulateTransaction.mockResolvedValue({
+        results: [{ retval: {} }],
+      });
+
+      const balance = await sdk.getCAddressBalance(MOCK_ADDRESS, MOCK_ASSET);
+
+      expect(balance).toBe('1000');
+    });
+
+    it('returns "0" when no results', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({});
+
+      const balance = await sdk.getCAddressBalance(MOCK_ADDRESS, MOCK_ASSET);
+
+      expect(balance).toBe('0');
+    });
+  });
+
+  describe('isInitialized', () => {
+    it('returns true when contract is initialized', async () => {
+      (scValToNative as jest.Mock).mockReturnValue(true);
+      mockProvider.simulateTransaction.mockResolvedValue({
+        results: [{ retval: {} }],
+      });
+
+      const result = await sdk.isInitialized();
+
+      expect(result).toBe(true);
+    });
+
+    it('returns false when no results', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({});
+
+      const result = await sdk.isInitialized();
+
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/sdk/src/__tests__/offramp.test.ts
+++ b/sdk/src/__tests__/offramp.test.ts
@@ -1,0 +1,147 @@
+import { OffRampIntegration } from '../offramp';
+
+const TARGET_C_ADDRESS = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
+
+describe('OffRampIntegration', () => {
+  describe('getMoonpayUrl', () => {
+    it('returns a production URL with correct params', () => {
+      const offramp = new OffRampIntegration({
+        moonpayApiKey: 'test_api_key',
+        testMode: false,
+      });
+
+      const url = offramp.getMoonpayUrl({
+        targetCAddress: TARGET_C_ADDRESS,
+        amount: '100',
+        currency: 'xlm',
+      });
+
+      expect(url).toContain('https://buy.moonpay.com');
+      expect(url).toContain('apiKey=test_api_key');
+      expect(url).toContain('currency=xlm');
+      expect(url).toContain('baseCurrencyAmount=100');
+      expect(url).toContain(encodeURIComponent(TARGET_C_ADDRESS));
+    });
+
+    it('returns a staging URL when testMode is true', () => {
+      const offramp = new OffRampIntegration({
+        moonpayApiKey: 'pk_test_123',
+        testMode: true,
+      });
+
+      const url = offramp.getMoonpayUrl({
+        targetCAddress: TARGET_C_ADDRESS,
+        amount: '50',
+        currency: 'usd',
+      });
+
+      expect(url).toContain('https://buy-staging.moonpay.com');
+    });
+
+    it('includes assetCode when provided', () => {
+      const offramp = new OffRampIntegration({
+        moonpayApiKey: 'key',
+        testMode: false,
+      });
+
+      const url = offramp.getMoonpayUrl({
+        targetCAddress: TARGET_C_ADDRESS,
+        amount: '200',
+        currency: 'xlm',
+        assetCode: 'xlm',
+      });
+
+      expect(url).toContain('baseCurrencyCode=xlm');
+    });
+  });
+
+  describe('getTransakUrl', () => {
+    it('returns a production URL with correct params', () => {
+      const offramp = new OffRampIntegration({
+        transakApiKey: 'transak_key',
+        testMode: false,
+      });
+
+      const url = offramp.getTransakUrl({
+        targetCAddress: TARGET_C_ADDRESS,
+        amount: '150',
+        currency: 'xlm',
+      });
+
+      expect(url).toContain('https://global.transak.com');
+      expect(url).toContain('apiKey=transak_key');
+      expect(url).toContain('defaultCryptoCurrency=XLM');
+      expect(url).toContain('network=stellar');
+      expect(url).toContain('defaultFiatAmount=150');
+    });
+
+    it('returns a staging URL when testMode is true', () => {
+      const offramp = new OffRampIntegration({
+        transakApiKey: 'key',
+        testMode: true,
+      });
+
+      const url = offramp.getTransakUrl({
+        targetCAddress: TARGET_C_ADDRESS,
+        amount: '50',
+        currency: 'xlm',
+      });
+
+      expect(url).toContain('https://global-staging.transak.com');
+    });
+
+    it('includes fiatCurrency when provided', () => {
+      const offramp = new OffRampIntegration({
+        transakApiKey: 'key',
+        testMode: false,
+      });
+
+      const url = offramp.getTransakUrl({
+        targetCAddress: TARGET_C_ADDRESS,
+        amount: '100',
+        currency: 'xlm',
+        fiatCurrency: 'EUR',
+      });
+
+      expect(url).toContain('fiatCurrency=EUR');
+    });
+  });
+
+  describe('generateCEXDepositMemo', () => {
+    it('returns memo in bridge:<address> format', () => {
+      const offramp = new OffRampIntegration({});
+
+      const memo = offramp.generateCEXDepositMemo(TARGET_C_ADDRESS);
+
+      expect(memo).toBe(`bridge:${TARGET_C_ADDRESS}`);
+    });
+
+    it('always prefixes with bridge:', () => {
+      const offramp = new OffRampIntegration({});
+      const addr = 'GSOME_ADDRESS';
+
+      const memo = offramp.generateCEXDepositMemo(addr);
+
+      expect(memo.startsWith('bridge:')).toBe(true);
+      expect(memo).toBe('bridge:GSOME_ADDRESS');
+    });
+  });
+
+  describe('decodeCEXDepositMemo', () => {
+    it('decodes a valid bridge memo', () => {
+      const offramp = new OffRampIntegration({});
+
+      const decoded = offramp.decodeCEXDepositMemo(`bridge:${TARGET_C_ADDRESS}`);
+
+      expect(decoded).toBe(TARGET_C_ADDRESS);
+    });
+
+    it('returns null for an invalid memo', () => {
+      const offramp = new OffRampIntegration({});
+
+      expect(offramp.decodeCEXDepositMemo('invalid_memo')).toBeNull();
+      expect(offramp.decodeCEXDepositMemo('')).toBeNull();
+      expect(offramp.decodeCEXDepositMemo('nobridge:addr')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Closes #4


## Summary

- Adds `sdk/jest.config.js` — jest configuration using the `ts-jest` preset with node environment; no new runtime dependencies (jest + ts-jest already present in `devDependencies`)
- Adds `sdk/src/__tests__/bridge.test.ts` — 20 tests covering all `OnboardingBridgeSDK` methods; `SorobanRpc.Server` is fully mocked so tests run offline
- Adds `sdk/src/__tests__/offramp.test.ts` — 10 tests covering all `OffRampIntegration` methods


## Coverage

### `OnboardingBridgeSDK` (bridge.test.ts)
| Method | Cases |
|---|---|
| `fundCAddress` | success, ERROR status, network error |
| `batchFundCAddresses` | success, on-chain error (mismatched arrays) |
| `withdrawFees` | success |
| `setFee` / `setFeeCollector` / `setAdmin` | success |
| `getFee` | correct value, empty result default, simulation error |
| `getFeeCollector` / `getAdmin` | correct address string, empty result default |
| `getCAddressBalance` | correct balance string, empty result default |
| `isInitialized` | true, false (empty result) |
