### PR TITLE
fix: remove unused Networks import and fix amount string→i128 conversion

### DIFF
--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -15,7 +15,6 @@ import {
   scValToNative,
   TransactionBuilder,
   BASE_FEE,
-  Networks,
 } from '@stellar/stellar-sdk';
 
 export class OnboardingBridgeSDK {
@@ -408,6 +407,9 @@ export class OnboardingBridgeSDK {
     if (typeof arg === 'string') {
       if (arg.startsWith('C') || arg.startsWith('G')) {
         return new Address(arg).toScVal();
+      }
+      if (/^\d+$/.test(arg)) {
+        return nativeToScVal(BigInt(arg), { type: 'i128' });
       }
       return nativeToScVal(arg, { type: 'string' });
     }


### PR DESCRIPTION
- Remove Networks from stellar-sdk imports in bridge.ts (unused)
- Fix toSingleScVal to parse numeric strings as BigInt i128 instead of treating them as string ScVals, so amount fields in FundCOptions, BatchFundCOptions, and WithdrawFeesOptions correctly serialize to i128 for the Soroban contract
Closes #11 