### PR TITLE
Fix SDK keypair typing, enforce batch size, update benchmark budget API, and add timelock tests

### DIFF
--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -94,11 +94,11 @@ fn mint(env: &Env, token_id: &Address, to: &Address, amount: i128) {
 
 /// Reset the budget tracker, run `f`, then capture and print costs.
 fn measure(env: &Env, name: &str, f: impl FnOnce()) {
-    env.budget().reset_unlimited();
-    env.budget().reset_tracker();
+    env.cost_estimate().budget().reset_unlimited();
+    env.cost_estimate().budget().reset_tracker();
     f();
-    let cpu = env.budget().cpu_instruction_cost();
-    let mem = env.budget().memory_bytes_cost();
+    let cpu = env.cost_estimate().budget().cpu_instruction_cost();
+    let mem = env.cost_estimate().budget().memory_bytes_cost();
     // Tab-separated so CI can parse it with `column -t`
     println!("BENCH\t{name}\t{cpu}\t{mem}");
 }

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -85,7 +85,6 @@ pub enum DataKey {
 
 const MAX_FEE_BPS: u32 = 1_000;
 const FEE_DENOMINATOR: i128 = 10_000;
-#[allow(dead_code)]
 const MAX_BATCH_SIZE: u32 = 100;
 const MAX_ALLOWED_TTL: u32 = 3_110_400; // ~1 year in ledgers (5s/ledger)
 const CRITICAL_ENTRY_TTL_THRESHOLD: u32 = 100_000;
@@ -913,6 +912,9 @@ impl OnboardingBridge {
     ) -> Result<(), BridgeError> {
         check_initialized(&env)?;
         check_not_paused(&env)?;
+        if targets.len() > MAX_BATCH_SIZE {
+            return Err(BridgeError::InvalidAmount);
+        }
         if let Some(d) = deadline {
             if env.ledger().timestamp() > d {
                 return Err(BridgeError::TransactionExpired);

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1500,7 +1500,7 @@ fn test_batch_negative_amount_rejected() {
 
 /// Fee causes net_amount == 0 — transfer is skipped, fee still accrues.
 /// At 1000 bps (10%), an amount of 9 → fee=0 (rounds down), net=9, transfer happens.
-/// At 1000 bps, amount=1 → fee=0 (1*1000/10000 = 0), net=1. 
+/// At 1000 bps, amount=1 → fee=0 (1*1000/10000 = 0), net=1.
 /// To get net==0 we need fee_bps=10000 which exceeds max. Instead, use fee_bps=1000 and
 /// amount=1: fee = 1*1000/10000 = 0, net = 1. Can't get net=0 with valid fee_bps.
 /// The contract MAX_FEE_BPS is 1000 (10%), so with amount=1: fee=0, net=1.
@@ -1627,6 +1627,26 @@ fn test_batch_100_targets() {
     }
     // Source spent 100_000 tokens from the extra mint.
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128); // original unchanged
+}
+
+/// Batches larger than MAX_BATCH_SIZE (100) must be rejected.
+#[test]
+fn test_batch_exceeds_max_size() {
+    let env = Env::default();
+    let (bridge, user, token_id, _) = setup_batch(&env);
+
+    let mut targets: Vec<Address> = Vec::new(&env);
+    let mut amounts: Vec<i128> = Vec::new(&env);
+    for _ in 0..101 {
+        targets.push_back(Address::generate(&env));
+        amounts.push_back(1i128);
+    }
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
+    assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
 }
 
 /********** Nonce tests **********/
@@ -1817,6 +1837,153 @@ fn test_batch_fund_deadline_in_future_passes() {
     let amounts = Vec::from_array(&env, [1000i128]);
     bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &Some(9999u64));
     assert_eq!(check_balance(&env, &token_id, &t1), 990i128); // 1% fee
+}
+
+/********** Timelocked funding tests **********/
+
+#[cfg(test)]
+mod timelocked_tests {
+    use super::*;
+
+    fn setup_timelocked(env: &Env) -> (
+        crate::OnboardingBridgeClient<'_>,
+        Address,
+        Address,
+        Address,
+        Address,
+    ) {
+        let (bridge_id, token_id) = register_all_contracts(env);
+        let bridge = create_bridge_client(env, &bridge_id);
+        let (admin, user, fee_collector) = create_test_users(env);
+        init_token(env, &token_id, &admin);
+        bridge.initialize(&admin, &fee_collector, &100u32, &None); // 1% fee
+        bridge.add_asset(&token_id, &None);
+        mint_tokens(env, &token_id, &user, 10_000i128);
+        (bridge, user, token_id, fee_collector, admin)
+    }
+
+    #[test]
+    fn test_timelocked_happy_path() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+        let release_time = 1_100u64;
+
+        let id = bridge.fund_c_address_timelocked(
+            &user,
+            &target,
+            &token_id,
+            &500i128,
+            &release_time,
+            &0u64,
+        );
+
+        env.ledger().set_timestamp(release_time + 1);
+        bridge.claim_timelocked(&id);
+
+        assert_eq!(check_balance(&env, &token_id, &target), 495i128);
+        assert_eq!(bridge.query_accrued_fees(&token_id), 5i128);
+    }
+
+    #[test]
+    fn test_timelocked_claim_before_release_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(2_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+
+        let id = bridge.fund_c_address_timelocked(
+            &user,
+            &target,
+            &token_id,
+            &500i128,
+            &(2_100u64),
+            &0u64,
+        );
+
+        assert_eq!(
+            bridge.try_claim_timelocked(&id),
+            Err(Ok(BridgeError::TimelockNotMatured))
+        );
+    }
+
+    #[test]
+    fn test_timelocked_cliff_time_after_release_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(3_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+
+        assert_eq!(
+            bridge.try_fund_c_address_timelocked(
+                &user,
+                &target,
+                &token_id,
+                &500i128,
+                &3_100u64,
+                &3_101u64,
+            ),
+            Err(Ok(BridgeError::InvalidReleaseTime))
+        );
+    }
+
+    #[test]
+    fn test_timelocked_release_in_past_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(4_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+
+        assert_eq!(
+            bridge.try_fund_c_address_timelocked(
+                &user,
+                &target,
+                &token_id,
+                &500i128,
+                &4_000u64,
+                &0u64,
+            ),
+            Err(Ok(BridgeError::InvalidReleaseTime))
+        );
+    }
+
+    #[test]
+    fn test_timelocked_double_claim_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(5_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+        let release_time = 5_050u64;
+
+        let id = bridge.fund_c_address_timelocked(
+            &user,
+            &target,
+            &token_id,
+            &500i128,
+            &release_time,
+            &0u64,
+        );
+
+        env.ledger().set_timestamp(release_time + 1);
+        bridge.claim_timelocked(&id);
+
+        assert_eq!(
+            bridge.try_claim_timelocked(&id),
+            Err(Ok(BridgeError::Unauthorized))
+        );
+    }
+
+    #[test]
+    fn test_query_timelocked_unknown_id_fails() {
+        let env = Env::default();
+        let (bridge, _user, _token_id, _fee_collector, _admin) = setup_timelocked(&env);
+
+        assert_eq!(
+            bridge.try_query_timelocked(&999_999u64),
+            Err(Ok(BridgeError::TimelockNotFound))
+        );
+    }
 }
 
 /********** Cross-chain Onboarding Tests **********/

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -18,6 +18,7 @@ import {
   xdr,
   Address,
   Account,
+  Keypair,
   nativeToScVal,
   scValToNative,
   TransactionBuilder,
@@ -44,7 +45,7 @@ export class OnboardingBridgeSDK {
    */
   async fundCAddress(
     options: FundCOptions,
-    sourceKeypair: any,
+    sourceKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       assertAccountAddress(options.source, 'source');
@@ -93,7 +94,7 @@ export class OnboardingBridgeSDK {
    */
   async batchFundCAddresses(
     options: BatchFundCOptions,
-    sourceKeypair: any,
+    sourceKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       assertAccountAddress(options.source, 'source');
@@ -143,7 +144,7 @@ export class OnboardingBridgeSDK {
    */
   async withdrawFees(
     options: WithdrawFeesOptions,
-    feeCollectorKeypair: any,
+    feeCollectorKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       assertContractAddress(options.asset, 'asset');
@@ -187,7 +188,7 @@ export class OnboardingBridgeSDK {
    */
   async reclaimTokens(
     options: ReclaimTokensOptions,
-    adminKeypair: any,
+    adminKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       assertContractAddress(options.asset, 'asset');
@@ -366,7 +367,7 @@ export class OnboardingBridgeSDK {
    */
   async setFee(
     newFeeBps: number,
-    adminKeypair: any,
+    adminKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       const adminAccount = await this.provider.getAccount(
@@ -409,7 +410,7 @@ export class OnboardingBridgeSDK {
    */
   async setFeeCollector(
     newFeeCollector: string,
-    adminKeypair: any,
+    adminKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       assertAccountAddress(newFeeCollector, 'newFeeCollector');
@@ -453,7 +454,7 @@ export class OnboardingBridgeSDK {
    */
   async setAdmin(
     newAdmin: string,
-    adminKeypair: any,
+    adminKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       assertAccountAddress(newAdmin, 'newAdmin');
@@ -499,7 +500,7 @@ export class OnboardingBridgeSDK {
    */
   async upgrade(
     options: UpgradeOptions,
-    adminKeypair: any,
+    adminKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       const adminAccount = await this.provider.getAccount(
@@ -545,7 +546,7 @@ export class OnboardingBridgeSDK {
    */
   async fundCrosschain(
     options: CrossChainFundOptions,
-    relayerKeypair: any,
+    relayerKeypair: Keypair,
   ): Promise<TransactionResult> {
     try {
       const relayerAccount = await this.provider.getAccount(relayerKeypair.publicKey());
@@ -592,7 +593,7 @@ export class OnboardingBridgeSDK {
   }
 
   /** Register an Ed25519 relayer pubkey (admin only). */
-  async addRelayer(options: RelayerManagementOptions, adminKeypair: any): Promise<TransactionResult> {
+  async addRelayer(options: RelayerManagementOptions, adminKeypair: Keypair): Promise<TransactionResult> {
     try {
       const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
       const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
@@ -609,7 +610,7 @@ export class OnboardingBridgeSDK {
   }
 
   /** Remove an Ed25519 relayer pubkey (admin only). */
-  async removeRelayer(options: RelayerManagementOptions, adminKeypair: any): Promise<TransactionResult> {
+  async removeRelayer(options: RelayerManagementOptions, adminKeypair: Keypair): Promise<TransactionResult> {
     try {
       const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
       const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
@@ -626,7 +627,7 @@ export class OnboardingBridgeSDK {
   }
 
   /** Set the M-of-N relayer threshold (admin only). Must not exceed total relayer count. */
-  async setRelayerThreshold(threshold: number, adminKeypair: any): Promise<TransactionResult> {
+  async setRelayerThreshold(threshold: number, adminKeypair: Keypair): Promise<TransactionResult> {
     try {
       const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
       const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })


### PR DESCRIPTION
## Summary
- replace SDK keypair `any` annotations with `Keypair` in bridge methods
- enforce `MAX_BATCH_SIZE` in `batch_fund_c_address` and remove dead code allowance
- migrate deprecated `env.budget()` usage in benchmarks to `env.cost_estimate().budget()`
- add regression tests for oversized batch and timelocked fund/claim flows

## Validation
- `npm run build` (in `sdk/`)
- `cargo test -p onboarding-bridge --features testutils bench_ -- --nocapture`
- `cargo test -p onboarding-bridge --features testutils test_batch_exceeds_max_size -- --nocapture`
- `cargo test -p onboarding-bridge --features testutils timelocked_tests -- --nocapture`

Closes #166
Closes #165
Closes #164
Closes #168