### PR TITLE
Feat/add optional nonce to state changing functions

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -34,6 +34,8 @@ pub enum DataKey {
     AssetWhitelist,
     TotalBridged(Address),
     TotalFeesCollected(Address),
+    SourceDailyLimit(Address, Address),
+    AssetFeeCap(Address),
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -206,6 +208,45 @@ fn increment_total_fees_collected(env: &Env, asset: &Address, amount: i128) {
     env.storage()
         .persistent()
         .set(&DataKey::TotalFeesCollected(asset.clone()), &(current + amount));
+}
+
+fn save_source_daily_limit(env: &Env, source: &Address, asset: &Address, limit: i128) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::SourceDailyLimit(source.clone(), asset.clone()), &limit);
+}
+
+fn read_source_daily_limit(env: &Env, source: &Address, asset: &Address) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::SourceDailyLimit(source.clone(), asset.clone()))
+        .unwrap_or(0)
+}
+
+fn check_daily_limit(env: &Env, source: &Address, asset: &Address, amount: i128) -> Result<(), BridgeError> {
+    let limit = read_source_daily_limit(env, source, asset);
+    if limit > 0 && amount > limit {
+        return Err(BridgeError::DailyLimitExceeded);
+    }
+    Ok(())
+}
+
+fn save_asset_fee_cap(env: &Env, asset: &Address, max_fee_bps: u32) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::AssetFeeCap(asset.clone()), &max_fee_bps);
+}
+
+fn read_asset_fee_cap(env: &Env, asset: &Address) -> u32 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::AssetFeeCap(asset.clone()))
+        .unwrap_or(MAX_FEE_BPS)
+}
+
+fn get_effective_fee_bps(env: &Env, asset: &Address, global_fee_bps: u32) -> u32 {
+    let cap = read_asset_fee_cap(env, asset);
+    if global_fee_bps < cap { global_fee_bps } else { cap }
 }
 
 #[contract]

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -18,6 +18,8 @@ pub enum BridgeError {
     InsufficientReclaimable = 9,
     AssetNotWhitelisted = 10,
     DailyLimitExceeded = 11,
+
+    DuplicateNonce = 12,
 }
 
 #[contracttype]
@@ -36,6 +38,7 @@ pub enum DataKey {
     TotalFeesCollected(Address),
     SourceDailyLimit(Address, Address),
     AssetFeeCap(Address),
+    Nonce(Address),
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -249,6 +252,28 @@ fn get_effective_fee_bps(env: &Env, asset: &Address, global_fee_bps: u32) -> u32
     if global_fee_bps < cap { global_fee_bps } else { cap }
 }
 
+fn read_nonce(env: &Env, caller: &Address) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Nonce(caller.clone()))
+        .unwrap_or(0)
+}
+
+/// If `nonce` is `Some(n)`, verify it equals the caller's current nonce then increment.
+/// If `None`, no check is performed (standard Stellar tx path — replay prevented by sequence number).
+fn consume_nonce(env: &Env, caller: &Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+    if let Some(n) = nonce {
+        let stored = read_nonce(env, caller);
+        if n != stored {
+            return Err(BridgeError::DuplicateNonce);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::Nonce(caller.clone()), &(stored + 1));
+    }
+    Ok(())
+}
+
 #[contract]
 pub struct OnboardingBridge;
 
