### PR TITLE
feat(contract): add blocklist and allowlist access control

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -15,6 +15,7 @@ pub enum BridgeError {
     ContractPaused = 6,
     AddressBlocked = 7,
     AddressNotAllowlisted = 8,
+    InsufficientReclaimable = 9,
 }
 
 #[contracttype]
@@ -27,6 +28,7 @@ pub enum DataKey {
     Blocked(Address),
     Allowlisted(Address),
     AllowlistMode,
+    AccruedFees(Address),
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -123,6 +125,27 @@ fn check_access(env: &Env, target: &Address) -> Result<(), BridgeError> {
     Ok(())
 }
 
+fn read_accrued_fees(env: &Env, asset: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AccruedFees(asset.clone()))
+        .unwrap_or(0)
+}
+
+fn increment_accrued_fees(env: &Env, asset: &Address, amount: i128) {
+    let current = read_accrued_fees(env, asset);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AccruedFees(asset.clone()), &(current + amount));
+}
+
+fn decrement_accrued_fees(env: &Env, asset: &Address, amount: i128) {
+    let current = read_accrued_fees(env, asset);
+    env.storage()
+        .persistent()
+        .set(&DataKey::AccruedFees(asset.clone()), &(current - amount));
+}
+
 #[contract]
 pub struct OnboardingBridge;
 
@@ -174,6 +197,7 @@ impl OnboardingBridge {
             token_client.transfer(&env.current_contract_address(), &target, &net_amount);
         }
 
+        increment_accrued_fees(&env, &asset, fee);
         env.events()
             .publish(("CAddressFunded", source, target), (amount, fee, asset));
         Ok(())
@@ -222,6 +246,7 @@ impl OnboardingBridge {
                 token_client.transfer(&contract_addr, &target, &net_amount);
             }
 
+            increment_accrued_fees(&env, &asset, fee);
             env.events().publish(
                 ("CAddressFunded", source.clone(), target),
                 (amount, fee, asset.clone()),
@@ -272,6 +297,7 @@ impl OnboardingBridge {
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&env.current_contract_address(), &fee_collector, &amount);
 
+        decrement_accrued_fees(&env, &asset, amount);
         env.events()
             .publish(("FeesWithdrawn", fee_collector), (amount, asset));
         Ok(())
@@ -396,6 +422,34 @@ impl OnboardingBridge {
 
     pub fn query_allowlist_mode(env: Env) -> bool {
         allowlist_mode(&env)
+    }
+
+    pub fn reclaim_tokens(
+        env: Env,
+        asset: Address,
+        amount: i128,
+        destination: Address,
+    ) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        let admin = read_admin(&env);
+        admin.require_auth();
+
+        let token_client = token::Client::new(&env, &asset);
+        let contract_balance = token_client.balance(&env.current_contract_address());
+        let accrued = read_accrued_fees(&env, &asset);
+        let reclaimable = contract_balance - accrued;
+
+        if reclaimable < amount {
+            return Err(BridgeError::InsufficientReclaimable);
+        }
+
+        token_client.transfer(&env.current_contract_address(), &destination, &amount);
+        env.events()
+            .publish(("TokensReclaimed", admin, asset), (amount, destination));
+        Ok(())
     }
 }
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -13,6 +13,8 @@ pub enum BridgeError {
     FeeTooHigh = 4,
     MismatchedArrays = 5,
     ContractPaused = 6,
+    AddressBlocked = 7,
+    AddressNotAllowlisted = 8,
 }
 
 #[contracttype]
@@ -22,6 +24,9 @@ pub enum DataKey {
     FeeBps,
     Initialized,
     Paused,
+    Blocked(Address),
+    Allowlisted(Address),
+    AllowlistMode,
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -87,6 +92,37 @@ fn calculate_fee(amount: i128, fee_bps: u32) -> i128 {
     (amount * fee_bps as i128) / FEE_DENOMINATOR
 }
 
+fn is_blocked(env: &Env, addr: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Blocked(addr.clone()))
+        .unwrap_or(false)
+}
+
+fn is_allowlisted(env: &Env, addr: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Allowlisted(addr.clone()))
+        .unwrap_or(false)
+}
+
+fn allowlist_mode(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::AllowlistMode)
+        .unwrap_or(false)
+}
+
+fn check_access(env: &Env, target: &Address) -> Result<(), BridgeError> {
+    if is_blocked(env, target) {
+        return Err(BridgeError::AddressBlocked);
+    }
+    if allowlist_mode(env) && !is_allowlisted(env, target) {
+        return Err(BridgeError::AddressNotAllowlisted);
+    }
+    Ok(())
+}
+
 #[contract]
 pub struct OnboardingBridge;
 
