### PR TITLE
Feat/add two phase admin transfer

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -83,6 +83,8 @@ pub enum DataKey {
     CurrentWasmHash,
     // Issue #21: two-phase admin transfer
     PendingAdmin,
+    // Issue #22: two-phase fee collector transfer
+    PendingFeeCollector,
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -195,6 +197,18 @@ fn read_pending_admin(env: &Env) -> Option<Address> {
 
 fn clear_pending_admin(env: &Env) {
     env.storage().instance().remove(&DataKey::PendingAdmin);
+}
+
+fn save_pending_fee_collector(env: &Env, addr: &Address) {
+    env.storage().instance().set(&DataKey::PendingFeeCollector, addr);
+}
+
+fn read_pending_fee_collector(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::PendingFeeCollector)
+}
+
+fn clear_pending_fee_collector(env: &Env) {
+    env.storage().instance().remove(&DataKey::PendingFeeCollector);
 }
 
 fn read_bridge_config(env: &Env) -> BridgeConfigData {
@@ -1102,6 +1116,38 @@ impl OnboardingBridge {
         env.events()
             .publish(("FeeCollectorChanged", old_collector, new_fee_collector), (config.admin,));
         Ok(())
+    }
+
+    pub fn propose_new_fee_collector(env: Env, new_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        save_pending_fee_collector(&env, &new_collector);
+        env.events()
+            .publish(("FeeCollectorTransferProposed", admin, new_collector), ());
+        Ok(())
+    }
+
+    pub fn accept_fee_collector(env: Env) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let pending = read_pending_fee_collector(&env).ok_or(BridgeError::Unauthorized)?;
+        pending.require_auth();
+        let old_collector = read_fee_collector(&env);
+        save_fee_collector(&env, &pending);
+        let mut config = read_bridge_config(&env);
+        config.fee_collector = pending.clone();
+        save_bridge_config(&env, &config);
+        clear_pending_fee_collector(&env);
+        env.events()
+            .publish(("FeeCollectorTransferred", old_collector, pending), ());
+        Ok(())
+    }
+
+    pub fn query_pending_fee_collector(env: Env) -> Option<Address> {
+        read_pending_fee_collector(&env)
     }
 
     pub fn set_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -37,6 +37,8 @@ pub enum BridgeError {
     UpgradeNotScheduled = 25,
     UpgradeHashMismatch = 26,
     UpgradeTimelockActive = 27,
+    // Issue #23: max withdraw per tx
+    WithdrawExceedsLimit = 28,
 }
 
 #[contracttype]
@@ -85,6 +87,8 @@ pub enum DataKey {
     PendingAdmin,
     // Issue #22: two-phase fee collector transfer
     PendingFeeCollector,
+    // Issue #23: max withdraw per tx
+    MaxWithdrawPerTx,
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -209,6 +213,17 @@ fn read_pending_fee_collector(env: &Env) -> Option<Address> {
 
 fn clear_pending_fee_collector(env: &Env) {
     env.storage().instance().remove(&DataKey::PendingFeeCollector);
+}
+
+fn save_max_withdraw_per_tx(env: &Env, amount: i128) {
+    env.storage().instance().set(&DataKey::MaxWithdrawPerTx, &amount);
+}
+
+fn read_max_withdraw_per_tx(env: &Env) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::MaxWithdrawPerTx)
+        .unwrap_or(0)
 }
 
 fn read_bridge_config(env: &Env) -> BridgeConfigData {
@@ -1220,6 +1235,10 @@ impl OnboardingBridge {
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
         }
+        let max_withdraw = read_max_withdraw_per_tx(&env);
+        if max_withdraw > 0 && amount > max_withdraw {
+            return Err(BridgeError::WithdrawExceedsLimit);
+        }
         let accrued = read_accrued_fees(&env, &asset);
         if amount > accrued {
             return Err(BridgeError::InsufficientReclaimable);
@@ -1235,6 +1254,24 @@ impl OnboardingBridge {
         env.events()
             .publish(("FeesWithdrawn", fee_collector), (amount, asset));
         Ok(())
+    }
+
+    pub fn set_max_withdraw_per_tx(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        if amount < 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        save_max_withdraw_per_tx(&env, amount);
+        env.events().publish(("MaxWithdrawPerTxSet", admin), (amount,));
+        Ok(())
+    }
+
+    pub fn query_max_withdraw_per_tx(env: Env) -> Result<i128, BridgeError> {
+        check_initialized(&env)?;
+        Ok(read_max_withdraw_per_tx(&env))
     }
 
     pub fn query_fee_bps(env: Env) -> Result<u32, BridgeError> {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -89,6 +89,8 @@ pub enum DataKey {
     PendingFeeCollector,
     // Issue #23: max withdraw per tx
     MaxWithdrawPerTx,
+    // Issue #24: reentrancy guard flag
+    Entered,
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -858,6 +860,30 @@ fn mint_loyalty_tokens(env: &Env, recipient: &Address) {
     }
 }
 
+struct ReentrancyGuard {
+    env: Env,
+}
+
+impl ReentrancyGuard {
+    fn enter(env: &Env) -> Self {
+        let entered: bool = env.storage()
+            .instance()
+            .get(&DataKey::Entered)
+            .unwrap_or(false);
+        if entered {
+            panic!("reentrant call");
+        }
+        env.storage().instance().set(&DataKey::Entered, &true);
+        Self { env: env.clone() }
+    }
+}
+
+impl Drop for ReentrancyGuard {
+    fn drop(&mut self) {
+        self.env.storage().instance().remove(&DataKey::Entered);
+    }
+}
+
 #[contract]
 pub struct OnboardingBridge;
 
@@ -870,6 +896,7 @@ impl OnboardingBridge {
         fee_bps: u32,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         if read_initialized(&env) {
             return Err(BridgeError::AlreadyInitialized);
         }
@@ -902,6 +929,7 @@ impl OnboardingBridge {
         nonce: Option<u64>,
         deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if let Some(d) = deadline {
@@ -954,6 +982,7 @@ impl OnboardingBridge {
         nonce: Option<u64>,
         deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if let Some(d) = deadline {
@@ -1052,6 +1081,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_fee_bps(env: Env, new_fee_bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if new_fee_bps > MAX_FEE_BPS {
@@ -1076,6 +1106,7 @@ impl OnboardingBridge {
         limit_amount: i128,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1099,6 +1130,7 @@ impl OnboardingBridge {
         max_fee_bps: u32,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         if max_fee_bps > MAX_FEE_BPS {
             return Err(BridgeError::FeeTooHigh);
@@ -1119,6 +1151,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_fee_collector(env: Env, new_fee_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let mut config = read_bridge_config(&env);
@@ -1134,6 +1167,7 @@ impl OnboardingBridge {
     }
 
     pub fn propose_new_fee_collector(env: Env, new_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let admin = read_admin(&env);
@@ -1146,6 +1180,7 @@ impl OnboardingBridge {
     }
 
     pub fn accept_fee_collector(env: Env) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let pending = read_pending_fee_collector(&env).ok_or(BridgeError::Unauthorized)?;
@@ -1166,6 +1201,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let mut config = read_bridge_config(&env);
@@ -1181,6 +1217,7 @@ impl OnboardingBridge {
     }
 
     pub fn propose_new_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let admin = read_admin(&env);
@@ -1193,6 +1230,7 @@ impl OnboardingBridge {
     }
 
     pub fn accept_admin(env: Env) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let pending = read_pending_admin(&env).ok_or(BridgeError::Unauthorized)?;
@@ -1213,6 +1251,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_minimum_amount(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         if amount < 0 {
             return Err(BridgeError::InvalidAmount);
@@ -1230,6 +1269,7 @@ impl OnboardingBridge {
     }
 
     pub fn withdraw_fees(env: Env, asset: Address, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -1257,6 +1297,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_max_withdraw_per_tx(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         if amount < 0 {
             return Err(BridgeError::InvalidAmount);
@@ -1280,6 +1321,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_referral_rate(env: Env, bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         if bps > 10_000 {
             return Err(BridgeError::FeeTooHigh);
@@ -1305,6 +1347,7 @@ impl OnboardingBridge {
         amount: i128,
         referrer: Option<Address>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -1413,6 +1456,7 @@ impl OnboardingBridge {
     }
 
     pub fn pause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1423,6 +1467,7 @@ impl OnboardingBridge {
     }
 
     pub fn unpause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1437,6 +1482,7 @@ impl OnboardingBridge {
     }
 
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1474,6 +1520,7 @@ impl OnboardingBridge {
         new_wasm_hash: BytesN<32>,
         nonce: Option<u64>,
     ) -> Result<u32, BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1507,6 +1554,7 @@ impl OnboardingBridge {
         expected_hash: BytesN<32>,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1544,6 +1592,7 @@ impl OnboardingBridge {
 
     /// Cancel a pending scheduled upgrade. Only callable by admin.
     pub fn cancel_upgrade(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1569,6 +1618,7 @@ impl OnboardingBridge {
     // --- Blocklist / Allowlist ---
 
     pub fn add_to_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1580,6 +1630,7 @@ impl OnboardingBridge {
     }
 
     pub fn remove_from_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1591,6 +1642,7 @@ impl OnboardingBridge {
     }
 
     pub fn add_to_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1602,6 +1654,7 @@ impl OnboardingBridge {
     }
 
     pub fn remove_from_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1613,6 +1666,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_allowlist_mode(env: Env, enabled: bool, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1640,6 +1694,7 @@ impl OnboardingBridge {
         destination: Address,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
@@ -1666,6 +1721,7 @@ impl OnboardingBridge {
     // --- Asset Whitelist ---
 
     pub fn add_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1677,6 +1733,7 @@ impl OnboardingBridge {
     }
 
     pub fn remove_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1704,6 +1761,7 @@ impl OnboardingBridge {
         token: Address,
         amount_per_fund: i128,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1727,6 +1785,7 @@ impl OnboardingBridge {
     // --- Tiered Fees ---
 
     pub fn set_fee_tiers(env: Env, tiers: Vec<FeeTier>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1791,6 +1850,7 @@ impl OnboardingBridge {
         amount: i128,
         sigs: Vec<RelayerSig>,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -1881,6 +1941,7 @@ impl OnboardingBridge {
     }
 
     pub fn add_relayer(env: Env, pubkey: BytesN<32>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         read_admin(&env).require_auth();
         add_relayer(&env, &pubkey);
@@ -1888,6 +1949,7 @@ impl OnboardingBridge {
     }
 
     pub fn remove_relayer(env: Env, pubkey: BytesN<32>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         read_admin(&env).require_auth();
         // Prevent removing below threshold
@@ -1900,6 +1962,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_relayer_threshold(env: Env, threshold: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         read_admin(&env).require_auth();
         if threshold > relayer_count(&env) {
@@ -1930,6 +1993,7 @@ impl OnboardingBridge {
         release_time: u64,
         cliff_time: u64,
     ) -> Result<u64, BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -1972,6 +2036,7 @@ impl OnboardingBridge {
     }
 
     pub fn claim_timelocked(env: Env, id: u64) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
 
@@ -2015,6 +2080,7 @@ impl OnboardingBridge {
     // --- TTL Management ---
 
     pub fn extend_instance_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2035,6 +2101,7 @@ impl OnboardingBridge {
         key_asset: Address,
         ttl: u32,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2062,6 +2129,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_max_instance_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2077,6 +2145,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_max_persistent_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2124,6 +2193,7 @@ impl OnboardingBridge {
         valid_after_ledger: u32,
         valid_before_ledger: u32,
     ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
         source.require_auth();

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -81,6 +81,8 @@ pub enum DataKey {
     // Issue #72: timelocked upgrade path
     PendingUpgrade,
     CurrentWasmHash,
+    // Issue #21: two-phase admin transfer
+    PendingAdmin,
 }
 
 const MAX_FEE_BPS: u32 = 1_000;
@@ -181,6 +183,18 @@ fn save_pending_upgrade(env: &Env, pending: &PendingUpgrade) {
 
 fn clear_pending_upgrade(env: &Env) {
     env.storage().instance().remove(&DataKey::PendingUpgrade);
+}
+
+fn save_pending_admin(env: &Env, addr: &Address) {
+    env.storage().instance().set(&DataKey::PendingAdmin, addr);
+}
+
+fn read_pending_admin(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::PendingAdmin)
+}
+
+fn clear_pending_admin(env: &Env) {
+    env.storage().instance().remove(&DataKey::PendingAdmin);
 }
 
 fn read_bridge_config(env: &Env) -> BridgeConfigData {
@@ -1103,6 +1117,38 @@ impl OnboardingBridge {
         env.events()
             .publish(("AdminChanged", old_admin, new_admin.clone()), ());
         Ok(())
+    }
+
+    pub fn propose_new_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        save_pending_admin(&env, &new_admin);
+        env.events()
+            .publish(("AdminTransferProposed", admin, new_admin), ());
+        Ok(())
+    }
+
+    pub fn accept_admin(env: Env) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let pending = read_pending_admin(&env).ok_or(BridgeError::Unauthorized)?;
+        pending.require_auth();
+        let old_admin = read_admin(&env);
+        save_admin(&env, &pending);
+        let mut config = read_bridge_config(&env);
+        config.admin = pending.clone();
+        save_bridge_config(&env, &config);
+        clear_pending_admin(&env);
+        env.events()
+            .publish(("AdminTransferred", old_admin, pending), ());
+        Ok(())
+    }
+
+    pub fn query_pending_admin(env: Env) -> Option<Address> {
+        read_pending_admin(&env)
     }
 
     pub fn set_minimum_amount(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {


### PR DESCRIPTION
Here is the PR description you can use:

Summary
Two-phase admin transfer (propose_new_admin / accept_admin): replaces the single-step set_admin risk with a commit-then-confirm flow. A wrong address set by propose_new_admin is harmless until the new admin calls accept_admin; the current admin remains in control until that confirmation arrives.
Two-phase fee collector transfer (propose_new_fee_collector / accept_fee_collector): same pattern applied to the fee collector role, preventing fees from becoming permanently unrecoverable due to a typo.
Max withdraw per tx (set_max_withdraw_per_tx): admin-configurable cap (default 0 = no limit) checked inside withdraw_fees before any transfer. Limits blast radius if the fee collector key is compromised.
Reentrancy guard: ReentrancyGuard RAII struct backed by DataKey::Entered in instance storage. ReentrancyGuard::enter panics if the flag is already set; Drop clears it. Applied to all 44 state-mutating public functions as a defense-in-depth measure. Soroban transaction rollback ensures the flag is always reset on failure, making the Drop a belt-and-suspenders cleanup for the success path.

Changes

Issue #21 — Two-phase admin transfer
Added DataKey::PendingAdmin
Added save_pending_admin / read_pending_admin / clear_pending_admin helpers
Added propose_new_admin(new_admin, nonce) — admin-only; sets pending admin and emits AdminTransferProposed
Added accept_admin() — pending-admin-only; promotes pending to active admin, clears pending, emits AdminTransferred
Added query_pending_admin() — view function

Issue #22 — Two-phase fee collector transfer
Added DataKey::PendingFeeCollector
Added save_pending_fee_collector / read_pending_fee_collector / clear_pending_fee_collector helpers
Added propose_new_fee_collector(new_collector, nonce) — admin-only; emits FeeCollectorTransferProposed
Added accept_fee_collector() — pending-collector-only; promotes pending, emits FeeCollectorTransferred
Added query_pending_fee_collector() — view function

Issue #23 — Max withdraw per tx
Added BridgeError::WithdrawExceedsLimit = 28
Added DataKey::MaxWithdrawPerTx
Added save_max_withdraw_per_tx / read_max_withdraw_per_tx helpers
Added set_max_withdraw_per_tx(amount, nonce) — admin-only; 0 means no limit; emits MaxWithdrawPerTxSet
Added query_max_withdraw_per_tx() — view function
Modified withdraw_fees to check amount <= max_withdraw_per_tx when a limit is set

Issue #24 — Reentrancy guards
Added DataKey::Entered
Added ReentrancyGuard struct with enter(env) constructor (panics on reentrant call) and Drop impl that removes the flag
Added let _guard = ReentrancyGuard::enter(&env); as the first statement in all 44 state-mutating public functions

Closes
Closes #21
Closes #22
Closes #23
Closes #24