@@ -259,6 +284,7 @@ impl OnboardingBridge {
         admin: Address,
         fee_collector: Address,
         fee_bps: u32,
+        nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
         if read_initialized(&env) {
             return Err(BridgeError::AlreadyInitialized);
@@ -267,6 +293,7 @@ impl OnboardingBridge {
             return Err(BridgeError::FeeTooHigh);
         }
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         save_admin(&env, &admin);
         save_fee_collector(&env, &fee_collector);
         save_fee_bps(&env, &fee_bps);
@@ -282,6 +309,7 @@ impl OnboardingBridge {
         target: Address,
         asset: Address,
         amount: i128,
+        nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
@@ -292,6 +320,7 @@ impl OnboardingBridge {
         check_asset_whitelisted(&env, &asset)?;
         check_daily_limit(&env, &source, &asset, amount)?;
         source.require_auth();
+        consume_nonce(&env, &source, nonce)?;
 
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&source, &env.current_contract_address(), &amount);
@@ -319,6 +348,7 @@ impl OnboardingBridge {
         targets: Vec<Address>,
         amounts: Vec<i128>,
         asset: Address,
+        nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
@@ -330,6 +360,7 @@ impl OnboardingBridge {
         }
         check_asset_whitelisted(&env, &asset)?;
         source.require_auth();
+        consume_nonce(&env, &source, nonce)?;
 
         let mut total: i128 = 0;
         for i in 0..targets.len() {
@@ -391,7 +422,7 @@ impl OnboardingBridge {
         Ok(())
     }
 
-    pub fn set_fee_bps(env: Env, new_fee_bps: u32) -> Result<(), BridgeError> {
+    pub fn set_fee_bps(env: Env, new_fee_bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if new_fee_bps > MAX_FEE_BPS {
@@ -399,6 +430,7 @@ impl OnboardingBridge {
         }
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         let old_fee_bps = read_fee_bps(&env);
         save_fee_bps(&env, &new_fee_bps);
         env.events()
@@ -411,10 +443,12 @@ impl OnboardingBridge {
         source: Address,
         asset: Address,
         limit_amount: i128,
+        nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         save_source_daily_limit(&env, &source, &asset, limit_amount);
         Ok(())
     }
@@ -432,6 +466,7 @@ impl OnboardingBridge {
         env: Env,
         asset: Address,
         max_fee_bps: u32,
+        nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         if max_fee_bps > MAX_FEE_BPS {
@@ -439,6 +474,7 @@ impl OnboardingBridge {
         }
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         save_asset_fee_cap(&env, &asset, max_fee_bps);
         Ok(())
     }
@@ -451,11 +487,12 @@ impl OnboardingBridge {
         Ok(read_asset_fee_cap(&env, &asset))
     }
 
-    pub fn set_fee_collector(env: Env, new_fee_collector: Address) -> Result<(), BridgeError> {
+    pub fn set_fee_collector(env: Env, new_fee_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         let old_collector = read_fee_collector(&env);
         save_fee_collector(&env, &new_fee_collector);
         env.events()
@@ -463,24 +500,26 @@ impl OnboardingBridge {
         Ok(())
     }
 
-    pub fn set_admin(env: Env, new_admin: Address) -> Result<(), BridgeError> {
+    pub fn set_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         save_admin(&env, &new_admin);
         env.events()
             .publish(("AdminChanged", admin, new_admin.clone()), ());
         Ok(())
     }
 
-    pub fn set_minimum_amount(env: Env, amount: i128) -> Result<(), BridgeError> {
+    pub fn set_minimum_amount(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         if amount < 0 {
             return Err(BridgeError::InvalidAmount);
         }
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         save_minimum_amount(&env, &amount);
         Ok(())
     }
@@ -490,7 +529,7 @@ impl OnboardingBridge {
         Ok(read_minimum_amount(&env))
     }
 
-    pub fn withdraw_fees(env: Env, asset: Address, amount: i128) -> Result<(), BridgeError> {
+    pub fn withdraw_fees(env: Env, asset: Address, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -498,6 +537,7 @@ impl OnboardingBridge {
         }
         let fee_collector = read_fee_collector(&env);
         fee_collector.require_auth();
+        consume_nonce(&env, &fee_collector, nonce)?;
 
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&env.current_contract_address(), &fee_collector, &amount);
@@ -549,6 +589,10 @@ impl OnboardingBridge {
         read_initialized(&env)
     }
 
+    pub fn query_nonce(env: Env, caller: Address) -> u64 {
+        read_nonce(&env, &caller)
+    }
+
     pub fn query_calculate_fee(env: Env, gross_amount: i128) -> (i128, i128) {
         let fee_bps = read_fee_bps(&env);
         let fee = calculate_fee(gross_amount, fee_bps);
@@ -566,19 +610,21 @@ impl OnboardingBridge {
         Ok(read_total_fees_collected(&env, &asset))
     }
 
-    pub fn pause(env: Env) -> Result<(), BridgeError> {
+    pub fn pause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&DataKey::Paused, &true);
         env.events().publish(("ContractPaused",), (admin,));
         Ok(())
     }
 
-    pub fn unpause(env: Env) -> Result<(), BridgeError> {
+    pub fn unpause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage().instance().set(&DataKey::Paused, &false);
         env.events().publish(("ContractUnpaused",), (admin,));
         Ok(())
@@ -588,10 +634,11 @@ impl OnboardingBridge {
         read_paused(&env)
     }
 
-    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), BridgeError> {
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.deployer()
             .update_current_contract_wasm(new_wasm_hash.clone());
         env.events().publish(("Upgraded",), (admin, new_wasm_hash));
@@ -600,45 +647,55 @@ impl OnboardingBridge {
 
     // --- Blocklist / Allowlist ---
 
-    pub fn add_to_blocklist(env: Env, address: Address) -> Result<(), BridgeError> {
+    pub fn add_to_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
-        read_admin(&env).require_auth();
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage()
             .persistent()
             .set(&DataKey::Blocked(address), &true);
         Ok(())
     }
 
-    pub fn remove_from_blocklist(env: Env, address: Address) -> Result<(), BridgeError> {
+    pub fn remove_from_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
-        read_admin(&env).require_auth();
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage()
             .persistent()
             .remove(&DataKey::Blocked(address));
         Ok(())
     }
 
-    pub fn add_to_allowlist(env: Env, address: Address) -> Result<(), BridgeError> {
+    pub fn add_to_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
-        read_admin(&env).require_auth();
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage()
             .persistent()
             .set(&DataKey::Allowlisted(address), &true);
         Ok(())
     }
 
-    pub fn remove_from_allowlist(env: Env, address: Address) -> Result<(), BridgeError> {
+    pub fn remove_from_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
-        read_admin(&env).require_auth();
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage()
             .persistent()
             .remove(&DataKey::Allowlisted(address));
         Ok(())
     }
 
-    pub fn set_allowlist_mode(env: Env, enabled: bool) -> Result<(), BridgeError> {
+    pub fn set_allowlist_mode(env: Env, enabled: bool, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
-        read_admin(&env).require_auth();
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         env.storage()
             .instance()
             .set(&DataKey::AllowlistMode, &enabled);
@@ -662,6 +719,7 @@ impl OnboardingBridge {
         asset: Address,
         amount: i128,
         destination: Address,
+        nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         if amount <= 0 {
@@ -669,6 +727,7 @@ impl OnboardingBridge {
         }
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
 
         let token_client = token::Client::new(&env, &asset);
         let contract_balance = token_client.balance(&env.current_contract_address());
@@ -687,20 +746,22 @@ impl OnboardingBridge {
 
     // --- Asset Whitelist ---
 
-    pub fn add_asset(env: Env, asset: Address) -> Result<(), BridgeError> {
+    pub fn add_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         let mut whitelist = read_whitelist(&env);
         whitelist.set(asset, true);
         save_whitelist(&env, &whitelist);
         Ok(())
     }
 
-    pub fn remove_asset(env: Env, asset: Address) -> Result<(), BridgeError> {
+    pub fn remove_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
         let mut whitelist = read_whitelist(&env);
         whitelist.remove(asset);
         save_whitelist(&env, &whitelist);

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -20,6 +20,7 @@ pub enum BridgeError {
     DailyLimitExceeded = 11,
 
     DuplicateNonce = 12,
+    TransactionExpired = 13,
 }
 
 #[contracttype]
@@ -310,9 +311,15 @@ impl OnboardingBridge {
         asset: Address,
         amount: i128,
         nonce: Option<u64>,
+        deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
+        if let Some(d) = deadline {
+            if env.ledger().timestamp() > d {
+                return Err(BridgeError::TransactionExpired);
+            }
+        }
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
         }
@@ -349,9 +356,15 @@ impl OnboardingBridge {
         amounts: Vec<i128>,
         asset: Address,
         nonce: Option<u64>,
+        deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
+        if let Some(d) = deadline {
+            if env.ledger().timestamp() > d {
+                return Err(BridgeError::TransactionExpired);
+            }
+        }
         if targets.len() != amounts.len() {
             return Err(BridgeError::MismatchedArrays);
         }

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -49,7 +49,7 @@ fn test_initialize() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     assert_eq!(bridge.query_fee_bps(), 50u32);
     assert_eq!(bridge.query_fee_collector(), fee_collector);
@@ -64,9 +64,9 @@ fn test_initialize_twice() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     assert_eq!(
-        bridge.try_initialize(&admin, &fee_collector, &50u32),
+        bridge.try_initialize(&admin, &fee_collector, &50u32, &None),
         Err(Ok(BridgeError::AlreadyInitialized))
     );
 }
@@ -79,7 +79,7 @@ fn test_initialize_fee_too_high() {
     let bridge = create_bridge_client(&env, &bridge_id);
 
     assert_eq!(
-        bridge.try_initialize(&admin, &fee_collector, &2000u32),
+        bridge.try_initialize(&admin, &fee_collector, &2000u32, &None),
         Err(Ok(BridgeError::FeeTooHigh))
     );
 }
@@ -92,12 +92,12 @@ fn test_fund_c_address() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
 
     assert_eq!(check_balance(&env, &token_id, &user), 500i128);
     assert_eq!(check_balance(&env, &token_id, &target), 495i128);
@@ -112,13 +112,13 @@ fn test_fund_without_initialize() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&Address::generate(&env), &Address::generate(&env), &50u32);
+    bridge.initialize(&Address::generate(&env), &Address::generate(&env), &50u32, &None);
 
     let b2_id = env.register(OnboardingBridge, ());
     let b2 = crate::OnboardingBridgeClient::new(&env, &b2_id);
     let target = Address::generate(&env);
     assert_eq!(
-        b2.try_fund_c_address(&user, &target, &token_id, &100i128),
+        b2.try_fund_c_address(&user, &target, &token_id, &100i128, &None),
         Err(Ok(BridgeError::NotInitialized))
     );
 }
@@ -131,8 +131,8 @@ fn test_batch_fund_c_addresses() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 3000i128);
 
     let target1 = Address::generate(&env);
@@ -140,7 +140,7 @@ fn test_batch_fund_c_addresses() {
     let targets = Vec::from_array(&env, [target1.clone(), target2.clone()]);
     let amounts = Vec::from_array(&env, [1000i128, 500i128]);
 
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     assert_eq!(check_balance(&env, &token_id, &user), 1500i128);
     assert_eq!(check_balance(&env, &token_id, &target1), 990i128);
@@ -157,12 +157,12 @@ fn test_fund_with_zero_fee() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &0u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
 
     assert_eq!(check_balance(&env, &token_id, &user), 500i128);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
@@ -177,10 +177,10 @@ fn test_set_fee_bps() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     assert_eq!(bridge.query_fee_bps(), 50u32);
 
-    bridge.set_fee_bps(&200u32);
+    bridge.set_fee_bps(&200u32, &None);
     assert_eq!(bridge.query_fee_bps(), 200u32);
 }
 
@@ -191,9 +191,9 @@ fn test_set_fee_bps_too_high() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     assert_eq!(
-        bridge.try_set_fee_bps(&2000u32),
+        bridge.try_set_fee_bps(&2000u32, &None),
         Err(Ok(BridgeError::FeeTooHigh))
     );
 }
@@ -205,9 +205,9 @@ fn test_set_fee_collector() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     let new_collector = Address::generate(&env);
-    bridge.set_fee_collector(&new_collector);
+    bridge.set_fee_collector(&new_collector, &None);
     assert_eq!(bridge.query_fee_collector(), new_collector);
 }
 
@@ -218,9 +218,9 @@ fn test_set_admin() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     let new_admin = Address::generate(&env);
-    bridge.set_admin(&new_admin);
+    bridge.set_admin(&new_admin, &None);
     assert_eq!(bridge.query_admin(), new_admin);
 }
 
@@ -232,17 +232,17 @@ fn test_withdraw_fees() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
 
     assert_eq!(check_balance(&env, &token_id, &fee_collector), 0i128);
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 5i128);
 
-    bridge.withdraw_fees(&token_id, &5i128);
+    bridge.withdraw_fees(&token_id, &5i128, &None);
 
     assert_eq!(check_balance(&env, &token_id, &fee_collector), 5i128);
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 0i128);
@@ -256,7 +256,7 @@ fn test_query_balance() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &Address::generate(&env), &0u32);
+    bridge.initialize(&admin, &Address::generate(&env), &0u32, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let bal = bridge.query_balance(&user, &token_id);
@@ -271,12 +271,12 @@ fn test_batch_empty() {
     let bridge = create_bridge_client(&env, &bridge_id);
 
     let token_id = Address::generate(&env);
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     let targets: Vec<Address> = Vec::new(&env);
     let amounts: Vec<i128> = Vec::new(&env);
 
-    bridge.batch_fund_c_address(&admin, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&admin, &targets, &amounts, &token_id, &None);
 }
 
 #[test]
@@ -287,12 +287,12 @@ fn test_fund_events() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
 
     let events = env.events().all();
     assert!(events.len() > 0);
@@ -321,14 +321,14 @@ fn test_pause_and_unpause() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     assert!(!bridge.query_is_paused());
 
-    bridge.pause();
+    bridge.pause(&None);
     assert!(bridge.query_is_paused());
 
-    bridge.unpause();
+    bridge.unpause(&None);
     assert!(!bridge.query_is_paused());
 }
 
@@ -340,13 +340,13 @@ fn test_fund_c_address_paused() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
-    bridge.pause();
+    bridge.pause(&None);
 
     let target = Address::generate(&env);
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
         Err(Ok(BridgeError::ContractPaused))
     );
 }
@@ -359,15 +359,15 @@ fn test_batch_fund_paused() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
-    bridge.pause();
+    bridge.pause(&None);
 
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone()]);
     let amounts = Vec::from_array(&env, [500i128]);
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
         Err(Ok(BridgeError::ContractPaused))
     );
 }
@@ -380,15 +380,15 @@ fn test_withdraw_fees_paused() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
-    bridge.pause();
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.pause(&None);
 
     assert_eq!(
-        bridge.try_withdraw_fees(&token_id, &5i128),
+        bridge.try_withdraw_fees(&token_id, &5i128, &None),
         Err(Ok(BridgeError::ContractPaused))
     );
 }
@@ -400,10 +400,10 @@ fn test_set_fee_bps_paused() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.pause();
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
     assert_eq!(
-        bridge.try_set_fee_bps(&100u32),
+        bridge.try_set_fee_bps(&100u32, &None),
         Err(Ok(BridgeError::ContractPaused))
     );
 }
@@ -415,8 +415,8 @@ fn test_set_fee_collector_paused() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.pause();
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
     assert_eq!(
         bridge.try_set_fee_collector(&Address::generate(&env)),
         Err(Ok(BridgeError::ContractPaused))
@@ -430,8 +430,8 @@ fn test_set_admin_paused() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.pause();
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
     assert_eq!(
         bridge.try_set_admin(&Address::generate(&env)),
         Err(Ok(BridgeError::ContractPaused))
@@ -446,9 +446,9 @@ fn test_view_functions_work_when_paused() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
-    bridge.pause();
+    bridge.pause(&None);
 
     assert_eq!(bridge.query_fee_bps(), 50u32);
     assert_eq!(bridge.query_fee_collector(), fee_collector);
@@ -465,8 +465,8 @@ fn test_pause_emits_event() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.pause();
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -480,9 +480,9 @@ fn test_unpause_emits_event() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.pause();
-    bridge.unpause();
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    bridge.unpause(&None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -497,14 +497,14 @@ fn test_fund_works_after_unpause() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
-    bridge.pause();
-    bridge.unpause();
+    bridge.pause(&None);
+    bridge.unpause(&None);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
 
     assert_eq!(check_balance(&env, &token_id, &target), 495i128);
 }
@@ -525,12 +525,12 @@ fn test_upgrade_admin_only_and_event() {
     let bridge = create_bridge_client(&env, &bridge_id);
     env.mock_all_auths();
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     let wasm_bytes = Bytes::from_slice(&env, V2_WASM);
     let wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(wasm_bytes);
 
-    bridge.upgrade(&wasm_hash);
+    bridge.upgrade(&wasm_hash, &None);
 
     // Verify the Upgraded event was emitted from the bridge contract.
     let events = env.events().all();
@@ -547,7 +547,7 @@ fn test_upgrade_non_admin_rejected() {
     env.mock_all_auths();
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     let wasm_bytes = Bytes::from_slice(&env, V2_WASM);
     let wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(wasm_bytes);
@@ -555,7 +555,7 @@ fn test_upgrade_non_admin_rejected() {
     // Clear all mocked auths so upgrade is called without admin authorization.
     use soroban_sdk::xdr::SorobanAuthorizationEntry;
     env.set_auths(&[] as &[SorobanAuthorizationEntry]);
-    bridge.upgrade(&wasm_hash);
+    bridge.upgrade(&wasm_hash, &None);
 }
 
 // --------- Blocklist / Allowlist Tests ---------
@@ -565,8 +565,8 @@ fn setup_bridge(env: &Env) -> (crate::OnboardingBridgeClient, Address, Address, 
     let bridge = create_bridge_client(env, &bridge_id);
     let (admin, user, fee_collector) = create_test_users(env);
     init_token(env, &token_id, &admin);
-    bridge.initialize(&admin, &fee_collector, &0u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(env, &token_id, &user, 1000i128);
     (bridge, user, token_id, admin)
 }
@@ -577,11 +577,11 @@ fn test_blocklist_prevents_fund() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
     let target = Address::generate(&env);
 
-    bridge.add_to_blocklist(&target);
+    bridge.add_to_blocklist(&target, &None);
     assert!(bridge.query_is_blocked(&target));
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
         Err(Ok(crate::BridgeError::AddressBlocked))
     );
 }
@@ -592,11 +592,11 @@ fn test_remove_from_blocklist_allows_fund() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
     let target = Address::generate(&env);
 
-    bridge.add_to_blocklist(&target);
-    bridge.remove_from_blocklist(&target);
+    bridge.add_to_blocklist(&target, &None);
+    bridge.remove_from_blocklist(&target, &None);
     assert!(!bridge.query_is_blocked(&target));
 
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
@@ -606,11 +606,11 @@ fn test_allowlist_mode_blocks_non_allowlisted() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
     let target = Address::generate(&env);
 
-    bridge.set_allowlist_mode(&true);
+    bridge.set_allowlist_mode(&true, &None);
     assert!(bridge.query_allowlist_mode());
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
         Err(Ok(crate::BridgeError::AddressNotAllowlisted))
     );
 }
@@ -621,11 +621,11 @@ fn test_allowlist_mode_allows_allowlisted() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
     let target = Address::generate(&env);
 
-    bridge.set_allowlist_mode(&true);
-    bridge.add_to_allowlist(&target);
+    bridge.set_allowlist_mode(&true, &None);
+    bridge.add_to_allowlist(&target, &None);
     assert!(bridge.query_is_allowlisted(&target));
 
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
@@ -635,13 +635,13 @@ fn test_remove_from_allowlist_blocks_in_allowlist_mode() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
     let target = Address::generate(&env);
 
-    bridge.set_allowlist_mode(&true);
-    bridge.add_to_allowlist(&target);
-    bridge.remove_from_allowlist(&target);
+    bridge.set_allowlist_mode(&true, &None);
+    bridge.add_to_allowlist(&target, &None);
+    bridge.remove_from_allowlist(&target, &None);
     assert!(!bridge.query_is_allowlisted(&target));
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
         Err(Ok(crate::BridgeError::AddressNotAllowlisted))
     );
 }
@@ -652,12 +652,12 @@ fn test_blocklist_overrides_allowlist() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
     let target = Address::generate(&env);
 
-    bridge.set_allowlist_mode(&true);
-    bridge.add_to_allowlist(&target);
-    bridge.add_to_blocklist(&target);
+    bridge.set_allowlist_mode(&true, &None);
+    bridge.add_to_allowlist(&target, &None);
+    bridge.add_to_blocklist(&target, &None);
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
         Err(Ok(crate::BridgeError::AddressBlocked))
     );
 }
@@ -669,13 +669,13 @@ fn test_batch_fund_blocked_address_fails() {
     let t1 = Address::generate(&env);
     let t2 = Address::generate(&env);
 
-    bridge.add_to_blocklist(&t2);
+    bridge.add_to_blocklist(&t2, &None);
 
     let targets = Vec::from_array(&env, [t1, t2]);
     let amounts = Vec::from_array(&env, [200i128, 300i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
         Err(Ok(crate::BridgeError::AddressBlocked))
     );
 }
@@ -688,7 +688,7 @@ fn test_allowlist_mode_off_allows_all() {
 
     // allowlist mode off by default
     assert!(!bridge.query_allowlist_mode());
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
@@ -703,7 +703,7 @@ fn test_reclaim_accidentally_sent_tokens() {
     mint_tokens(&env, &token_id, &bridge.address, 500i128);
 
     let destination = Address::generate(&env);
-    bridge.reclaim_tokens(&token_id, &500i128, &destination);
+    bridge.reclaim_tokens(&token_id, &500i128, &destination, &None);
 
     assert_eq!(check_balance(&env, &token_id, &destination), 500i128);
     let _ = admin; // suppress unused warning
@@ -715,14 +715,14 @@ fn test_reclaim_cannot_take_accrued_fees() {
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
 
     // Fund so fees (10%) accrue in contract
-    bridge.set_fee_bps(&1000u32); // 10%
+    bridge.set_fee_bps(&1000u32, &None); // 10%
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &1000i128);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None);
     // contract now holds 100 in accrued fees, 0 reclaimable
 
     let destination = Address::generate(&env);
     assert_eq!(
-        bridge.try_reclaim_tokens(&token_id, &1i128, &destination),
+        bridge.try_reclaim_tokens(&token_id, &1i128, &destination, &None),
         Err(Ok(crate::BridgeError::InsufficientReclaimable))
     );
 }
@@ -732,21 +732,21 @@ fn test_reclaim_only_excess_over_fees() {
     let env = Env::default();
     let (bridge, user, token_id, _admin) = setup_bridge(&env);
 
-    bridge.set_fee_bps(&1000u32); // 10%
+    bridge.set_fee_bps(&1000u32, &None); // 10%
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &1000i128);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None);
     // 100 accrued fees in contract; mint 200 more directly
     mint_tokens(&env, &token_id, &bridge.address, 200i128);
 
     let destination = Address::generate(&env);
     // Can reclaim exactly 200 (the excess)
-    bridge.reclaim_tokens(&token_id, &200i128, &destination);
+    bridge.reclaim_tokens(&token_id, &200i128, &destination, &None);
     assert_eq!(check_balance(&env, &token_id, &destination), 200i128);
 
     // Cannot reclaim 1 more
     let dest2 = Address::generate(&env);
     assert_eq!(
-        bridge.try_reclaim_tokens(&token_id, &1i128, &dest2),
+        bridge.try_reclaim_tokens(&token_id, &1i128, &dest2, &None),
         Err(Ok(crate::BridgeError::InsufficientReclaimable))
     );
 }
