### PR TITLE
feat: add time-locked C-address funding (vesting)

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -18,6 +18,10 @@ pub enum BridgeError {
     InsufficientReclaimable = 9,
     AssetNotWhitelisted = 10,
     DailyLimitExceeded = 11,
+    TimelockNotFound = 12,
+    TimelockNotMatured = 13,
+    Unauthorized = 14,
+    InvalidReleaseTime = 15,
 }
 
 #[contracttype]
@@ -34,6 +38,20 @@ pub enum DataKey {
     AssetWhitelist,
     TotalBridged(Address),
     TotalFeesCollected(Address),
+    TimelockEntry(u64),
+    TimelockCounter,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TimelockEntry {
+    pub source: Address,
+    pub target: Address,
+    pub asset: Address,
+    pub amount: i128,       // gross amount (fee already deducted at claim time)
+    pub release_time: u64,
+    pub cliff_time: u64,
+    pub claimed: bool,
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -206,6 +224,30 @@ fn increment_total_fees_collected(env: &Env, asset: &Address, amount: i128) {
     env.storage()
         .persistent()
         .set(&DataKey::TotalFeesCollected(asset.clone()), &(current + amount));
+}
+
+fn next_timelock_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::TimelockCounter)
+        .unwrap_or(0u64);
+    env.storage()
+        .instance()
+        .set(&DataKey::TimelockCounter, &(id + 1));
+    id
+}
+
+fn save_timelock_entry(env: &Env, id: u64, entry: &TimelockEntry) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TimelockEntry(id), entry);
+}
+
+fn read_timelock_entry(env: &Env, id: u64) -> Option<TimelockEntry> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TimelockEntry(id))
 }
 
 #[contract]
@@ -674,6 +716,101 @@ impl OnboardingBridge {
     pub fn query_whitelisted_assets(env: Env) -> Result<Vec<Address>, BridgeError> {
         check_initialized(&env)?;
         Ok(read_whitelist(&env).keys())
+    }
+
+    // --- Timelocked Funding ---
+
+    pub fn fund_c_address_timelocked(
+        env: Env,
+        source: Address,
+        target: Address,
+        asset: Address,
+        amount: i128,
+        release_time: u64,
+        cliff_time: u64,
+    ) -> Result<u64, BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        let now = env.ledger().timestamp();
+        if release_time <= now {
+            return Err(BridgeError::InvalidReleaseTime);
+        }
+        if cliff_time > 0 && cliff_time > release_time {
+            return Err(BridgeError::InvalidReleaseTime);
+        }
+        check_access(&env, &target)?;
+        check_asset_whitelisted(&env, &asset)?;
+        source.require_auth();
+
+        token::Client::new(&env, &asset)
+            .transfer(&source, &env.current_contract_address(), &amount);
+
+        let id = next_timelock_id(&env);
+        save_timelock_entry(
+            &env,
+            id,
+            &TimelockEntry {
+                source: source.clone(),
+                target: target.clone(),
+                asset: asset.clone(),
+                amount,
+                release_time,
+                cliff_time,
+                claimed: false,
+            },
+        );
+
+        env.events().publish(
+            ("TimelockCreated", source, target),
+            (id, amount, asset, release_time, cliff_time),
+        );
+        Ok(id)
+    }
+
+    pub fn claim_timelocked(env: Env, id: u64) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+
+        let mut entry = read_timelock_entry(&env, id)
+            .ok_or(BridgeError::TimelockNotFound)?;
+
+        entry.target.require_auth();
+
+        if env.ledger().timestamp() < entry.release_time {
+            return Err(BridgeError::TimelockNotMatured);
+        }
+        if entry.claimed {
+            return Err(BridgeError::Unauthorized);
+        }
+
+        entry.claimed = true;
+        save_timelock_entry(&env, id, &entry);
+
+        let fee_bps = read_fee_bps(&env);
+        let effective_fee_bps = get_effective_fee_bps(&env, &entry.asset, fee_bps);
+        let fee = calculate_fee(entry.amount, effective_fee_bps);
+        let net_amount = entry.amount - fee;
+
+        let token_client = token::Client::new(&env, &entry.asset);
+        if net_amount > 0 {
+            token_client.transfer(&env.current_contract_address(), &entry.target, &net_amount);
+        }
+        increment_accrued_fees(&env, &entry.asset, fee);
+        increment_total_bridged(&env, &entry.asset, net_amount);
+        increment_total_fees_collected(&env, &entry.asset, fee);
+
+        env.events().publish(
+            ("TimelockClaimed", entry.target),
+            (id, net_amount, fee, entry.asset),
+        );
+        Ok(())
+    }
+
+    pub fn query_timelocked(env: Env, id: u64) -> Result<TimelockEntry, BridgeError> {
+        read_timelock_entry(&env, id).ok_or(BridgeError::TimelockNotFound)
     }
 }
 

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -2,7 +2,7 @@ use crate::{BridgeError, OnboardingBridge};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    testutils::{Address as _, Events},
+    testutils::{Address as _, Events, Ledger},
     Address, Bytes, BytesN, Env, IntoVal, Vec,
 };
 
