### PR TITLE
feat: add query_all_balances for dashboard and monitoring (#20)

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -487,6 +487,17 @@ impl OnboardingBridge {
         token_client.balance(&c_address)
     }
 
+    pub fn query_all_balances(env: Env, assets: Vec<Address>) -> Map<Address, i128> {
+        let contract = env.current_contract_address();
+        let mut result: Map<Address, i128> = Map::new(&env);
+        for i in 0..assets.len() {
+            let asset = assets.get(i).unwrap();
+            let balance = token::Client::new(&env, &asset).balance(&contract);
+            result.set(asset, balance);
+        }
+        result
+    }
+
     pub fn query_fee_balance(env: Env, asset: Address) -> Result<i128, BridgeError> {
         check_initialized(&env)?;
         let token_client = token::Client::new(&env, &asset);

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -919,6 +919,39 @@ fn test_batch_fund_rejects_non_whitelisted_asset() {
     );
 }
 
+/********** query_all_balances Tests **********/
+
+#[test]
+fn test_query_all_balances_returns_contract_balances() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+    bridge.initialize(&admin, &fee_collector, &0u32);
+
+    // Mint directly to the bridge contract
+    mint_tokens(&env, &token_id, &bridge_id, 750i128);
+
+    let assets = Vec::from_array(&env, [token_id.clone()]);
+    let balances = bridge.query_all_balances(&assets);
+
+    assert_eq!(balances.get(token_id).unwrap(), 750i128);
+}
+
+#[test]
+fn test_query_all_balances_empty_input() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    bridge.initialize(&admin, &fee_collector, &0u32);
+
+    let assets: Vec<Address> = Vec::new(&env);
+    let balances = bridge.query_all_balances(&assets);
+    assert_eq!(balances.len(), 0);
+}
+
 /********** Minimal Test Token **********/
 
 #[contracttype]

--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -287,4 +287,33 @@ describe('OnboardingBridgeSDK', () => {
       expect(result).toBe(false);
     });
   });
+
+  describe('getAllBalances', () => {
+    it('returns a record of asset → balance strings', async () => {
+      const mockMap = new Map([[MOCK_ASSET, BigInt(1000)]]);
+      (scValToNative as jest.Mock).mockReturnValue(mockMap);
+      mockProvider.simulateTransaction.mockResolvedValue({
+        results: [{ retval: {} }],
+      });
+
+      const result = await sdk.getAllBalances([MOCK_ASSET]);
+
+      expect(result).toEqual({ [MOCK_ASSET]: '1000' });
+      expect(mockProvider.simulateTransaction).toHaveBeenCalled();
+    });
+
+    it('returns empty object when no results', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({});
+
+      const result = await sdk.getAllBalances([MOCK_ASSET]);
+
+      expect(result).toEqual({});
+    });
+
+    it('throws when simulation returns an error', async () => {
+      mockProvider.simulateTransaction.mockResolvedValue({ error: 'contract error' });
+
+      await expect(sdk.getAllBalances([MOCK_ASSET])).rejects.toThrow('Failed to get all balances');
+    });
+  });
 });

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -4,6 +4,7 @@ import {
   BatchFundCOptions,
   WithdrawFeesOptions,
   UpgradeOptions,
+  ReclaimTokensOptions,
   TransactionResult,
 } from './types';
 import {
@@ -297,6 +298,31 @@ export class OnboardingBridgeSDK {
 
     const scVal = (result as any).results?.[0]?.retval;
     return scVal ? scValToNative(scVal).toString() : '0';
+  }
+
+  /**
+   * Get all token balances held by the contract for the given assets.
+   * Returns a map of asset address → balance string.
+   */
+  async getAllBalances(assets: string[]): Promise<Record<string, string>> {
+    const result = await this.provider
+      .simulateTransaction(
+        this.buildSimulationTx('query_all_balances', [assets]),
+      );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to get all balances: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    if (!scVal) return {};
+
+    const native = scValToNative(scVal) as Map<string, bigint>;
+    const out: Record<string, string> = {};
+    native.forEach((value, key) => {
+      out[key] = value.toString();
+    });
+    return out;
   }
 
   /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -43,6 +43,15 @@ export interface UpgradeOptions {
   newWasmHash: string;
 }
 
+export interface ReclaimTokensOptions {
+  /** Asset contract address */
+  asset: string;
+  /** Amount to reclaim */
+  amount: string;
+  /** Destination address to receive the reclaimed tokens */
+  to: string;
+}
+
 export interface OffRampConfig {
   /** Your Moonpay API key */
   moonpayApiKey?: string;


### PR DESCRIPTION
closes #20 

## Summary

Implements [#20](https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge--Contract/issues/20) — adds a `query_all_balances` view function that returns the contract's balance for each of the given assets in a single call.

## Changes

### Contract (`contracts/onboarding-bridge/src/lib.rs`)
- Added `query_all_balances(env: Env, assets: Vec<Address>) -> Map<Address, i128>`  
  Iterates the provided asset list, queries the contract's own token balance for each, and returns an `Address → i128` map.

### Contract tests (`contracts/onboarding-bridge/src/tests.rs`)
- `test_query_all_balances_returns_contract_balances` — mints tokens to the bridge and asserts the correct balance is returned.
- `test_query_all_balances_empty_input` — asserts an empty map is returned when no assets are provided.

### SDK (`sdk/src/bridge.ts`, `sdk/src/types.ts`)
- Added `getAllBalances(assets: string[]): Promise<Record<string, string>>` method that calls `query_all_balances` via simulation and converts the result to a plain JS object.
- Added missing `ReclaimTokensOptions` type (pre-existing omission that caused the test suite to fail).

### SDK tests (`sdk/src/__tests__/bridge.test.ts`)
- Returns `Record<string, string>` with correct values.
- Returns `{}` when simulation has no results.
- Throws `Failed to get all balances` on simulation error.

## Testing

TypeScript SDK: **33/33 tests pass**.  
Rust tests added but require Soroban toolchain to run (not available in this environment).