@@ -758,7 +758,7 @@ fn test_reclaim_emits_event() {
 
     mint_tokens(&env, &token_id, &bridge.address, 300i128);
     let destination = Address::generate(&env);
-    bridge.reclaim_tokens(&token_id, &300i128, &destination);
+    bridge.reclaim_tokens(&token_id, &300i128, &destination, &None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -774,10 +774,10 @@ fn test_add_asset_whitelists_it() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     assert_eq!(bridge.query_is_asset_whitelisted(&token_id), false);
 
-    bridge.add_asset(&token_id);
+    bridge.add_asset(&token_id, &None);
     assert_eq!(bridge.query_is_asset_whitelisted(&token_id), true);
 }
 
@@ -788,11 +788,11 @@ fn test_remove_asset() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.add_asset(&token_id, &None);
     assert_eq!(bridge.query_is_asset_whitelisted(&token_id), true);
 
-    bridge.remove_asset(&token_id);
+    bridge.remove_asset(&token_id, &None);
     assert_eq!(bridge.query_is_asset_whitelisted(&token_id), false);
 }
 
@@ -803,12 +803,12 @@ fn test_query_whitelisted_assets() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     let asset1 = Address::generate(&env);
     let asset2 = Address::generate(&env);
-    bridge.add_asset(&asset1);
-    bridge.add_asset(&asset2);
+    bridge.add_asset(&asset1, &None);
+    bridge.add_asset(&asset2, &None);
 
     let assets = bridge.query_whitelisted_assets();
     assert_eq!(assets.len(), 2);
@@ -833,9 +833,9 @@ fn test_add_asset_is_idempotent() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.add_asset(&token_id);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.add_asset(&token_id, &None);
 
     assert_eq!(bridge.query_whitelisted_assets().len(), 1);
 }
@@ -848,10 +848,10 @@ fn test_add_asset_non_admin_rejected() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     env.set_auths(&[]);
-    bridge.add_asset(&token_id);
+    bridge.add_asset(&token_id, &None);
 }
 
 #[test]
@@ -862,11 +862,11 @@ fn test_remove_asset_non_admin_rejected() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.add_asset(&token_id, &None);
 
     env.set_auths(&[]);
-    bridge.remove_asset(&token_id);
+    bridge.remove_asset(&token_id, &None);
 }
 
 #[test]
@@ -888,12 +888,12 @@ fn test_fund_rejects_non_whitelisted_asset() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
         Err(Ok(BridgeError::AssetNotWhitelisted))
     );
 }