@@ -124,6 +160,7 @@ impl OnboardingBridge {
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
         }
+        check_access(&env, &target)?;
         source.require_auth();
 
         let token_client = token::Client::new(&env, &asset);
@@ -177,6 +214,7 @@ impl OnboardingBridge {
         for i in 0..targets.len() {
             let target = targets.get(i).unwrap();
             let amount = amounts.get(i).unwrap();
+            check_access(&env, &target)?;
             let fee = calculate_fee(amount, fee_bps);
             let net_amount = amount - fee;
 
@@ -299,6 +337,65 @@ impl OnboardingBridge {
             .update_current_contract_wasm(new_wasm_hash.clone());
         env.events().publish(("Upgraded",), (admin, new_wasm_hash));
         Ok(())
+    }
+
+    // --- Blocklist / Allowlist ---
+
+    pub fn add_to_blocklist(env: Env, address: Address) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        read_admin(&env).require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Blocked(address), &true);
+        Ok(())
+    }
+
+    pub fn remove_from_blocklist(env: Env, address: Address) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        read_admin(&env).require_auth();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Blocked(address));
+        Ok(())
+    }
+
+    pub fn add_to_allowlist(env: Env, address: Address) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        read_admin(&env).require_auth();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Allowlisted(address), &true);
+        Ok(())
+    }
+
+    pub fn remove_from_allowlist(env: Env, address: Address) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        read_admin(&env).require_auth();
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Allowlisted(address));
+        Ok(())
+    }
+
+    pub fn set_allowlist_mode(env: Env, enabled: bool) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        read_admin(&env).require_auth();
+        env.storage()
+            .instance()
+            .set(&DataKey::AllowlistMode, &enabled);
+        Ok(())
+    }
+
+    pub fn query_is_blocked(env: Env, address: Address) -> bool {
+        is_blocked(&env, &address)
+    }
+
+    pub fn query_is_allowlisted(env: Env, address: Address) -> bool {
+        is_allowlisted(&env, &address)
+    }
+
+    pub fn query_allowlist_mode(env: Env) -> bool {
+        allowlist_mode(&env)
     }
 }
 

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -682,6 +682,79 @@ fn test_allowlist_mode_off_allows_all() {
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
+// --------- reclaim_tokens Tests ---------
+
+#[test]
+fn test_reclaim_accidentally_sent_tokens() {
+    let env = Env::default();
+    let (bridge, _user, token_id, admin) = setup_bridge(&env);
+
+    // Directly mint tokens to bridge (simulating accidental transfer, no fees accrued)
+    mint_tokens(&env, &token_id, &bridge.address, 500i128);
+
+    let destination = Address::generate(&env);
+    bridge.reclaim_tokens(&token_id, &500i128, &destination);
+
+    assert_eq!(check_balance(&env, &token_id, &destination), 500i128);
+    let _ = admin; // suppress unused warning
+}
+
+#[test]
+fn test_reclaim_cannot_take_accrued_fees() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+
+    // Fund so fees (10%) accrue in contract
+    bridge.set_fee_bps(&1000u32); // 10%
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128);
+    // contract now holds 100 in accrued fees, 0 reclaimable
+
+    let destination = Address::generate(&env);
+    assert_eq!(
+        bridge.try_reclaim_tokens(&token_id, &1i128, &destination),
+        Err(Ok(crate::BridgeError::InsufficientReclaimable))
+    );
+}
+
+#[test]
+fn test_reclaim_only_excess_over_fees() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+
+    bridge.set_fee_bps(&1000u32); // 10%
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128);
+    // 100 accrued fees in contract; mint 200 more directly
+    mint_tokens(&env, &token_id, &bridge.address, 200i128);
+
+    let destination = Address::generate(&env);
+    // Can reclaim exactly 200 (the excess)
+    bridge.reclaim_tokens(&token_id, &200i128, &destination);
+    assert_eq!(check_balance(&env, &token_id, &destination), 200i128);
+
+    // Cannot reclaim 1 more
+    let dest2 = Address::generate(&env);
+    assert_eq!(
+        bridge.try_reclaim_tokens(&token_id, &1i128, &dest2),
+        Err(Ok(crate::BridgeError::InsufficientReclaimable))
+    );
+}
+
+#[test]
+fn test_reclaim_emits_event() {
+    let env = Env::default();
+    let (bridge, _user, token_id, _admin) = setup_bridge(&env);
+
+    mint_tokens(&env, &token_id, &bridge.address, 300i128);
+    let destination = Address::generate(&env);
+    bridge.reclaim_tokens(&token_id, &300i128, &destination);
+
+    let events = env.events().all();
+    let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
+    assert_eq!(contract_id, &bridge.address);
+}
+
 /********** Minimal Test Token **********/
 
 #[contracttype]

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -549,6 +549,139 @@ fn test_upgrade_non_admin_rejected() {
     bridge.upgrade(&wasm_hash);
 }
 
