### PR TITLE
Feat/add overflow safe arithmetic with checked math library

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -47,7 +47,8 @@
 #![no_std]
 
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, token, Address, BytesN, Env, Map, Vec,
+    contract, contracterror, contractimpl, contracttype, token, Address, Bytes, BytesN, Env, Map,
+    Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -119,6 +120,8 @@ pub enum BridgeError {
     UpgradeTimelockActive = 27,
     // Issue #23: max withdraw per tx
     WithdrawExceedsLimit = 28,
+    /// An arithmetic operation overflowed i128 bounds.
+    Overflow = 29,
 }
 
 // ---------------------------------------------------------------------------
@@ -518,18 +521,13 @@ fn check_not_paused(env: &Env) -> Result<(), BridgeError> {
 }
 
 #[inline(always)]
-fn calculate_fee(amount: i128, fee_bps: u32) -> i128 {
+fn calculate_fee(amount: i128, fee_bps: u32) -> Result<i128, BridgeError> {
     if fee_bps == 0 {
-        return 0;
+        return Ok(0);
     }
     let bps = fee_bps as i128;
-    // Use checked arithmetic to guard against overflow on very large amounts.
-    // If checked_mul overflows i128 (amount > ~1.7e38 / 1000), fall back to
-    // dividing first at the cost of minor precision loss.
-    match amount.checked_mul(bps) {
-        Some(product) => product / FEE_DENOMINATOR,
-        None => (amount / FEE_DENOMINATOR) * bps,
-    }
+    let product = safe_math::safe_mul(amount, bps)?;
+    safe_math::safe_div(product, FEE_DENOMINATOR)
 }
 
 fn is_blocked(env: &Env, addr: &Address) -> bool {
@@ -983,6 +981,34 @@ fn mint_loyalty_tokens(env: &Env, recipient: &Address) {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Overflow-safe arithmetic (issue #26)
+// ---------------------------------------------------------------------------
+
+mod safe_math {
+    use super::BridgeError;
+
+    #[inline(always)]
+    pub fn safe_add(a: i128, b: i128) -> Result<i128, BridgeError> {
+        a.checked_add(b).ok_or(BridgeError::Overflow)
+    }
+
+    #[inline(always)]
+    pub fn safe_sub(a: i128, b: i128) -> Result<i128, BridgeError> {
+        a.checked_sub(b).ok_or(BridgeError::Overflow)
+    }
+
+    #[inline(always)]
+    pub fn safe_mul(a: i128, b: i128) -> Result<i128, BridgeError> {
+        a.checked_mul(b).ok_or(BridgeError::Overflow)
+    }
+
+    #[inline(always)]
+    pub fn safe_div(a: i128, b: i128) -> Result<i128, BridgeError> {
+        a.checked_div(b).ok_or(BridgeError::Overflow)
+    }
+}
+
 struct ReentrancyGuard {
     env: Env,
 }
@@ -1182,8 +1208,8 @@ impl OnboardingBridge {
         let global_fee_bps = read_fee_bps(&env);
         let tiered_fee_bps = get_tiered_fee_bps(&env, &source, global_fee_bps);
         let effective_fee_bps = get_effective_fee_bps(&env, &asset, tiered_fee_bps);
-        let fee = calculate_fee(amount, effective_fee_bps);
-        let net_amount = amount - fee;
+        let fee = calculate_fee(amount, effective_fee_bps)?;
+        let net_amount = safe_math::safe_sub(amount, fee)?;
 
         if net_amount > 0 {
             token_client.transfer(&contract_addr, &target, &net_amount);
@@ -1293,7 +1319,7 @@ impl OnboardingBridge {
             if amount <= 0 {
                 return Err(BridgeError::InvalidAmount);
             }
-            total += amount;
+            total = safe_math::safe_add(total, amount)?;
         }
 
         let token_client = token::Client::new(&env, &asset);
@@ -1315,8 +1341,8 @@ impl OnboardingBridge {
             let target = targets.get(i).unwrap();
             let amount = amounts.get(i).unwrap();
 
-            let fee = calculate_fee(amount, effective_fee_bps);
-            let net_amount = amount - fee;
+            let fee = calculate_fee(amount, effective_fee_bps)?;
+            let net_amount = safe_math::safe_sub(amount, fee)?;
 
             if check_access(&env, &target).is_err() {
                 num_failures += 1;
@@ -1935,8 +1961,8 @@ impl OnboardingBridge {
 
         let global_fee_bps = read_fee_bps(&env);
         let effective_fee_bps = get_effective_fee_bps(&env, &asset, global_fee_bps);
-        let fee = calculate_fee(amount, effective_fee_bps);
-        let net_amount = amount - fee;
+        let fee = calculate_fee(amount, effective_fee_bps)?;
+        let net_amount = safe_math::safe_sub(amount, fee)?;
 
         if net_amount > 0 {
             token_client.transfer(&env.current_contract_address(), &target, &net_amount);
@@ -1945,7 +1971,7 @@ impl OnboardingBridge {
         // Split fee: referral portion goes directly to referrer
         let referral_fee = if let Some(ref referrer_addr) = referrer {
             let referral_rate = read_referral_rate(&env);
-            let rf = (fee * referral_rate as i128) / FEE_DENOMINATOR;
+            let rf = safe_math::safe_div(safe_math::safe_mul(fee, referral_rate as i128)?, FEE_DENOMINATOR)?;
             if rf > 0 {
                 token_client.transfer(&env.current_contract_address(), referrer_addr, &rf);
                 env.events().publish(
@@ -2095,11 +2121,11 @@ impl OnboardingBridge {
     /// // assert_eq!(fee, 10i128);
     /// // assert_eq!(net, 990i128);
     /// ```
-    pub fn query_calculate_fee(env: Env, gross_amount: i128) -> (i128, i128) {
+    pub fn query_calculate_fee(env: Env, gross_amount: i128) -> Result<(i128, i128), BridgeError> {
         let fee_bps = read_fee_bps(&env);
-        let fee = calculate_fee(gross_amount, fee_bps);
-        let net = gross_amount - fee;
-        (fee, net)
+        let fee = calculate_fee(gross_amount, fee_bps)?;
+        let net = safe_math::safe_sub(gross_amount, fee)?;
+        Ok((fee, net))
     }
 
     /// Returns the cumulative net amount of `asset` that has been delivered to
@@ -3116,8 +3142,8 @@ impl OnboardingBridge {
 
         let fee_bps = read_fee_bps(&env);
         let effective_fee_bps = get_effective_fee_bps(&env, &asset, fee_bps);
-        let fee = calculate_fee(amount, effective_fee_bps);
-        let net_amount = amount - fee;
+        let fee = calculate_fee(amount, effective_fee_bps)?;
+        let net_amount = safe_math::safe_sub(amount, fee)?;
 
         let token_client = token::Client::new(&env, &asset);
         if net_amount > 0 {
@@ -3398,8 +3424,8 @@ impl OnboardingBridge {
 
         let fee_bps = read_fee_bps(&env);
         let effective_fee_bps = get_effective_fee_bps(&env, &entry.asset, fee_bps);
-        let fee = calculate_fee(entry.amount, effective_fee_bps);
-        let net_amount = entry.amount - fee;
+        let fee = calculate_fee(entry.amount, effective_fee_bps)?;
+        let net_amount = safe_math::safe_sub(entry.amount, fee)?;
 
         let token_client = token::Client::new(&env, &entry.asset);
         if net_amount > 0 {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1224,7 +1224,7 @@ impl OnboardingBridge {
         mint_loyalty_tokens(&env, &source);
 
         env.events()
-            .publish(("CAddressFunded", source, target), (amount, fee, asset));
+            .publish(("CAddressFunded", asset, source, target), (amount, fee));
         Ok(())
     }
 
@@ -1364,8 +1364,8 @@ impl OnboardingBridge {
             }
 
             env.events().publish(
-                ("CAddressFunded", source.clone(), target),
-                (amount, fee, asset.clone()),
+                ("CAddressFunded", asset.clone(), source.clone(), target),
+                (amount, fee),
             );
         }
 
@@ -1990,8 +1990,8 @@ impl OnboardingBridge {
         increment_total_fees_collected(&env, &asset, fee);
 
         env.events().publish(
-            ("CAddressFunded", source, target),
-            (amount, fee, asset),
+            ("CAddressFunded", asset, source, target),
+            (amount, fee),
         );
         Ok(())
     }

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -122,6 +122,16 @@ pub enum BridgeError {
     WithdrawExceedsLimit = 28,
     /// An arithmetic operation overflowed i128 bounds.
     Overflow = 29,
+    /// No commitment exists for the given ID.
+    CommitmentNotFound = 30,
+    /// The commitment has already been revealed.
+    CommitmentAlreadyRevealed = 31,
+    /// The reveal deadline has passed.
+    CommitmentExpired = 32,
+    /// The revealed amount+nonce does not match the stored hash.
+    CommitmentHashMismatch = 33,
+    /// The minimum delay between commit and reveal has not elapsed.
+    CommitmentNotMatured = 34,
 }
 
 // ---------------------------------------------------------------------------
@@ -179,6 +189,9 @@ pub enum DataKey {
     MaxWithdrawPerTx,
     // Issue #24: reentrancy guard flag
     Entered,
+    // Issue #30: commit-reveal counter and entries
+    CommitmentId,
+    Commitment(u64),
 }
 
 // ---------------------------------------------------------------------------
@@ -193,6 +206,8 @@ const MAX_ALLOWED_TTL: u32 = 3_110_400; // ~1 year in ledgers (5s/ledger)
 const CRITICAL_ENTRY_TTL_THRESHOLD: u32 = 100_000;
 /// Minimum ledgers that must pass before a scheduled upgrade becomes executable (~24 h at 5 s/ledger).
 const UPGRADE_TIMELOCK_LEDGERS: u32 = 17_280;
+/// Minimum ledgers between commit_fund and reveal_fund (~25 s at 5 s/ledger).
+const COMMIT_REVEAL_MIN_DELAY_LEDGERS: u32 = 5;
 
 // ---------------------------------------------------------------------------
 // Structs
@@ -294,6 +309,30 @@ pub struct PendingUpgrade {
     pub new_wasm_hash: BytesN<32>,
     /// Ledger sequence at or after which `execute_upgrade` may be called.
     pub executable_after_ledger: u32,
+}
+
+/// A pending commit-reveal entry created by `commit_fund`.
+///
+/// The `amount_hash` is `sha256(amount_be16 || nonce_be8)`.  The `reveal_fund`
+/// function verifies this hash before executing the transfer so that the
+/// actual amount is never visible in the mempool.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CommitmentEntry {
+    /// Address that will provide the tokens at reveal time.
+    pub source: Address,
+    /// Address that will receive the net amount at reveal time.
+    pub target: Address,
+    /// Whitelisted token contract address.
+    pub asset: Address,
+    /// sha256(amount_be16 || nonce_be8) — binds the reveal to a specific amount.
+    pub amount_hash: BytesN<32>,
+    /// Unix timestamp deadline; reveal must happen before this.
+    pub deadline: u64,
+    /// Ledger sequence when the commitment was created; used to enforce delay.
+    pub committed_at_ledger: u32,
+    /// Set to `true` once `reveal_fund` has been successfully called.
+    pub revealed: bool,
 }
 
 // ---------------------------------------------------------------------------
@@ -982,6 +1021,30 @@ fn mint_loyalty_tokens(env: &Env, recipient: &Address) {
 }
 
 // ---------------------------------------------------------------------------
+// Commit-reveal helpers (issue #30)
+// ---------------------------------------------------------------------------
+
+fn next_commitment_id(env: &Env) -> u64 {
+    let id: u64 = env
+        .storage()
+        .instance()
+        .get(&DataKey::CommitmentId)
+        .unwrap_or(0u64);
+    env.storage().instance().set(&DataKey::CommitmentId, &(id + 1));
+    id
+}
+
+fn save_commitment(env: &Env, id: u64, entry: &CommitmentEntry) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Commitment(id), entry);
+}
+
+fn read_commitment(env: &Env, id: u64) -> Option<CommitmentEntry> {
+    env.storage().persistent().get(&DataKey::Commitment(id))
+}
+
+// ---------------------------------------------------------------------------
 // Overflow-safe arithmetic (issue #26)
 // ---------------------------------------------------------------------------
 
@@ -1160,7 +1223,7 @@ impl OnboardingBridge {
     ///
     /// # Events
     ///
-    /// * `("CAddressFunded", source, target)` — data: `(amount, fee, asset)`
+    /// * `("CAddressFunded", asset, source, target)` — data: `(amount, fee)`
     ///
     /// # Security Considerations
     ///
@@ -1265,8 +1328,8 @@ impl OnboardingBridge {
     ///
     /// # Events
     ///
-    /// * `("CAddressFunded", source, target)` — Emitted per successful entry;
-    ///   data: `(amount, fee, asset)`.
+    /// * `("CAddressFunded", asset, source, target)` — Emitted per successful entry;
+    ///   data: `(amount, fee)`.
     /// * `("BatchTransferFailed", source, target)` — Emitted per skipped entry;
     ///   data: `(amount, "access_denied")`.
     /// * `("BatchCompleted", source)` — Emitted once at the end;
@@ -1921,7 +1984,7 @@ impl OnboardingBridge {
     ///
     /// * `("ReferralPaid", source, referrer)` — Emitted only when `referrer` is
     ///   `Some` and `referral_fee > 0`; data: `(rf, asset)`.
-    /// * `("CAddressFunded", source, target)` — data: `(amount, fee, asset)`.
+    /// * `("CAddressFunded", asset, source, target)` — data: `(amount, fee)`.
     ///
     /// # Security Considerations
     ///
@@ -3746,6 +3809,219 @@ impl OnboardingBridge {
     pub fn query_accrued_fees(env: Env, asset: Address) -> Result<i128, BridgeError> {
         check_initialized(&env)?;
         Ok(read_accrued_fees(&env, &asset))
+    }
+
+    // -----------------------------------------------------------------------
+    // Commit-reveal funding (issue #30)
+    // -----------------------------------------------------------------------
+
+    /// Stores a blinded funding commitment without revealing the amount.
+    ///
+    /// The caller commits to a specific `(source, target, asset, amount)` by
+    /// providing `amount_hash = sha256(amount_be16 || nonce_be8)`.  The actual
+    /// amount stays hidden until `reveal_fund` is called, preventing
+    /// front-runners from observing the value before the commitment is settled.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` (`Address`) — The account that will supply the tokens.
+    /// * `target` (`Address`) — The C-address that will receive the net amount.
+    /// * `asset` (`Address`) — Whitelisted token contract address.
+    /// * `amount_hash` (`BytesN<32>`) — `sha256(amount_be16 || nonce_be8)`.
+    /// * `deadline` (`u64`) — Unix timestamp; `reveal_fund` must be called
+    ///   before this time.
+    ///
+    /// # Authorization
+    ///
+    /// Requires `source.require_auth()`.
+    ///
+    /// # Returns
+    ///
+    /// A numeric commitment ID used to reference this entry in `reveal_fund`
+    /// and `query_commitment`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::ContractPaused`] — Contract is paused.
+    /// * [`BridgeError::TransactionExpired`] — `deadline` is in the past.
+    /// * [`BridgeError::AddressBlocked`] — `target` is on the blocklist.
+    /// * [`BridgeError::AddressNotAllowlisted`] — Allowlist mode on and `target`
+    ///   is not allowlisted.
+    /// * [`BridgeError::AssetNotWhitelisted`] — `asset` has not been added.
+    ///
+    /// # Events
+    ///
+    /// * `("CommitFund", source, target)` — data: `(id, amount_hash, asset, deadline)`
+    pub fn commit_fund(
+        env: Env,
+        source: Address,
+        target: Address,
+        asset: Address,
+        amount_hash: BytesN<32>,
+        deadline: u64,
+    ) -> Result<u64, BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        if env.ledger().timestamp() >= deadline {
+            return Err(BridgeError::TransactionExpired);
+        }
+        check_access(&env, &target)?;
+        check_asset_whitelisted(&env, &asset)?;
+        source.require_auth();
+        extend_instance_ttl(&env);
+
+        let id = next_commitment_id(&env);
+        let committed_at_ledger = env.ledger().sequence();
+
+        save_commitment(
+            &env,
+            id,
+            &CommitmentEntry {
+                source: source.clone(),
+                target: target.clone(),
+                asset: asset.clone(),
+                amount_hash: amount_hash.clone(),
+                deadline,
+                committed_at_ledger,
+                revealed: false,
+            },
+        );
+
+        env.events().publish(
+            ("CommitFund", source, target),
+            (id, amount_hash, asset, deadline),
+        );
+        Ok(id)
+    }
+
+    /// Executes a previously committed fund transfer after the minimum delay.
+    ///
+    /// Verifies `sha256(amount_be16 || nonce_be8) == stored_amount_hash` before
+    /// transferring tokens, ensuring the caller cannot substitute a different
+    /// amount from the one committed.
+    ///
+    /// # Arguments
+    ///
+    /// * `commitment_id` (`u64`) — ID returned by `commit_fund`.
+    /// * `source` (`Address`) — Must match the committed source.
+    /// * `target` (`Address`) — Must match the committed target.
+    /// * `asset` (`Address`) — Must match the committed asset.
+    /// * `amount` (`i128`) — Actual gross amount; must satisfy the hash.
+    /// * `nonce` (`u64`) — Blinding nonce used when computing `amount_hash`.
+    ///
+    /// # Authorization
+    ///
+    /// Requires `source.require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::ContractPaused`] — Contract is paused.
+    /// * [`BridgeError::CommitmentNotFound`] — No entry for `commitment_id`.
+    /// * [`BridgeError::CommitmentAlreadyRevealed`] — Already revealed.
+    /// * [`BridgeError::CommitmentExpired`] — Past the reveal deadline.
+    /// * [`BridgeError::CommitmentNotMatured`] — Minimum delay not yet elapsed.
+    /// * [`BridgeError::Unauthorized`] — `source`, `target`, or `asset` do not
+    ///   match the commitment.
+    /// * [`BridgeError::CommitmentHashMismatch`] — Hash does not match.
+    /// * [`BridgeError::InvalidAmount`] — `amount` ≤ 0.
+    /// * [`BridgeError::Overflow`] — Fee arithmetic overflowed.
+    ///
+    /// # Events
+    ///
+    /// * `("CommitRevealFunded", asset, source, target)` — data:
+    ///   `(commitment_id, amount, fee)`
+    pub fn reveal_fund(
+        env: Env,
+        commitment_id: u64,
+        source: Address,
+        target: Address,
+        asset: Address,
+        amount: i128,
+        nonce: u64,
+    ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+
+        let mut entry = read_commitment(&env, commitment_id)
+            .ok_or(BridgeError::CommitmentNotFound)?;
+
+        if entry.revealed {
+            return Err(BridgeError::CommitmentAlreadyRevealed);
+        }
+
+        if env.ledger().timestamp() > entry.deadline {
+            return Err(BridgeError::CommitmentExpired);
+        }
+
+        if env.ledger().sequence()
+            < entry
+                .committed_at_ledger
+                .saturating_add(COMMIT_REVEAL_MIN_DELAY_LEDGERS)
+        {
+            return Err(BridgeError::CommitmentNotMatured);
+        }
+
+        if entry.source != source || entry.target != target || entry.asset != asset {
+            return Err(BridgeError::Unauthorized);
+        }
+
+        // Verify hash: sha256(amount_be16 || nonce_be8)
+        let mut preimage = Bytes::new(&env);
+        preimage.extend_from_array(&amount.to_be_bytes());
+        preimage.extend_from_array(&nonce.to_be_bytes());
+        let computed_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+        if computed_hash != entry.amount_hash {
+            return Err(BridgeError::CommitmentHashMismatch);
+        }
+
+        if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+
+        source.require_auth();
+
+        // Mark revealed before the transfer to prevent re-entrancy replay.
+        entry.revealed = true;
+        save_commitment(&env, commitment_id, &entry);
+
+        let token_client = token::Client::new(&env, &asset);
+        let contract_addr = env.current_contract_address();
+        token_client.transfer(&source, &contract_addr, &amount);
+
+        let global_fee_bps = read_fee_bps(&env);
+        let tiered_fee_bps = get_tiered_fee_bps(&env, &source, global_fee_bps);
+        let effective_fee_bps = get_effective_fee_bps(&env, &asset, tiered_fee_bps);
+        let fee = calculate_fee(amount, effective_fee_bps)?;
+        let net_amount = safe_math::safe_sub(amount, fee)?;
+
+        if net_amount > 0 {
+            token_client.transfer(&contract_addr, &target, &net_amount);
+        }
+
+        increment_accrued_fees(&env, &asset, fee);
+        increment_total_bridged(&env, &asset, net_amount);
+        increment_total_fees_collected(&env, &asset, fee);
+        increment_source_bridged_volume(&env, &source, amount);
+        extend_instance_ttl(&env);
+
+        env.events().publish(
+            ("CommitRevealFunded", asset, source, target),
+            (commitment_id, amount, fee),
+        );
+        Ok(())
+    }
+
+    /// Returns a commitment entry by ID.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::CommitmentNotFound`] — No entry for `id`.
+    pub fn query_commitment(env: Env, id: u64) -> Result<CommitmentEntry, BridgeError> {
+        read_commitment(&env, id).ok_or(BridgeError::CommitmentNotFound)
     }
 }
 

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -9,8 +9,12 @@ use soroban_sdk::{
 fn register_all_contracts(env: &Env) -> (Address, Address) {
     let bridge_id = env.register(OnboardingBridge, ());
     let token_id = env.register(TestToken, ());
-    env.mock_all_auths();
     (bridge_id, token_id)
+}
+
+fn register_all_contracts_mocked(env: &Env) -> (Address, Address) {
+    env.mock_all_auths();
+    register_all_contracts(env)
 }
 
 fn init_token(env: &Env, token_id: &Address, admin: &Address) {
@@ -46,7 +50,7 @@ fn check_balance(env: &Env, token_id: &Address, addr: &Address) -> i128 {
 fn test_initialize() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -61,7 +65,7 @@ fn test_initialize() {
 fn test_initialize_twice() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -75,7 +79,7 @@ fn test_initialize_twice() {
 fn test_initialize_fee_too_high() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     assert_eq!(
@@ -88,7 +92,7 @@ fn test_initialize_fee_too_high() {
 fn test_fund_c_address() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -109,7 +113,7 @@ fn test_fund_c_address() {
 fn test_fund_without_initialize() {
     let env = Env::default();
     let (_admin, user, _fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&Address::generate(&env), &Address::generate(&env), &50u32, &None);
@@ -127,7 +131,7 @@ fn test_fund_without_initialize() {
 fn test_batch_fund_c_addresses() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -153,7 +157,7 @@ fn test_batch_fund_c_addresses() {
 fn test_fund_with_zero_fee() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -174,7 +178,7 @@ fn test_fund_with_zero_fee() {
 fn test_set_fee_bps() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -188,7 +192,7 @@ fn test_set_fee_bps() {
 fn test_set_fee_bps_too_high() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -202,7 +206,7 @@ fn test_set_fee_bps_too_high() {
 fn test_set_fee_collector() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -215,7 +219,7 @@ fn test_set_fee_collector() {
 fn test_set_admin() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -228,7 +232,7 @@ fn test_set_admin() {
 fn test_withdraw_fees() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -252,7 +256,7 @@ fn test_withdraw_fees() {
 fn test_query_balance() {
     let env = Env::default();
     let (admin, user, _fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -267,7 +271,7 @@ fn test_query_balance() {
 fn test_batch_empty() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     let token_id = Address::generate(&env);
@@ -283,7 +287,7 @@ fn test_batch_empty() {
 fn test_fund_events() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -304,7 +308,7 @@ fn test_fund_events() {
 #[test]
 fn test_query_fee_bps_uninitialized() {
     let env = Env::default();
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     assert_eq!(
         bridge.try_query_fee_bps(),
@@ -318,7 +322,7 @@ fn test_query_fee_bps_uninitialized() {
 fn test_pause_and_unpause() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -336,7 +340,7 @@ fn test_pause_and_unpause() {
 fn test_fund_c_address_paused() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -355,7 +359,7 @@ fn test_fund_c_address_paused() {
 fn test_batch_fund_paused() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -376,7 +380,7 @@ fn test_batch_fund_paused() {
 fn test_withdraw_fees_paused() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -397,7 +401,7 @@ fn test_withdraw_fees_paused() {
 fn test_set_fee_bps_paused() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -412,7 +416,7 @@ fn test_set_fee_bps_paused() {
 fn test_set_fee_collector_paused() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -427,7 +431,7 @@ fn test_set_fee_collector_paused() {
 fn test_set_admin_paused() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -442,7 +446,7 @@ fn test_set_admin_paused() {
 fn test_view_functions_work_when_paused() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -462,7 +466,7 @@ fn test_view_functions_work_when_paused() {
 fn test_pause_emits_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -477,7 +481,7 @@ fn test_pause_emits_event() {
 fn test_unpause_emits_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -493,7 +497,7 @@ fn test_unpause_emits_event() {
 fn test_fund_works_after_unpause() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -521,7 +525,7 @@ const V2_WASM: &[u8] = include_bytes!(concat!(
 fn test_upgrade_admin_only_and_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     env.mock_all_auths();
 
@@ -561,7 +565,7 @@ fn test_upgrade_non_admin_rejected() {
 // --------- Blocklist / Allowlist Tests ---------
 
 fn setup_bridge(env: &Env) -> (crate::OnboardingBridgeClient<'_>, Address, Address, Address) {
-    let (bridge_id, token_id) = register_all_contracts(env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(env);
     let bridge = create_bridge_client(env, &bridge_id);
     let (admin, user, fee_collector) = create_test_users(env);
     init_token(env, &token_id, &admin);
@@ -771,7 +775,7 @@ fn test_reclaim_emits_event() {
 fn test_add_asset_whitelists_it() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -785,7 +789,7 @@ fn test_add_asset_whitelists_it() {
 fn test_remove_asset() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -800,7 +804,7 @@ fn test_remove_asset() {
 fn test_query_whitelisted_assets() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -830,7 +834,7 @@ fn test_query_whitelisted_assets() {
 fn test_add_asset_is_idempotent() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -845,7 +849,7 @@ fn test_add_asset_is_idempotent() {
 fn test_add_asset_non_admin_rejected() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -859,7 +863,7 @@ fn test_add_asset_non_admin_rejected() {
 fn test_remove_asset_non_admin_rejected() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -872,7 +876,7 @@ fn test_remove_asset_non_admin_rejected() {
 #[test]
 fn test_whitelist_query_uninitialized() {
     let env = Env::default();
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     assert_eq!(
         bridge.try_query_is_asset_whitelisted(&token_id),
@@ -884,7 +888,7 @@ fn test_whitelist_query_uninitialized() {
 fn test_fund_rejects_non_whitelisted_asset() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -902,7 +906,7 @@ fn test_fund_rejects_non_whitelisted_asset() {
 fn test_batch_fund_rejects_non_whitelisted_asset() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -925,7 +929,7 @@ fn test_batch_fund_rejects_non_whitelisted_asset() {
 fn test_query_all_balances_returns_contract_balances() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
     bridge.initialize(&admin, &fee_collector, &0u32, &None);
@@ -943,7 +947,7 @@ fn test_query_all_balances_returns_contract_balances() {
 fn test_query_all_balances_empty_input() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _token_id) = register_all_contracts(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     bridge.initialize(&admin, &fee_collector, &0u32, &None);
 
@@ -956,7 +960,7 @@ fn test_query_all_balances_empty_input() {
 fn test_accrued_fees_single_deposit() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -975,7 +979,7 @@ fn test_accrued_fees_single_deposit() {
 fn test_accrued_fees_accumulate_across_deposits() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -994,7 +998,7 @@ fn test_accrued_fees_accumulate_across_deposits() {
 fn test_accrued_fees_batch_accumulate() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1017,7 +1021,7 @@ fn test_accrued_fees_batch_accumulate() {
 fn test_withdraw_fees_decrements_accrued() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1038,7 +1042,7 @@ fn test_withdraw_fees_decrements_accrued() {
 fn test_withdraw_fees_exceeds_accrued() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1059,7 +1063,7 @@ fn test_withdraw_fees_exceeds_accrued() {
 fn test_zero_fee_no_accrued_entry() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1145,7 +1149,7 @@ impl TestToken {
 fn test_query_calculate_fee() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &100u32, &None);
@@ -1159,7 +1163,7 @@ fn test_query_calculate_fee() {
 fn test_query_calculate_fee_zero_fee() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &0u32, &None);
@@ -1173,7 +1177,7 @@ fn test_query_calculate_fee_zero_fee() {
 fn test_query_calculate_fee_max_fee() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &1000u32, &None);
@@ -1189,7 +1193,7 @@ fn test_query_calculate_fee_max_fee() {
 fn test_query_total_bridged_and_fees_collected() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1211,7 +1215,7 @@ fn test_query_total_bridged_and_fees_collected() {
 fn test_query_total_bridged_accumulates() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1236,7 +1240,7 @@ fn test_query_total_bridged_accumulates() {
 fn test_query_total_bridged_batch() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -1262,7 +1266,7 @@ fn test_query_total_bridged_batch() {
 fn test_query_total_bridged_zero() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -1280,7 +1284,7 @@ fn test_query_total_bridged_zero() {
 fn test_initialize_emits_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -1294,7 +1298,7 @@ fn test_initialize_emits_event() {
 fn test_fee_bps_changed_emits_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -1309,7 +1313,7 @@ fn test_fee_bps_changed_emits_event() {
 fn test_fee_collector_changed_emits_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -1325,7 +1329,7 @@ fn test_fee_collector_changed_emits_event() {
 fn test_admin_changed_emits_event() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &50u32, &None);
@@ -1340,7 +1344,7 @@ fn test_admin_changed_emits_event() {
 // --------- batch_fund_c_address edge case tests ---------
 
 fn setup_batch(env: &Env) -> (crate::OnboardingBridgeClient<'_>, Address, Address, Address) {
-    let (bridge_id, token_id) = register_all_contracts(env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(env);
     let bridge = create_bridge_client(env, &bridge_id);
     let (admin, user, fee_collector) = create_test_users(env);
     init_token(env, &token_id, &admin);
@@ -1634,7 +1638,7 @@ fn test_batch_100_targets() {
 #[test]
 fn test_nonce_starts_at_zero() {
     let env = Env::default();
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     let caller = Address::generate(&env);
     assert_eq!(bridge.query_nonce(&caller), 0u64);
@@ -2077,7 +2081,7 @@ mod crosschain_tests {
 fn test_set_and_query_referral_rate() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &100u32, &None);
@@ -2094,7 +2098,7 @@ fn test_set_and_query_referral_rate() {
 fn test_set_referral_rate_too_high() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &100u32, &None);
@@ -2109,7 +2113,7 @@ fn test_set_referral_rate_too_high() {
 fn test_fund_with_referral_splits_fee() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2142,7 +2146,7 @@ fn test_fund_with_referral_splits_fee() {
 fn test_fund_with_no_referrer_accrues_full_fee() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2164,7 +2168,7 @@ fn test_fund_with_no_referrer_accrues_full_fee() {
 fn test_fund_with_referral_zero_referral_rate() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2197,7 +2201,7 @@ fn test_fund_with_referral_zero_referral_rate() {
 fn test_fund_c_address_zero_amount_fails() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2216,7 +2220,7 @@ fn test_fund_c_address_zero_amount_fails() {
 fn test_fund_c_address_zero_amount_no_event() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2238,7 +2242,7 @@ fn test_fund_c_address_zero_amount_no_event() {
 fn test_batch_fund_all_zeros_fails() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2260,7 +2264,7 @@ fn test_batch_fund_all_zeros_fails() {
 fn test_batch_fund_mixed_zero_nonzero_fails() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2287,7 +2291,7 @@ fn test_batch_fund_mixed_zero_nonzero_fails() {
 fn test_calculate_fee_zero_amount() {
     let env = Env::default();
     let (admin, _user, fee_collector) = create_test_users(&env);
-    let (bridge_id, _) = register_all_contracts(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
 
     bridge.initialize(&admin, &fee_collector, &100u32, &None);
@@ -2302,7 +2306,7 @@ fn test_calculate_fee_zero_amount() {
 fn test_fund_c_address_zero_amount_max_fee_fails() {
     let env = Env::default();
     let (admin, user, fee_collector) = create_test_users(&env);
-    let (bridge_id, token_id) = register_all_contracts(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
     let bridge = create_bridge_client(&env, &bridge_id);
     init_token(&env, &token_id, &admin);
 
@@ -2314,4 +2318,82 @@ fn test_fund_c_address_zero_amount_max_fee_fails() {
         bridge.try_fund_c_address(&user, &target, &token_id, &0i128, &None, &None),
         Err(Ok(BridgeError::InvalidAmount))
     );
+}
+
+// --------- Authorization enforcement tests (issue #27) ---------
+// These tests verify that specific require_auth() calls are enforced.
+// Setup uses register_all_contracts_mocked; auths are cleared before the
+// operation under test so that auth enforcement is real, not bypassed.
+
+#[test]
+#[should_panic]
+fn test_fund_c_address_requires_source_auth() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    use soroban_sdk::xdr::SorobanAuthorizationEntry;
+    env.set_auths(&[] as &[SorobanAuthorizationEntry]);
+
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
+}
+
+#[test]
+#[should_panic]
+fn test_set_fee_bps_requires_admin_auth() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    use soroban_sdk::xdr::SorobanAuthorizationEntry;
+    env.set_auths(&[] as &[SorobanAuthorizationEntry]);
+
+    bridge.set_fee_bps(&200u32, &None);
+}
+
+#[test]
+#[should_panic]
+fn test_withdraw_fees_requires_fee_collector_auth() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
+
+    use soroban_sdk::xdr::SorobanAuthorizationEntry;
+    env.set_auths(&[] as &[SorobanAuthorizationEntry]);
+
+    bridge.withdraw_fees(&token_id, &5i128, &None);
+}
+
+#[test]
+#[should_panic]
+fn test_pause_requires_admin_auth() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    use soroban_sdk::xdr::SorobanAuthorizationEntry;
+    env.set_auths(&[] as &[SorobanAuthorizationEntry]);
+
+    bridge.pause(&None);
 }


### PR DESCRIPTION
Summary
This PR addresses four independent issues across the contract's arithmetic safety, authorization testing, event schema, and front-running protection.

#26 — Overflow-safe arithmetic (safe_math module)
All fee and amount arithmetic on i128 values now routes through a new safe_math module (safe_add, safe_sub, safe_mul, safe_div) that wraps the checked_* methods and returns BridgeError::Overflow on overflow instead of panicking. The existing calculate_fee helper was updated to return Result<i128, BridgeError>, and all six call sites (fund_c_address, batch_fund_c_address, fund_c_address_with_referral, query_calculate_fee, and the batch-total accumulator) now propagate errors with ?.

#27 — Authorization enforcement in tests
The blanket env.mock_all_auths() call was removed from register_all_contracts so that tests opt in to auth-mocking rather than getting it for free. A new register_all_contracts_mocked helper preserves the existing behavior for the ~50 tests that test functionality rather than authorization. Four new #[should_panic] tests verify that fund_c_address, set_fee_bps, withdraw_fees, and pause all reject calls made without the required authorization.

#28 — Asset address in CAddressFunded event topics
The CAddressFunded event emitted by fund_c_address, batch_fund_c_address, and fund_c_address_with_referral was changed from 3 topics ("CAddressFunded", source, target) to 4 topics ("CAddressFunded", asset, source, target). This allows off-chain indexers to filter by asset using a topic filter alone, without needing to decode the event data body.

#30 — Commit-reveal funding for front-running protection
Two new public functions implement the commit-reveal pattern:

commit_fund — the caller submits a sha256(amount_be16 || nonce_be8) hash along with source, target, asset, and a UNIX deadline. The commitment is stored in persistent storage and a numeric ID is returned.
reveal_fund — the caller provides the commitment_id, plaintext amount, and nonce. The contract verifies the hash, enforces the minimum reveal delay (COMMIT_REVEAL_MIN_DELAY_LEDGERS = 5), checks the deadline, and then executes the token transfer via the same fee path as fund_c_address.
A CommitmentEntry struct and DataKey::Commitment(u64) / DataKey::CommitmentId storage keys back the feature. A query_commitment read-only function allows callers to inspect a stored entry.

New BridgeError variants: Overflow, CommitmentNotFound, CommitmentAlreadyRevealed, CommitmentExpired, CommitmentHashMismatch, CommitmentNotMatured.

closes #26
closes #27
closes #28
closes #30