@@ -906,7 +906,7 @@ fn test_batch_fund_rejects_non_whitelisted_asset() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
     mint_tokens(&env, &token_id, &user, 3000i128);
 
     let target1 = Address::generate(&env);
@@ -914,7 +914,7 @@ fn test_batch_fund_rejects_non_whitelisted_asset() {
     let amounts = Vec::from_array(&env, [1000i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
         Err(Ok(BridgeError::AssetNotWhitelisted))
     );
 }
@@ -928,7 +928,7 @@ fn test_query_all_balances_returns_contract_balances() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
-    bridge.initialize(&admin, &fee_collector, &0u32);
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
 
     // Mint directly to the bridge contract
     mint_tokens(&env, &token_id, &bridge_id, 750i128);
@@ -945,7 +945,7 @@ fn test_query_all_balances_empty_input() {
     let (admin, _user, fee_collector) = create_test_users(&env);
     let (bridge_id, _token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
-    bridge.initialize(&admin, &fee_collector, &0u32);
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
 
     let assets: Vec<Address> = Vec::new(&env);
     let balances = bridge.query_all_balances(&assets);
@@ -1024,7 +1024,7 @@ fn test_query_calculate_fee() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
 
     let (fee, net) = bridge.query_calculate_fee(&1000i128);
     assert_eq!(fee, 10i128);
@@ -1038,7 +1038,7 @@ fn test_query_calculate_fee_zero_fee() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &0u32);
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
 
     let (fee, net) = bridge.query_calculate_fee(&1000i128);
     assert_eq!(fee, 0i128);
@@ -1052,7 +1052,7 @@ fn test_query_calculate_fee_max_fee() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &1000u32);
+    bridge.initialize(&admin, &fee_collector, &1000u32, &None);
 
     let (fee, net) = bridge.query_calculate_fee(&1000i128);
     assert_eq!(fee, 100i128);
@@ -1069,12 +1069,12 @@ fn test_query_total_bridged_and_fees_collected() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1091,15 +1091,15 @@ fn test_query_total_bridged_accumulates() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 5000i128);
 
     let target1 = Address::generate(&env);
     let target2 = Address::generate(&env);
 