@@ -1211,4 +1211,184 @@ fn test_admin_changed_emits_event() {
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
     assert_eq!(contract_id, &bridge_id);
+}
+
+/********** Timelocked Funding Tests **********/
+
+fn setup_timelocked(env: &Env) -> (Address, Address, Address, Address, crate::OnboardingBridgeClient) {
+    let (admin, user, fee_collector) = create_test_users(env);
+    let (bridge_id, token_id) = register_all_contracts(env);
+    let bridge = create_bridge_client(env, &bridge_id);
+    init_token(env, &token_id, &admin);
+    bridge.initialize(&admin, &fee_collector, &100u32); // 1% fee
+    bridge.add_asset(&token_id);
+    mint_tokens(env, &token_id, &user, 1000i128);
+    (bridge_id, token_id, user, fee_collector, bridge)
+}
+
+#[test]
+fn test_fund_timelocked_creates_entry() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &0u64);
+
+    assert_eq!(id, 0u64);
+    let entry = bridge.query_timelocked(&id);
+    assert_eq!(entry.amount, 500i128);
+    assert_eq!(entry.release_time, 2000u64);
+    assert_eq!(entry.cliff_time, 0u64);
+    assert!(!entry.claimed);
+}
+
+#[test]
+fn test_fund_timelocked_holds_tokens_in_contract() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &0u64);
+
+    // Tokens leave source, sit in bridge (not yet transferred to target)
+    assert_eq!(check_balance(&env, &token_id, &user), 500i128);
+    assert_eq!(check_balance(&env, &token_id, &target), 0i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 500i128);
+}
+
+#[test]
+fn test_claim_timelocked_after_release() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &0u64);
+
+    env.ledger().set_timestamp(2000);
+    bridge.claim_timelocked(&id);
+
+    // 1% fee on 500 = 5; net = 495
+    assert_eq!(check_balance(&env, &token_id, &target), 495i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 5i128);
+}
+
+#[test]
+fn test_claim_timelocked_before_release_fails() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &0u64);
+
+    env.ledger().set_timestamp(1999);
+    assert_eq!(
+        bridge.try_claim_timelocked(&id),
+        Err(Ok(BridgeError::TimelockNotMatured))
+    );
+}
+
+#[test]
+fn test_claim_timelocked_twice_fails() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &0u64);
+
+    env.ledger().set_timestamp(2000);
+    bridge.claim_timelocked(&id);
+
+    assert_eq!(
+        bridge.try_claim_timelocked(&id),
+        Err(Ok(BridgeError::Unauthorized))
+    );
+}
+
+#[test]
+fn test_query_timelocked_not_found() {
+    let env = Env::default();
+    let (_bridge_id, _token_id, _user, _fee_collector, bridge) = setup_timelocked(&env);
+
+    assert_eq!(
+        bridge.try_query_timelocked(&99u64),
+        Err(Ok(BridgeError::TimelockNotFound))
+    );
+}
+
+#[test]
+fn test_fund_timelocked_invalid_release_time() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    // release_time in the past
+    assert_eq!(
+        bridge.try_fund_c_address_timelocked(&user, &target, &token_id, &500i128, &999u64, &0u64),
+        Err(Ok(BridgeError::InvalidReleaseTime))
+    );
+}
+
+#[test]
+fn test_fund_timelocked_cliff_after_release_fails() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    // cliff_time > release_time
+    assert_eq!(
+        bridge.try_fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &3000u64),
+        Err(Ok(BridgeError::InvalidReleaseTime))
+    );
+}
+
+#[test]
+fn test_fund_timelocked_with_cliff_stored_correctly() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &2000u64, &1500u64);
+    let entry = bridge.query_timelocked(&id);
+    assert_eq!(entry.cliff_time, 1500u64);
+    assert_eq!(entry.release_time, 2000u64);
+}
+
+#[test]
+fn test_fund_timelocked_increments_id() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id0 = bridge.fund_c_address_timelocked(&user, &target, &token_id, &100i128, &2000u64, &0u64);
+    let id1 = bridge.fund_c_address_timelocked(&user, &target, &token_id, &100i128, &2000u64, &0u64);
+    let id2 = bridge.fund_c_address_timelocked(&user, &target, &token_id, &100i128, &2000u64, &0u64);
+
+    assert_eq!(id0, 0u64);
+    assert_eq!(id1, 1u64);
+    assert_eq!(id2, 2u64);
+}
+
+#[test]
+fn test_claim_timelocked_updates_counters() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1000);
+    let (_bridge_id, token_id, user, _fee_collector, bridge) = setup_timelocked(&env);
+    let target = Address::generate(&env);
+
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &1000i128, &2000u64, &0u64);
+    env.ledger().set_timestamp(2000);
+    bridge.claim_timelocked(&id);
+
+    // 1% fee on 1000 = 10; net = 990
+    assert_eq!(bridge.query_total_bridged(&token_id), 990i128);
+    assert_eq!(bridge.query_total_fees_collected(&token_id), 10i128);
 }


### PR DESCRIPTION
Closes #97 

- Add fund_c_address_timelocked: locks tokens in bridge until release_time
- Add claim_timelocked: target claims after release_time; fee taken at claim
- Add query_timelocked: read TimelockEntry by id
- Add TimelockEntry struct and DataKey variants (TimelockEntry, TimelockCounter)
- Add BridgeErrors: TimelockNotFound, TimelockNotMatured, Unauthorized, InvalidReleaseTime
- Validate cliff_time <= release_time; cliff stored as metadata (full release at release_time)
- Add 10 tests covering create, hold, claim, premature claim, double-claim, not-found, validations