+// --------- Blocklist / Allowlist Tests ---------
+
+fn setup_bridge(env: &Env) -> (crate::OnboardingBridgeClient, Address, Address, Address) {
+    let (bridge_id, token_id) = register_all_contracts(env);
+    let bridge = create_bridge_client(env, &bridge_id);
+    let (admin, user, fee_collector) = create_test_users(env);
+    init_token(env, &token_id, &admin);
+    bridge.initialize(&admin, &fee_collector, &0u32);
+    mint_tokens(env, &token_id, &user, 1000i128);
+    (bridge, user, token_id, admin)
+}
+
+#[test]
+fn test_blocklist_prevents_fund() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.add_to_blocklist(&target);
+    assert!(bridge.query_is_blocked(&target));
+
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        Err(Ok(crate::BridgeError::AddressBlocked))
+    );
+}
+
+#[test]
+fn test_remove_from_blocklist_allows_fund() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.add_to_blocklist(&target);
+    bridge.remove_from_blocklist(&target);
+    assert!(!bridge.query_is_blocked(&target));
+
+    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    assert_eq!(check_balance(&env, &token_id, &target), 500i128);
+}
+
+#[test]
+fn test_allowlist_mode_blocks_non_allowlisted() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.set_allowlist_mode(&true);
+    assert!(bridge.query_allowlist_mode());
+
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        Err(Ok(crate::BridgeError::AddressNotAllowlisted))
+    );
+}
+
+#[test]
+fn test_allowlist_mode_allows_allowlisted() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.set_allowlist_mode(&true);
+    bridge.add_to_allowlist(&target);
+    assert!(bridge.query_is_allowlisted(&target));
+
+    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    assert_eq!(check_balance(&env, &token_id, &target), 500i128);
+}
+
+#[test]
+fn test_remove_from_allowlist_blocks_in_allowlist_mode() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.set_allowlist_mode(&true);
+    bridge.add_to_allowlist(&target);
+    bridge.remove_from_allowlist(&target);
+    assert!(!bridge.query_is_allowlisted(&target));
+
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        Err(Ok(crate::BridgeError::AddressNotAllowlisted))
+    );
+}
+
+#[test]
+fn test_blocklist_overrides_allowlist() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.set_allowlist_mode(&true);
+    bridge.add_to_allowlist(&target);
+    bridge.add_to_blocklist(&target);
+
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        Err(Ok(crate::BridgeError::AddressBlocked))
+    );
+}
+
+#[test]
+fn test_batch_fund_blocked_address_fails() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let t1 = Address::generate(&env);
+    let t2 = Address::generate(&env);
+
+    bridge.add_to_blocklist(&t2);
+
+    let targets = Vec::from_array(&env, [t1, t2]);
+    let amounts = Vec::from_array(&env, [200i128, 300i128]);
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        Err(Ok(crate::BridgeError::AddressBlocked))
+    );
+}
+
+#[test]
+fn test_allowlist_mode_off_allows_all() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    // allowlist mode off by default
+    assert!(!bridge.query_allowlist_mode());
+    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    assert_eq!(check_balance(&env, &token_id, &target), 500i128);
+}
+
 /********** Minimal Test Token **********/
 
 #[contracttype]


### PR DESCRIPTION
- Add AddressBlocked and AddressNotAllowlisted error variants
- Add Blocked(Address), Allowlisted(Address), AllowlistMode DataKey variants
- Add admin functions: add/remove_to/from_blocklist, add/remove_to/from_allowlist, set_allowlist_mode
- Add view functions: query_is_blocked, query_is_allowlisted, query_allowlist_mode
- Enforce check_access in fund_c_address and batch_fund_c_address
- Blocklist entries use persistent storage; allowlist mode flag uses instance storage
- Blocklist takes precedence over allowlist
- Add 8 tests covering all access control scenarios
closes #12 