-    bridge.fund_c_address(&user, &target1, &token_id, &1000i128);
-    bridge.fund_c_address(&user, &target2, &token_id, &1000i128);
+    bridge.fund_c_address(&user, &target1, &token_id, &1000i128, &None);
+    bridge.fund_c_address(&user, &target2, &token_id, &1000i128, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1116,8 +1116,8 @@ fn test_query_total_bridged_batch() {
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
-    bridge.initialize(&admin, &fee_collector, &100u32);
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 3000i128);
 
     let target1 = Address::generate(&env);
@@ -1125,7 +1125,7 @@ fn test_query_total_bridged_batch() {
     let targets = Vec::from_array(&env, [target1, target2]);
     let amounts = Vec::from_array(&env, [1000i128, 500i128]);
 
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1141,7 +1141,7 @@ fn test_query_total_bridged_zero() {
     let (bridge_id, token_id) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1159,7 +1159,7 @@ fn test_initialize_emits_event() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -1173,8 +1173,8 @@ fn test_fee_bps_changed_emits_event() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
-    bridge.set_fee_bps(&100u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.set_fee_bps(&100u32, &None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -1188,9 +1188,9 @@ fn test_fee_collector_changed_emits_event() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     let new_collector = Address::generate(&env);
-    bridge.set_fee_collector(&new_collector);
+    bridge.set_fee_collector(&new_collector, &None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -1204,9 +1204,9 @@ fn test_admin_changed_emits_event() {
     let (bridge_id, _) = register_all_contracts(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
-    bridge.initialize(&admin, &fee_collector, &50u32);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
     let new_admin = Address::generate(&env);
-    bridge.set_admin(&new_admin);
+    bridge.set_admin(&new_admin, &None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
@@ -1220,8 +1220,8 @@ fn setup_batch(env: &Env) -> (crate::OnboardingBridgeClient, Address, Address, A
     let bridge = create_bridge_client(env, &bridge_id);
     let (admin, user, fee_collector) = create_test_users(env);
     init_token(env, &token_id, &admin);
-    bridge.initialize(&admin, &fee_collector, &100u32); // 1% fee
-    bridge.add_asset(&token_id);
+    bridge.initialize(&admin, &fee_collector, &100u32, &None); // 1% fee
+    bridge.add_asset(&token_id, &None);
     mint_tokens(env, &token_id, &user, 1_000_000i128);
     (bridge, user, token_id, admin)
 }
@@ -1253,7 +1253,7 @@ fn test_batch_empty_array_no_events() {
 
     let targets: Vec<Address> = Vec::new(&env);
     let amounts: Vec<i128> = Vec::new(&env);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     // No new events emitted — the contract returns early before even emitting BatchCompleted.
     assert_eq!(env.events().all().len(), event_count_before);
@@ -1271,7 +1271,7 @@ fn test_batch_single_target() {
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone()]);
     let amounts = Vec::from_array(&env, [1000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     assert_eq!(check_balance(&env, &token_id, &target), 990i128); // 1% fee
     assert_eq!(check_balance(&env, &token_id, &user), 999_000i128);
@@ -1291,7 +1291,7 @@ fn test_batch_duplicate_targets() {
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone(), target.clone(), target.clone()]);
     let amounts = Vec::from_array(&env, [1000i128, 2000i128, 3000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     // Net: 990 + 1980 + 2970 = 5940
     assert_eq!(check_balance(&env, &token_id, &target), 5940i128);
@@ -1309,7 +1309,7 @@ fn test_batch_target_is_source() {
     // user sends 1000 to themselves; they pay fee, so net back is 990.
     let targets = Vec::from_array(&env, [user.clone()]);
     let amounts = Vec::from_array(&env, [1000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     // Started with 1_000_000. Paid 1000, received 990. Net: 999_990.
     assert_eq!(check_balance(&env, &token_id, &user), 999_990i128);
@@ -1326,7 +1326,7 @@ fn test_batch_target_is_contract() {
 
     let targets = Vec::from_array(&env, [bridge_id.clone()]);
     let amounts = Vec::from_array(&env, [1000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     // Contract should hold 1000 total (990 transferred to itself as target + 10 accrued fee).
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 1000i128);
@@ -1346,7 +1346,7 @@ fn test_batch_zero_amount_rejected() {
     let amounts = Vec::from_array(&env, [500i128, 0i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
         Err(Ok(BridgeError::InvalidAmount))
     );
     // No tokens moved — user balance intact.
@@ -1365,7 +1365,7 @@ fn test_batch_negative_amount_rejected() {
     let amounts = Vec::from_array(&env, [-1i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
         Err(Ok(BridgeError::InvalidAmount))
     );
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
@@ -1388,13 +1388,13 @@ fn test_batch_fee_never_produces_zero_net_within_max_fee_bps() {
     let bridge_id = bridge.address.clone();
 
     // Set max fee 1000 bps (10%).
-    bridge.set_fee_bps(&1000u32);
+    bridge.set_fee_bps(&1000u32, &None);
 
     // Amount=1: fee = 1*1000/10000 = 0, net = 1. Transfer happens.
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone()]);
     let amounts = Vec::from_array(&env, [1i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     assert_eq!(check_balance(&env, &token_id, &target), 1i128);
     assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
@@ -1412,7 +1412,7 @@ fn test_batch_mismatched_arrays() {
     let amounts = Vec::from_array(&env, [500i128, 300i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
         Err(Ok(BridgeError::MismatchedArrays))
     );
 }
@@ -1428,11 +1428,11 @@ fn test_batch_blocked_target_skipped_and_refunded() {
 
     let good = Address::generate(&env);
     let blocked = Address::generate(&env);
-    bridge.add_to_blocklist(&blocked);
+    bridge.add_to_blocklist(&blocked, &None);
 
     let targets = Vec::from_array(&env, [good.clone(), blocked.clone()]);
     let amounts = Vec::from_array(&env, [1000i128, 500i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     // Good target receives net amount (1% fee on 1000 = 990).
     assert_eq!(check_balance(&env, &token_id, &good), 990i128);
@@ -1455,12 +1455,12 @@ fn test_batch_all_blocked_full_refund() {
 
     let t1 = Address::generate(&env);
     let t2 = Address::generate(&env);
-    bridge.add_to_blocklist(&t1);
-    bridge.add_to_blocklist(&t2);
+    bridge.add_to_blocklist(&t1, &None);
+    bridge.add_to_blocklist(&t2, &None);
 
     let targets = Vec::from_array(&env, [t1.clone(), t2.clone()]);
     let amounts = Vec::from_array(&env, [400i128, 600i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
 
     // Full refund — source balance unchanged.
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
@@ -1492,7 +1492,7 @@ fn test_batch_100_targets() {
         amounts_vec.push_back(1000i128);
     }
 
-    bridge.batch_fund_c_address(&user, &targets_vec, &amounts_vec, &token_id);
+    bridge.batch_fund_c_address(&user, &targets_vec, &amounts_vec, &token_id, &None);
 
     // Each target receives 990 (1% fee on 1000).
     for i in 0..100 {
@@ -1502,4 +1502,118 @@ fn test_batch_100_targets() {
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128); // original unchanged
     assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 100);
     assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/********** Nonce tests **********/
+
+#[test]
+fn test_nonce_starts_at_zero() {
+    let env = Env::default();
+    let (bridge_id, _) = register_all_contracts(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    let caller = Address::generate(&env);
+    assert_eq!(bridge.query_nonce(&caller), 0u64);
+}
+
+#[test]
+fn test_nonce_increments_on_use() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    assert_eq!(bridge.query_nonce(&user), 0u64);
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target]);
+    let amounts = Vec::from_array(&env, [100i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(0u64));
+
+    assert_eq!(bridge.query_nonce(&user), 1u64);
+}
+
+#[test]
+fn test_nonce_replay_rejected() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let target1 = Address::generate(&env);
+    let target2 = Address::generate(&env);
+    let targets1 = Vec::from_array(&env, [target1]);
+    let targets2 = Vec::from_array(&env, [target2]);
+    let amounts = Vec::from_array(&env, [100i128]);
+
+    // First call with nonce=0 succeeds.
+    bridge.batch_fund_c_address(&user, &targets1, &amounts, &token_id, &Some(0u64));
+
+    // Replaying nonce=0 rejected.
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets2, &amounts, &token_id, &Some(0u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
+#[test]
+fn test_nonce_none_skips_check() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target]);
+    let amounts = Vec::from_array(&env, [100i128]);
+
+    // None skips nonce check; nonce stays at 0.
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    assert_eq!(bridge.query_nonce(&user), 0u64);
+}
+
+#[test]
+fn test_nonce_wrong_value_rejected() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target]);
+    let amounts = Vec::from_array(&env, [100i128]);
+
+    // Nonce is 0, passing 1 should fail.
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(1u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
+#[test]
+fn test_nonce_independent_per_caller() {
+    let env = Env::default();
+    let (bridge, user, token_id, admin) = setup_batch(&env);
+
+    let user2 = Address::generate(&env);
+    mint_tokens(&env, &token_id, &user2, 1_000i128);
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target]);
+    let amounts = Vec::from_array(&env, [100i128]);
+
+    // user uses nonce=0.
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(0u64));
+    // user2's nonce is still 0, independent of user's.
+    assert_eq!(bridge.query_nonce(&user2), 0u64);
+    assert_eq!(bridge.query_nonce(&user), 1u64);
+    let _ = admin;
+}
+
+#[test]
+fn test_fund_c_address_nonce() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &100i128, &Some(0u64));
+    assert_eq!(bridge.query_nonce(&user), 1u64);
+
+    // Reuse nonce=0 on fund_c_address rejected.
+    let target2 = Address::generate(&env);
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target2, &token_id, &100i128, &Some(0u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
 }

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1212,3 +1212,294 @@ fn test_admin_changed_emits_event() {
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
     assert_eq!(contract_id, &bridge_id);
 }
+
+// --------- batch_fund_c_address edge case tests ---------
+
+fn setup_batch(env: &Env) -> (crate::OnboardingBridgeClient, Address, Address, Address) {
+    let (bridge_id, token_id) = register_all_contracts(env);
+    let bridge = create_bridge_client(env, &bridge_id);
+    let (admin, user, fee_collector) = create_test_users(env);
+    init_token(env, &token_id, &admin);
+    bridge.initialize(&admin, &fee_collector, &100u32); // 1% fee
+    bridge.add_asset(&token_id);
+    mint_tokens(env, &token_id, &user, 1_000_000i128);
+    (bridge, user, token_id, admin)
+}
+
+/// Helper: count events from bridge with a given topic string prefix.
+fn count_events_with_topic(env: &Env, bridge_id: &Address, topic: &str) -> u32 {
+    use soroban_sdk::IntoVal;
+    let topic_val: soroban_sdk::Val = topic.into_val(env);
+    let mut count = 0u32;
+    for event in env.events().all().iter() {
+        let (cid, topics, _) = event;
+        if &cid == bridge_id && topics.len() > 0 {
+            if let Ok(t) = topics.get(0) {
+                if t == topic_val {
+                    count += 1;
+                }
+            }
+        }
+    }
+    count
+}
+
+/// Empty targets array — returns Ok immediately, no BatchCompleted event.
+#[test]
+fn test_batch_empty_array_no_events() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let event_count_before = env.events().all().len();
+
+    let targets: Vec<Address> = Vec::new(&env);
+    let amounts: Vec<i128> = Vec::new(&env);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    // No new events emitted — the contract returns early before even emitting BatchCompleted.
+    assert_eq!(env.events().all().len(), event_count_before);
+    // Source balance unchanged.
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
+}
+
+/// Single target — boundary case; correct fee and CAddressFunded + BatchCompleted events.
+#[test]
+fn test_batch_single_target() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    assert_eq!(check_balance(&env, &token_id, &target), 990i128); // 1% fee
+    assert_eq!(check_balance(&env, &token_id, &user), 999_000i128);
+
+    // Exactly 1 CAddressFunded and 1 BatchCompleted emitted.
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/// Duplicate target addresses — each entry is processed independently.
+#[test]
+fn test_batch_duplicate_targets() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target.clone(), target.clone(), target.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128, 2000i128, 3000i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    // Net: 990 + 1980 + 2970 = 5940
+    assert_eq!(check_balance(&env, &token_id, &target), 5940i128);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 3);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/// Target is same as source — source receives net amount back (self-fund).
+#[test]
+fn test_batch_target_is_source() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    // user sends 1000 to themselves; they pay fee, so net back is 990.
+    let targets = Vec::from_array(&env, [user.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    // Started with 1_000_000. Paid 1000, received 990. Net: 999_990.
+    assert_eq!(check_balance(&env, &token_id, &user), 999_990i128);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/// Target is the contract itself — contract receives the net amount.
+#[test]
+fn test_batch_target_is_contract() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    let targets = Vec::from_array(&env, [bridge_id.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    // Contract should hold 1000 total (990 transferred to itself as target + 10 accrued fee).
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 1000i128);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/// Zero amount in array — rejected with InvalidAmount before any transfer.
+#[test]
+fn test_batch_zero_amount_rejected() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let t1 = Address::generate(&env);
+    let t2 = Address::generate(&env);
+    let targets = Vec::from_array(&env, [t1.clone(), t2.clone()]);
+    let amounts = Vec::from_array(&env, [500i128, 0i128]);
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
+    // No tokens moved — user balance intact.
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
+    assert_eq!(check_balance(&env, &token_id, &t1), 0i128);
+}
+
+/// Negative amount in array — also rejected as InvalidAmount.
+#[test]
+fn test_batch_negative_amount_rejected() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target]);
+    let amounts = Vec::from_array(&env, [-1i128]);
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
+}
+
+/// Fee causes net_amount == 0 — transfer is skipped, fee still accrues.
+/// At 1000 bps (10%), an amount of 9 → fee=0 (rounds down), net=9, transfer happens.
+/// At 1000 bps, amount=1 → fee=0 (1*1000/10000 = 0), net=1. 
+/// To get net==0 we need fee_bps=10000 which exceeds max. Instead, use fee_bps=1000 and
+/// amount=1: fee = 1*1000/10000 = 0, net = 1. Can't get net=0 with valid fee_bps.
+/// The contract MAX_FEE_BPS is 1000 (10%), so with amount=1: fee=0, net=1.
+/// With amount=9 and fee_bps=1000: fee=0, net=9.
+/// The only way net rounds to 0 is if the math rounds to exactly amount.
+/// This is mathematically impossible with fee_bps <= 1000 for integer amount >= 1.
+/// Test documents this invariant: net is always > 0 for any valid input.
+#[test]
+fn test_batch_fee_never_produces_zero_net_within_max_fee_bps() {
+    let env = Env::default();
+    let (bridge, user, token_id, admin) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    // Set max fee 1000 bps (10%).
+    bridge.set_fee_bps(&1000u32);
+
+    // Amount=1: fee = 1*1000/10000 = 0, net = 1. Transfer happens.
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target.clone()]);
+    let amounts = Vec::from_array(&env, [1i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    assert_eq!(check_balance(&env, &token_id, &target), 1i128);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
+    let _ = admin;
+}
+
+/// Mismatched arrays — rejected with MismatchedArrays.
+#[test]
+fn test_batch_mismatched_arrays() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let t1 = Address::generate(&env);
+    let targets = Vec::from_array(&env, [t1]);
+    let amounts = Vec::from_array(&env, [500i128, 300i128]);
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id),
+        Err(Ok(BridgeError::MismatchedArrays))
+    );
+}
+
+/// Blocked target in batch — that entry is skipped and refunded, others succeed.
+/// BatchTransferFailed emitted for the blocked one, CAddressFunded for successful ones,
+/// BatchCompleted at the end reflecting counts.
+#[test]
+fn test_batch_blocked_target_skipped_and_refunded() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    let good = Address::generate(&env);
+    let blocked = Address::generate(&env);
+    bridge.add_to_blocklist(&blocked);
+
+    let targets = Vec::from_array(&env, [good.clone(), blocked.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128, 500i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    // Good target receives net amount (1% fee on 1000 = 990).
+    assert_eq!(check_balance(&env, &token_id, &good), 990i128);
+    // Blocked target receives nothing; 500 refunded to source.
+    assert_eq!(check_balance(&env, &token_id, &blocked), 0i128);
+    // Source paid 1500 total, got 500 back: net cost 1000.
+    assert_eq!(check_balance(&env, &token_id, &user), 999_000i128);
+
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchTransferFailed"), 1);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/// All targets blocked — all refunded, only BatchTransferFailed + BatchCompleted emitted.
+#[test]
+fn test_batch_all_blocked_full_refund() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    let t1 = Address::generate(&env);
+    let t2 = Address::generate(&env);
+    bridge.add_to_blocklist(&t1);
+    bridge.add_to_blocklist(&t2);
+
+    let targets = Vec::from_array(&env, [t1.clone(), t2.clone()]);
+    let amounts = Vec::from_array(&env, [400i128, 600i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id);
+
+    // Full refund — source balance unchanged.
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
+    assert_eq!(check_balance(&env, &token_id, &t1), 0i128);
+    assert_eq!(check_balance(&env, &token_id, &t2), 0i128);
+
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 0);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchTransferFailed"), 2);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}
+
+/// Large batch (100 targets) — verifies all succeed, correct event count, correct balances.
+#[test]
+fn test_batch_100_targets() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let bridge_id = bridge.address.clone();
+
+    // Give user enough tokens: 100 * 1000 = 100_000.
+    mint_tokens(&env, &token_id, &user, 100_000i128);
+
+    let mut targets_vec = Vec::new(&env);
+    let mut amounts_vec = Vec::new(&env);
+    let mut target_addrs: soroban_sdk::Vec<Address> = Vec::new(&env);
+    for _ in 0..100 {
+        let t = Address::generate(&env);
+        target_addrs.push_back(t.clone());
+        targets_vec.push_back(t);
+        amounts_vec.push_back(1000i128);
+    }
+
+    bridge.batch_fund_c_address(&user, &targets_vec, &amounts_vec, &token_id);
+
+    // Each target receives 990 (1% fee on 1000).
+    for i in 0..100 {
+        assert_eq!(check_balance(&env, &token_id, &target_addrs.get(i).unwrap()), 990i128);
+    }
+    // Source spent 100_000 tokens from the extra mint.
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128); // original unchanged
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 100);
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "BatchCompleted"), 1);
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -97,7 +97,7 @@ fn test_fund_c_address() {
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &user), 500i128);
     assert_eq!(check_balance(&env, &token_id, &target), 495i128);
@@ -118,7 +118,7 @@ fn test_fund_without_initialize() {
     let b2 = crate::OnboardingBridgeClient::new(&env, &b2_id);
     let target = Address::generate(&env);
     assert_eq!(
-        b2.try_fund_c_address(&user, &target, &token_id, &100i128, &None),
+        b2.try_fund_c_address(&user, &target, &token_id, &100i128, &None, &None),
         Err(Ok(BridgeError::NotInitialized))
     );
 }
@@ -140,7 +140,7 @@ fn test_batch_fund_c_addresses() {
     let targets = Vec::from_array(&env, [target1.clone(), target2.clone()]);
     let amounts = Vec::from_array(&env, [1000i128, 500i128]);
 
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &user), 1500i128);
     assert_eq!(check_balance(&env, &token_id, &target1), 990i128);
@@ -162,7 +162,7 @@ fn test_fund_with_zero_fee() {
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &user), 500i128);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
@@ -237,7 +237,7 @@ fn test_withdraw_fees() {
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &fee_collector), 0i128);
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 5i128);
@@ -276,7 +276,7 @@ fn test_batch_empty() {
     let targets: Vec<Address> = Vec::new(&env);
     let amounts: Vec<i128> = Vec::new(&env);
 
-    bridge.batch_fund_c_address(&admin, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&admin, &targets, &amounts, &token_id, &None, &None);
 }
 
 #[test]
@@ -292,7 +292,7 @@ fn test_fund_events() {
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
 
     let events = env.events().all();
     assert!(events.len() > 0);
@@ -346,7 +346,7 @@ fn test_fund_c_address_paused() {
 
     let target = Address::generate(&env);
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None, &None),
         Err(Ok(BridgeError::ContractPaused))
     );
 }
@@ -367,7 +367,7 @@ fn test_batch_fund_paused() {
     let targets = Vec::from_array(&env, [target.clone()]);
     let amounts = Vec::from_array(&env, [500i128]);
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
         Err(Ok(BridgeError::ContractPaused))
     );
 }
@@ -384,7 +384,7 @@ fn test_withdraw_fees_paused() {
     bridge.add_asset(&token_id, &None);
     mint_tokens(&env, &token_id, &user, 1000i128);
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
     bridge.pause(&None);
 
     assert_eq!(
@@ -504,7 +504,7 @@ fn test_fund_works_after_unpause() {
     bridge.unpause(&None);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &target), 495i128);
 }
@@ -581,7 +581,7 @@ fn test_blocklist_prevents_fund() {
     assert!(bridge.query_is_blocked(&target));
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None, &None),
         Err(Ok(crate::BridgeError::AddressBlocked))
     );
 }
@@ -596,7 +596,7 @@ fn test_remove_from_blocklist_allows_fund() {
     bridge.remove_from_blocklist(&target, &None);
     assert!(!bridge.query_is_blocked(&target));
 
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
@@ -610,7 +610,7 @@ fn test_allowlist_mode_blocks_non_allowlisted() {
     assert!(bridge.query_allowlist_mode());
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None, &None),
         Err(Ok(crate::BridgeError::AddressNotAllowlisted))
     );
 }
@@ -625,7 +625,7 @@ fn test_allowlist_mode_allows_allowlisted() {
     bridge.add_to_allowlist(&target, &None);
     assert!(bridge.query_is_allowlisted(&target));
 
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
@@ -641,7 +641,7 @@ fn test_remove_from_allowlist_blocks_in_allowlist_mode() {
     assert!(!bridge.query_is_allowlisted(&target));
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None, &None),
         Err(Ok(crate::BridgeError::AddressNotAllowlisted))
     );
 }
@@ -657,7 +657,7 @@ fn test_blocklist_overrides_allowlist() {
     bridge.add_to_blocklist(&target, &None);
 
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None, &None),
         Err(Ok(crate::BridgeError::AddressBlocked))
     );
 }
@@ -675,7 +675,7 @@ fn test_batch_fund_blocked_address_fails() {
     let amounts = Vec::from_array(&env, [200i128, 300i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
         Err(Ok(crate::BridgeError::AddressBlocked))
     );
 }
@@ -688,7 +688,7 @@ fn test_allowlist_mode_off_allows_all() {
 
     // allowlist mode off by default
     assert!(!bridge.query_allowlist_mode());
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
@@ -717,7 +717,7 @@ fn test_reclaim_cannot_take_accrued_fees() {
     // Fund so fees (10%) accrue in contract
     bridge.set_fee_bps(&1000u32, &None); // 10%
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None, &None);
     // contract now holds 100 in accrued fees, 0 reclaimable
 
     let destination = Address::generate(&env);
@@ -734,7 +734,7 @@ fn test_reclaim_only_excess_over_fees() {
 
     bridge.set_fee_bps(&1000u32, &None); // 10%
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None, &None);
     // 100 accrued fees in contract; mint 200 more directly
     mint_tokens(&env, &token_id, &bridge.address, 200i128);
 
@@ -893,7 +893,7 @@ fn test_fund_rejects_non_whitelisted_asset() {
 
     let target = Address::generate(&env);
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None),
+        bridge.try_fund_c_address(&user, &target, &token_id, &500i128, &None, &None),
         Err(Ok(BridgeError::AssetNotWhitelisted))
     );
 }
@@ -914,7 +914,7 @@ fn test_batch_fund_rejects_non_whitelisted_asset() {
     let amounts = Vec::from_array(&env, [1000i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
         Err(Ok(BridgeError::AssetNotWhitelisted))
     );
 }
@@ -1074,7 +1074,7 @@ fn test_query_total_bridged_and_fees_collected() {
     mint_tokens(&env, &token_id, &user, 1000i128);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1098,8 +1098,8 @@ fn test_query_total_bridged_accumulates() {
     let target1 = Address::generate(&env);
     let target2 = Address::generate(&env);
 
-    bridge.fund_c_address(&user, &target1, &token_id, &1000i128, &None);
-    bridge.fund_c_address(&user, &target2, &token_id, &1000i128, &None);
+    bridge.fund_c_address(&user, &target1, &token_id, &1000i128, &None, &None);
+    bridge.fund_c_address(&user, &target2, &token_id, &1000i128, &None, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1125,7 +1125,7 @@ fn test_query_total_bridged_batch() {
     let targets = Vec::from_array(&env, [target1, target2]);
     let amounts = Vec::from_array(&env, [1000i128, 500i128]);
 
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     let total_bridged = bridge.query_total_bridged(&token_id);
     let total_fees = bridge.query_total_fees_collected(&token_id);
@@ -1253,7 +1253,7 @@ fn test_batch_empty_array_no_events() {
 
     let targets: Vec<Address> = Vec::new(&env);
     let amounts: Vec<i128> = Vec::new(&env);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     // No new events emitted — the contract returns early before even emitting BatchCompleted.
     assert_eq!(env.events().all().len(), event_count_before);
@@ -1271,7 +1271,7 @@ fn test_batch_single_target() {
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone()]);
     let amounts = Vec::from_array(&env, [1000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &target), 990i128); // 1% fee
     assert_eq!(check_balance(&env, &token_id, &user), 999_000i128);
@@ -1291,7 +1291,7 @@ fn test_batch_duplicate_targets() {
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone(), target.clone(), target.clone()]);
     let amounts = Vec::from_array(&env, [1000i128, 2000i128, 3000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     // Net: 990 + 1980 + 2970 = 5940
     assert_eq!(check_balance(&env, &token_id, &target), 5940i128);
@@ -1309,7 +1309,7 @@ fn test_batch_target_is_source() {
     // user sends 1000 to themselves; they pay fee, so net back is 990.
     let targets = Vec::from_array(&env, [user.clone()]);
     let amounts = Vec::from_array(&env, [1000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     // Started with 1_000_000. Paid 1000, received 990. Net: 999_990.
     assert_eq!(check_balance(&env, &token_id, &user), 999_990i128);
@@ -1326,7 +1326,7 @@ fn test_batch_target_is_contract() {
 
     let targets = Vec::from_array(&env, [bridge_id.clone()]);
     let amounts = Vec::from_array(&env, [1000i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     // Contract should hold 1000 total (990 transferred to itself as target + 10 accrued fee).
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 1000i128);
@@ -1346,7 +1346,7 @@ fn test_batch_zero_amount_rejected() {
     let amounts = Vec::from_array(&env, [500i128, 0i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
         Err(Ok(BridgeError::InvalidAmount))
     );
     // No tokens moved — user balance intact.
@@ -1365,7 +1365,7 @@ fn test_batch_negative_amount_rejected() {
     let amounts = Vec::from_array(&env, [-1i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
         Err(Ok(BridgeError::InvalidAmount))
     );
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
@@ -1394,7 +1394,7 @@ fn test_batch_fee_never_produces_zero_net_within_max_fee_bps() {
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target.clone()]);
     let amounts = Vec::from_array(&env, [1i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     assert_eq!(check_balance(&env, &token_id, &target), 1i128);
     assert_eq!(count_events_with_topic(&env, &bridge_id, "CAddressFunded"), 1);
@@ -1412,7 +1412,7 @@ fn test_batch_mismatched_arrays() {
     let amounts = Vec::from_array(&env, [500i128, 300i128]);
 
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
         Err(Ok(BridgeError::MismatchedArrays))
     );
 }
@@ -1432,7 +1432,7 @@ fn test_batch_blocked_target_skipped_and_refunded() {
 
     let targets = Vec::from_array(&env, [good.clone(), blocked.clone()]);
     let amounts = Vec::from_array(&env, [1000i128, 500i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     // Good target receives net amount (1% fee on 1000 = 990).
     assert_eq!(check_balance(&env, &token_id, &good), 990i128);
@@ -1460,7 +1460,7 @@ fn test_batch_all_blocked_full_refund() {
 
     let targets = Vec::from_array(&env, [t1.clone(), t2.clone()]);
     let amounts = Vec::from_array(&env, [400i128, 600i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
 
     // Full refund — source balance unchanged.
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
@@ -1492,7 +1492,7 @@ fn test_batch_100_targets() {
         amounts_vec.push_back(1000i128);
     }
 
-    bridge.batch_fund_c_address(&user, &targets_vec, &amounts_vec, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets_vec, &amounts_vec, &token_id, &None, &None);
 
     // Each target receives 990 (1% fee on 1000).
     for i in 0..100 {
@@ -1525,7 +1525,7 @@ fn test_nonce_increments_on_use() {
     let target = Address::generate(&env);
     let targets = Vec::from_array(&env, [target]);
     let amounts = Vec::from_array(&env, [100i128]);
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(0u64));
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(0u64), &None);
 
     assert_eq!(bridge.query_nonce(&user), 1u64);
 }
@@ -1542,11 +1542,11 @@ fn test_nonce_replay_rejected() {
     let amounts = Vec::from_array(&env, [100i128]);
 
     // First call with nonce=0 succeeds.
-    bridge.batch_fund_c_address(&user, &targets1, &amounts, &token_id, &Some(0u64));
+    bridge.batch_fund_c_address(&user, &targets1, &amounts, &token_id, &Some(0u64), &None);
 
     // Replaying nonce=0 rejected.
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets2, &amounts, &token_id, &Some(0u64)),
+        bridge.try_batch_fund_c_address(&user, &targets2, &amounts, &token_id, &Some(0u64), &None),
         Err(Ok(BridgeError::DuplicateNonce))
     );
 }
@@ -1561,7 +1561,7 @@ fn test_nonce_none_skips_check() {
     let amounts = Vec::from_array(&env, [100i128]);
 
     // None skips nonce check; nonce stays at 0.
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
     assert_eq!(bridge.query_nonce(&user), 0u64);
 }
 
@@ -1576,7 +1576,7 @@ fn test_nonce_wrong_value_rejected() {
 
     // Nonce is 0, passing 1 should fail.
     assert_eq!(
-        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(1u64)),
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(1u64), &None),
         Err(Ok(BridgeError::DuplicateNonce))
     );
 }
@@ -1594,7 +1594,7 @@ fn test_nonce_independent_per_caller() {
     let amounts = Vec::from_array(&env, [100i128]);
 
     // user uses nonce=0.
-    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(0u64));
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &Some(0u64), &None);
     // user2's nonce is still 0, independent of user's.
     assert_eq!(bridge.query_nonce(&user2), 0u64);
     assert_eq!(bridge.query_nonce(&user), 1u64);
@@ -1607,13 +1607,89 @@ fn test_fund_c_address_nonce() {
     let (bridge, user, token_id, _) = setup_batch(&env);
 
     let target = Address::generate(&env);
-    bridge.fund_c_address(&user, &target, &token_id, &100i128, &Some(0u64));
+    bridge.fund_c_address(&user, &target, &token_id, &100i128, &Some(0u64), &None);
     assert_eq!(bridge.query_nonce(&user), 1u64);
 
     // Reuse nonce=0 on fund_c_address rejected.
     let target2 = Address::generate(&env);
     assert_eq!(
-        bridge.try_fund_c_address(&user, &target2, &token_id, &100i128, &Some(0u64)),
+        bridge.try_fund_c_address(&user, &target2, &token_id, &100i128, &Some(0u64), &None),
         Err(Ok(BridgeError::DuplicateNonce))
     );
+}
+
+/********** Deadline tests **********/
+
+#[test]
+fn test_fund_c_address_deadline_none_always_passes() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let target = Address::generate(&env);
+    // No deadline — always succeeds regardless of ledger time.
+    bridge.fund_c_address(&user, &target, &token_id, &100i128, &None, &None);
+    assert_eq!(check_balance(&env, &token_id, &target), 99i128); // 1% fee
+}
+
+#[test]
+fn test_fund_c_address_deadline_in_future_passes() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &100i128, &None, &Some(2000u64));
+    assert_eq!(check_balance(&env, &token_id, &target), 99i128);
+}
+
+#[test]
+fn test_fund_c_address_deadline_exact_passes() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let target = Address::generate(&env);
+    // deadline == current timestamp: not yet expired (strictly >).
+    bridge.fund_c_address(&user, &target, &token_id, &100i128, &None, &Some(1000u64));
+    assert_eq!(check_balance(&env, &token_id, &target), 99i128);
+}
+
+#[test]
+fn test_fund_c_address_deadline_expired_reverts() {
+    let env = Env::default();
+    env.ledger().set_timestamp(2000);
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let target = Address::generate(&env);
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &100i128, &None, &Some(1999u64)),
+        Err(Ok(BridgeError::TransactionExpired))
+    );
+    // No tokens moved.
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
+    assert_eq!(check_balance(&env, &token_id, &target), 0i128);
+}
+
+#[test]
+fn test_batch_fund_deadline_expired_reverts() {
+    let env = Env::default();
+    env.ledger().set_timestamp(5000);
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let t1 = Address::generate(&env);
+    let targets = Vec::from_array(&env, [t1.clone()]);
+    let amounts = Vec::from_array(&env, [500i128]);
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &Some(4999u64)),
+        Err(Ok(BridgeError::TransactionExpired))
+    );
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
+    assert_eq!(check_balance(&env, &token_id, &t1), 0i128);
+}
+
+#[test]
+fn test_batch_fund_deadline_in_future_passes() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (bridge, user, token_id, _) = setup_batch(&env);
+    let t1 = Address::generate(&env);
+    let targets = Vec::from_array(&env, [t1.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &Some(9999u64));
+    assert_eq!(check_balance(&env, &token_id, &t1), 990i128); // 1% fee
 }

--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -30,6 +30,10 @@ jest.mock('@stellar/stellar-sdk', () => ({
     TESTNET: 'Test SDF Network ; September 2015',
     PUBLIC: 'Public Global Stellar Network ; September 2015',
   },
+  StrKey: {
+    isValidEd25519PublicKey: jest.fn((addr: string) => addr.startsWith('G') && addr.length === 56),
+    isValidContract: jest.fn((addr: string) => addr.startsWith('C') && addr.length === 56),
+  },
 }));
 
 const CONFIG = {
@@ -68,7 +72,7 @@ describe('OnboardingBridgeSDK', () => {
   describe('fundCAddress', () => {
     it('returns pending status on success', async () => {
       const result = await sdk.fundCAddress(
-        { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+        { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000' },
         mockKeypair,
       );
 
@@ -83,7 +87,7 @@ describe('OnboardingBridgeSDK', () => {
       mockProvider.sendTransaction.mockResolvedValue({ hash: 'err_hash', status: 'ERROR' });
 
       const result = await sdk.fundCAddress(
-        { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+        { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000' },
         mockKeypair,
       );
 
@@ -95,7 +99,7 @@ describe('OnboardingBridgeSDK', () => {
       mockProvider.getAccount.mockRejectedValue(new Error('Network timeout'));
 
       const result = await sdk.fundCAddress(
-        { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+        { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000' },
         mockKeypair,
       );
 
@@ -110,7 +114,7 @@ describe('OnboardingBridgeSDK', () => {
       const result = await sdk.batchFundCAddresses(
         {
           source: MOCK_ADDRESS,
-          targets: [MOCK_ADDRESS, MOCK_ADDRESS],
+          targets: [MOCK_ASSET, MOCK_ASSET],
           amounts: ['500', '500'],
           asset: MOCK_ASSET,
         },
@@ -127,7 +131,7 @@ describe('OnboardingBridgeSDK', () => {
       const result = await sdk.batchFundCAddresses(
         {
           source: MOCK_ADDRESS,
-          targets: [MOCK_ADDRESS],
+          targets: [MOCK_ASSET],
           amounts: ['500', '500'],
           asset: MOCK_ASSET,
         },
@@ -253,7 +257,7 @@ describe('OnboardingBridgeSDK', () => {
         results: [{ retval: {} }],
       });
 
-      const balance = await sdk.getCAddressBalance(MOCK_ADDRESS, MOCK_ASSET);
+      const balance = await sdk.getCAddressBalance(MOCK_ASSET, MOCK_ASSET);
 
       expect(balance).toBe('1000');
     });
@@ -261,7 +265,7 @@ describe('OnboardingBridgeSDK', () => {
     it('returns "0" when no results', async () => {
       mockProvider.simulateTransaction.mockResolvedValue({});
 
-      const balance = await sdk.getCAddressBalance(MOCK_ADDRESS, MOCK_ASSET);
+      const balance = await sdk.getCAddressBalance(MOCK_ASSET, MOCK_ASSET);
 
       expect(balance).toBe('0');
     });
@@ -315,5 +319,134 @@ describe('OnboardingBridgeSDK', () => {
 
       await expect(sdk.getAllBalances([MOCK_ASSET])).rejects.toThrow('Failed to get all balances');
     });
+  });
+});
+
+describe('address validation', () => {
+  let sdk: OnboardingBridgeSDK;
+  let mockKeypair: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockKeypair = { publicKey: jest.fn().mockReturnValue(MOCK_ADDRESS), sign: jest.fn() };
+    const mockProvider = {
+      getAccount: jest.fn().mockResolvedValue({}),
+      prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
+      simulateTransaction: jest.fn().mockResolvedValue({}),
+    };
+    (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);
+    sdk = new OnboardingBridgeSDK(CONFIG);
+  });
+
+  it('constructor rejects an invalid contractId', () => {
+    expect(() => new OnboardingBridgeSDK({ ...CONFIG, contractId: 'not-a-contract' }))
+      .toThrow(/Invalid contract address for "contractId"/);
+  });
+
+  it('constructor rejects a G-address as contractId', () => {
+    expect(() => new OnboardingBridgeSDK({ ...CONFIG, contractId: MOCK_ADDRESS }))
+      .toThrow(/Invalid contract address for "contractId"/);
+  });
+
+  it('fundCAddress rejects a C-address as source', async () => {
+    const result = await sdk.fundCAddress(
+      { source: MOCK_ASSET, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000' },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid account address for "source"/);
+  });
+
+  it('fundCAddress rejects a G-address as target', async () => {
+    const result = await sdk.fundCAddress(
+      { source: MOCK_ADDRESS, target: MOCK_ADDRESS, asset: MOCK_ASSET, amount: '1000' },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid contract address for "target"/);
+  });
+
+  it('fundCAddress rejects a G-address as asset', async () => {
+    const result = await sdk.fundCAddress(
+      { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ADDRESS, amount: '1000' },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid contract address for "asset"/);
+  });
+
+  it('batchFundCAddresses rejects invalid source', async () => {
+    const result = await sdk.batchFundCAddresses(
+      { source: 'bad', targets: [MOCK_ASSET], amounts: ['100'], asset: MOCK_ASSET },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid account address for "source"/);
+  });
+
+  it('batchFundCAddresses rejects G-address in targets', async () => {
+    const result = await sdk.batchFundCAddresses(
+      { source: MOCK_ADDRESS, targets: [MOCK_ADDRESS], amounts: ['100'], asset: MOCK_ASSET },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid contract address for "targets\[0\]"/);
+  });
+
+  it('withdrawFees rejects G-address as asset', async () => {
+    const result = await sdk.withdrawFees({ asset: MOCK_ADDRESS, amount: '100' }, mockKeypair);
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid contract address for "asset"/);
+  });
+
+  it('reclaimTokens rejects G-address as asset', async () => {
+    const result = await sdk.reclaimTokens(
+      { asset: MOCK_ADDRESS, amount: '100', to: MOCK_ADDRESS },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid contract address for "asset"/);
+  });
+
+  it('reclaimTokens rejects C-address as to', async () => {
+    const result = await sdk.reclaimTokens(
+      { asset: MOCK_ASSET, amount: '100', to: MOCK_ASSET },
+      mockKeypair,
+    );
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid account address for "to"/);
+  });
+
+  it('setFeeCollector rejects a C-address', async () => {
+    const result = await sdk.setFeeCollector(MOCK_ASSET, mockKeypair);
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid account address for "newFeeCollector"/);
+  });
+
+  it('setAdmin rejects a C-address', async () => {
+    const result = await sdk.setAdmin(MOCK_ASSET, mockKeypair);
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/Invalid account address for "newAdmin"/);
+  });
+
+  it('getCAddressBalance rejects a G-address as cAddress', async () => {
+    await expect(sdk.getCAddressBalance(MOCK_ADDRESS, MOCK_ASSET))
+      .rejects.toThrow(/Invalid contract address for "cAddress"/);
+  });
+
+  it('getCAddressBalance rejects a G-address as asset', async () => {
+    await expect(sdk.getCAddressBalance(MOCK_ASSET, MOCK_ADDRESS))
+      .rejects.toThrow(/Invalid contract address for "asset"/);
+  });
+
+  it('getFeeBalance rejects a G-address as asset', async () => {
+    await expect(sdk.getFeeBalance(MOCK_ADDRESS))
+      .rejects.toThrow(/Invalid contract address for "asset"/);
+  });
+
+  it('getAllBalances rejects a G-address in assets list', async () => {
+    await expect(sdk.getAllBalances([MOCK_ASSET, MOCK_ADDRESS]))
+      .rejects.toThrow(/Invalid contract address for "assets\[1\]"/);
   });
 });

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -7,6 +7,7 @@ import {
   ReclaimTokensOptions,
   TransactionResult,
 } from './types';
+import { assertAccountAddress, assertContractAddress } from './validate';
 import {
   SorobanRpc,
   Contract,
@@ -26,6 +27,7 @@ export class OnboardingBridgeSDK {
   private networkPassphrase: string;
 
   constructor(config: BridgeConfig) {
+    assertContractAddress(config.contractId, 'contractId');
     this.config = config;
     this.contract = new Contract(config.contractId);
     this.provider = new SorobanRpc.Server(config.rpcUrl);
@@ -41,6 +43,9 @@ export class OnboardingBridgeSDK {
     sourceKeypair: any,
   ): Promise<TransactionResult> {
     try {
+      assertAccountAddress(options.source, 'source');
+      assertContractAddress(options.target, 'target');
+      assertContractAddress(options.asset, 'asset');
       const sourceAccount = await this.provider.getAccount(options.source);
 
       const tx = new TransactionBuilder(sourceAccount, {
@@ -87,6 +92,9 @@ export class OnboardingBridgeSDK {
     sourceKeypair: any,
   ): Promise<TransactionResult> {
     try {
+      assertAccountAddress(options.source, 'source');
+      options.targets.forEach((t, i) => assertContractAddress(t, `targets[${i}]`));
+      assertContractAddress(options.asset, 'asset');
       const sourceAccount = await this.provider.getAccount(options.source);
 
       const tx = new TransactionBuilder(sourceAccount, {
@@ -134,6 +142,7 @@ export class OnboardingBridgeSDK {
     feeCollectorKeypair: any,
   ): Promise<TransactionResult> {
     try {
+      assertContractAddress(options.asset, 'asset');
       const feeCollectorAccount = await this.provider.getAccount(
         feeCollectorKeypair.publicKey(),
       );
@@ -177,6 +186,8 @@ export class OnboardingBridgeSDK {
     adminKeypair: any,
   ): Promise<TransactionResult> {
     try {
+      assertContractAddress(options.asset, 'asset');
+      assertAccountAddress(options.to, 'to');
       const adminAccount = await this.provider.getAccount(
         adminKeypair.publicKey(),
       );
@@ -270,6 +281,8 @@ export class OnboardingBridgeSDK {
     cAddress: string,
     asset: string,
   ): Promise<string> {
+    assertContractAddress(cAddress, 'cAddress');
+    assertContractAddress(asset, 'asset');
     const result = await this.provider
       .simulateTransaction(
         this.buildSimulationTx('query_balance', [cAddress, asset]),
@@ -287,6 +300,7 @@ export class OnboardingBridgeSDK {
    * Get the fee balance held by the contract for a given asset.
    */
   async getFeeBalance(asset: string): Promise<string> {
+    assertContractAddress(asset, 'asset');
     const result = await this.provider
       .simulateTransaction(
         this.buildSimulationTx('query_fee_balance', [asset]),
@@ -305,6 +319,7 @@ export class OnboardingBridgeSDK {
    * Returns a map of asset address → balance string.
    */
   async getAllBalances(assets: string[]): Promise<Record<string, string>> {
+    assets.forEach((a, i) => assertContractAddress(a, `assets[${i}]`));
     const result = await this.provider
       .simulateTransaction(
         this.buildSimulationTx('query_all_balances', [assets]),
@@ -393,6 +408,7 @@ export class OnboardingBridgeSDK {
     adminKeypair: any,
   ): Promise<TransactionResult> {
     try {
+      assertAccountAddress(newFeeCollector, 'newFeeCollector');
       const adminAccount = await this.provider.getAccount(
         adminKeypair.publicKey(),
       );
@@ -436,6 +452,7 @@ export class OnboardingBridgeSDK {
     adminKeypair: any,
   ): Promise<TransactionResult> {
     try {
+      assertAccountAddress(newAdmin, 'newAdmin');
       const adminAccount = await this.provider.getAccount(
         adminKeypair.publicKey(),
       );

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,3 +1,4 @@
 export { OnboardingBridgeSDK } from './bridge';
 export { OffRampIntegration } from './offramp';
+export { assertAccountAddress, assertContractAddress } from './validate';
 export * from './types';

--- a/sdk/src/validate.ts
+++ b/sdk/src/validate.ts
@@ -1,0 +1,17 @@
+import { StrKey } from '@stellar/stellar-sdk';
+
+export function assertAccountAddress(address: string, field: string): void {
+  if (!StrKey.isValidEd25519PublicKey(address)) {
+    throw new Error(
+      `Invalid account address for "${field}": expected a G-address (ed25519 public key), got "${address}"`,
+    );
+  }
+}
+
+export function assertContractAddress(address: string, field: string): void {
+  if (!StrKey.isValidContract(address)) {
+    throw new Error(
+      `Invalid contract address for "${field}": expected a C-address (contract), got "${address}"`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #29 

- Add DuplicateNonce=12 to BridgeError
  - Add Nonce(Address) variant to DataKey enum
  - Add read_nonce/consume_nonce helpers (persistent storage, per-caller)
  - Add nonce: Option<u64> param to all 20 state-changing functions:
    initialize, fund_c_address, batch_fund_c_address, set_fee_bps,
    set_fee_collector, set_admin, set_minimum_amount, set_source_daily_limit,
    set_asset_fee_cap, withdraw_fees, pause, unpause, upgrade,
    add/remove_to/from_blocklist, add/remove_to/from_allowlist,
    set_allowlist_mode, reclaim_tokens, add_asset, remove_asset
  - Add query_nonce(caller) view function
  - None skips the check (standard Stellar tx path, replay prevented by
    account sequence number); Some(n) enforces n == stored_nonce then increments
  - Update all existing tests to pass &None for the new param
  - Add 7 nonce-specific tests: starts at 0, increments, replay rejected,
    None skips, wrong value rejected, independent per caller, fund_c_address"