### PR TITLE
feat(sdk): add retry logic with exponential backoff for RPC calls

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -44,6 +44,8 @@ const CONFIG = {
   contractId: 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4',
   rpcUrl: 'https://soroban-testnet.stellar.org',
   networkPassphrase: 'Test SDF Network ; September 2015',
+  // Keep retry backoff instant so tests that exercise transient errors stay fast.
+  retry: { baseDelayMs: 0, maxDelayMs: 0 },
 };
 
 const MOCK_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';

--- a/sdk/src/__tests__/retry.test.ts
+++ b/sdk/src/__tests__/retry.test.ts
@@ -1,0 +1,223 @@
+import {
+  withRetry,
+  withRpcRetry,
+  isRetryableRpcError,
+  computeBackoffDelay,
+  VIEW_RETRY_POLICY,
+  STATE_CHANGING_RETRY_POLICY,
+  RetryAttempt,
+} from '../retry';
+
+/** A sleep that resolves immediately but records the delays it was asked for. */
+function recordingSleep(): { sleep: (ms: number) => Promise<void>; delays: number[] } {
+  const delays: number[] = [];
+  return {
+    delays,
+    sleep: (ms: number) => {
+      delays.push(ms);
+      return Promise.resolve();
+    },
+  };
+}
+
+const RETRYABLE = new Error('Network timeout');
+const PERMANENT = new Error('Invalid contract address for "asset"');
+
+describe('isRetryableRpcError', () => {
+  it('retries on timeout, network, and rate-limit messages', () => {
+    expect(isRetryableRpcError(new Error('Network timeout'))).toBe(true);
+    expect(isRetryableRpcError(new Error('request timed out'))).toBe(true);
+    expect(isRetryableRpcError(new Error('socket hang up'))).toBe(true);
+    expect(isRetryableRpcError(new Error('429 Too Many Requests'))).toBe(true);
+    expect(isRetryableRpcError(new Error('rate limit exceeded'))).toBe(true);
+    expect(isRetryableRpcError(new Error('fetch failed'))).toBe(true);
+  });
+
+  it('retries on transient network error codes', () => {
+    expect(isRetryableRpcError({ code: 'ECONNRESET' })).toBe(true);
+    expect(isRetryableRpcError({ code: 'ENOTFOUND' })).toBe(true);
+    expect(isRetryableRpcError({ code: 'ETIMEDOUT' })).toBe(true);
+  });
+
+  it('retries on transient HTTP status codes', () => {
+    expect(isRetryableRpcError({ status: 429 })).toBe(true);
+    expect(isRetryableRpcError({ statusCode: 503 })).toBe(true);
+    expect(isRetryableRpcError({ response: { status: 504 } })).toBe(true);
+  });
+
+  it('does NOT retry permanent errors', () => {
+    expect(isRetryableRpcError(new Error('Invalid contract address'))).toBe(false);
+    expect(isRetryableRpcError(new Error('contract error: insufficient balance'))).toBe(false);
+    expect(isRetryableRpcError({ status: 400 })).toBe(false);
+    expect(isRetryableRpcError({ status: 404 })).toBe(false);
+    expect(isRetryableRpcError(null)).toBe(false);
+    expect(isRetryableRpcError(undefined)).toBe(false);
+  });
+});
+
+describe('computeBackoffDelay', () => {
+  it('produces the exponential sequence 1s, 2s, 4s, 8s without jitter', () => {
+    const delays = [0, 1, 2, 3].map((n) => computeBackoffDelay(n, 1000, 30000, false));
+    expect(delays).toEqual([1000, 2000, 4000, 8000]);
+  });
+
+  it('caps the delay at maxDelayMs', () => {
+    expect(computeBackoffDelay(4, 1000, 30000, false)).toBe(16000);
+    expect(computeBackoffDelay(5, 1000, 30000, false)).toBe(30000);
+    expect(computeBackoffDelay(10, 1000, 30000, false)).toBe(30000);
+  });
+
+  it('keeps jittered delays within [0, cappedDelay]', () => {
+    for (let attempt = 0; attempt <= 6; attempt++) {
+      const cap = Math.min(1000 * 2 ** attempt, 30000);
+      for (let i = 0; i < 200; i++) {
+        const delay = computeBackoffDelay(attempt, 1000, 30000, true);
+        expect(delay).toBeGreaterThanOrEqual(0);
+        expect(delay).toBeLessThanOrEqual(cap);
+      }
+    }
+  });
+});
+
+describe('withRetry', () => {
+  it('returns immediately on success without sleeping', async () => {
+    const { sleep, delays } = recordingSleep();
+    const fn = jest.fn().mockResolvedValue('ok');
+
+    const result = await withRetry(fn, { sleep });
+
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(delays).toEqual([]);
+  });
+
+  it('retries a transient failure and then succeeds', async () => {
+    const { sleep, delays } = recordingSleep();
+    const onRetry = jest.fn();
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(RETRYABLE)
+      .mockRejectedValueOnce(RETRYABLE)
+      .mockResolvedValue('recovered');
+
+    const result = await withRetry(fn, { sleep, onRetry, jitter: false });
+
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(onRetry).toHaveBeenCalledTimes(2);
+    expect(delays).toEqual([1000, 2000]);
+  });
+
+  it('does not retry a permanent error', async () => {
+    const { sleep, delays } = recordingSleep();
+    const onRetry = jest.fn();
+    const fn = jest.fn().mockRejectedValue(PERMANENT);
+
+    await expect(withRetry(fn, { sleep, onRetry })).rejects.toThrow(PERMANENT.message);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(onRetry).not.toHaveBeenCalled();
+    expect(delays).toEqual([]);
+  });
+
+  it('throws the last error after exhausting maxRetries', async () => {
+    const { sleep } = recordingSleep();
+    const onRetry = jest.fn();
+    const fn = jest.fn().mockRejectedValue(RETRYABLE);
+
+    await expect(withRetry(fn, { sleep, onRetry, maxRetries: 3 })).rejects.toThrow(
+      RETRYABLE.message,
+    );
+    // initial attempt + 3 retries
+    expect(fn).toHaveBeenCalledTimes(4);
+    expect(onRetry).toHaveBeenCalledTimes(3);
+  });
+
+  it('honours maxRetries: 0 (retries disabled)', async () => {
+    const { sleep } = recordingSleep();
+    const fn = jest.fn().mockRejectedValue(RETRYABLE);
+
+    await expect(withRetry(fn, { sleep, maxRetries: 0 })).rejects.toThrow(RETRYABLE.message);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports accurate metadata to the logger', async () => {
+    const { sleep } = recordingSleep();
+    const attempts: RetryAttempt[] = [];
+    const fn = jest
+      .fn()
+      .mockRejectedValueOnce(RETRYABLE)
+      .mockResolvedValue('ok');
+
+    await withRetry(fn, { sleep, jitter: false, onRetry: (a) => attempts.push(a) });
+
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0]).toMatchObject({ attempt: 1, maxRetries: 3, delayMs: 1000, error: RETRYABLE });
+  });
+});
+
+describe('view vs state-changing policies', () => {
+  it('exposes a more aggressive policy for view calls than for state-changing calls', () => {
+    expect(VIEW_RETRY_POLICY.maxRetries).toBeGreaterThan(STATE_CHANGING_RETRY_POLICY.maxRetries);
+  });
+
+  it('retries view calls more times than state-changing calls for the same error', async () => {
+    const { sleep } = recordingSleep();
+
+    const viewFn = jest.fn().mockRejectedValue(RETRYABLE);
+    await expect(withRetry(viewFn, { ...VIEW_RETRY_POLICY, sleep })).rejects.toThrow();
+
+    const stateFn = jest.fn().mockRejectedValue(RETRYABLE);
+    await expect(withRetry(stateFn, { ...STATE_CHANGING_RETRY_POLICY, sleep })).rejects.toThrow();
+
+    expect(viewFn).toHaveBeenCalledTimes(VIEW_RETRY_POLICY.maxRetries + 1);
+    expect(stateFn).toHaveBeenCalledTimes(STATE_CHANGING_RETRY_POLICY.maxRetries + 1);
+    expect(viewFn.mock.calls.length).toBeGreaterThan(stateFn.mock.calls.length);
+  });
+});
+
+describe('withRpcRetry', () => {
+  // baseDelayMs: 0 keeps the (real) backoff instant for these wiring tests.
+  const FAST = { baseDelayMs: 0, maxDelayMs: 0 };
+
+  it('routes read methods through the view policy (retries up to 3 times)', async () => {
+    const getAccount = jest.fn().mockRejectedValue(RETRYABLE);
+    const provider = withRpcRetry({ getAccount }, FAST);
+
+    await expect(provider.getAccount()).rejects.toThrow();
+    expect(getAccount).toHaveBeenCalledTimes(VIEW_RETRY_POLICY.maxRetries + 1);
+  });
+
+  it('routes sendTransaction through the conservative state policy (retries once)', async () => {
+    const sendTransaction = jest.fn().mockRejectedValue(RETRYABLE);
+    const provider = withRpcRetry({ sendTransaction }, FAST);
+
+    await expect(provider.sendTransaction()).rejects.toThrow();
+    expect(sendTransaction).toHaveBeenCalledTimes(STATE_CHANGING_RETRY_POLICY.maxRetries + 1);
+  });
+
+  it('passes through non-RPC methods and properties untouched', async () => {
+    const helper = jest.fn().mockReturnValue('plain');
+    const provider = withRpcRetry({ helper, label: 'server' } as any, FAST);
+
+    expect((provider as any).helper()).toBe('plain');
+    expect((provider as any).label).toBe('server');
+    expect(helper).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry on success and returns the resolved value', async () => {
+    const simulateTransaction = jest.fn().mockResolvedValue({ ok: true });
+    const provider = withRpcRetry({ simulateTransaction }, FAST);
+
+    await expect(provider.simulateTransaction()).resolves.toEqual({ ok: true });
+    expect(simulateTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards retry events to a configured logger', async () => {
+    const onRetry = jest.fn();
+    const getTransaction = jest.fn().mockRejectedValue(RETRYABLE);
+    const provider = withRpcRetry({ getTransaction }, { ...FAST, onRetry });
+
+    await expect(provider.getTransaction()).rejects.toThrow();
+    expect(onRetry).toHaveBeenCalledTimes(VIEW_RETRY_POLICY.maxRetries);
+  });
+});

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -15,6 +15,7 @@ import {
   PaginationOptions,
 } from './types';
 import { assertAccountAddress, assertContractAddress } from './validate';
+import { withRpcRetry } from './retry';
 import {
   SorobanRpc,
   Contract,
@@ -38,7 +39,13 @@ export class OnboardingBridgeSDK {
     assertContractAddress(config.contractId, 'contractId');
     this.config = config;
     this.contract = new Contract(config.contractId);
-    this.provider = new SorobanRpc.Server(config.rpcUrl);
+    // Wrap the provider so every RPC call automatically retries transient
+    // failures (network/timeout/rate-limit) with exponential backoff + jitter.
+    // Reads use an aggressive policy; writes use a conservative one (see retry.ts).
+    this.provider = withRpcRetry(
+      new SorobanRpc.Server(config.rpcUrl),
+      config.retry,
+    );
     this.networkPassphrase = config.networkPassphrase;
   }
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -1,4 +1,19 @@
 export { OnboardingBridgeSDK } from './bridge';
 export { OffRampIntegration } from './offramp';
 export { assertAccountAddress, assertContractAddress } from './validate';
+export {
+  withRetry,
+  withRpcRetry,
+  isRetryableRpcError,
+  computeBackoffDelay,
+  VIEW_RETRY_POLICY,
+  STATE_CHANGING_RETRY_POLICY,
+} from './retry';
+export type {
+  RetryOptions,
+  RpcRetryOptions,
+  RetryAttempt,
+  RetryLogger,
+  RetryableClassifier,
+} from './retry';
 export * from './types';

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -1,0 +1,292 @@
+/**
+ * Retry utilities for Soroban RPC calls.
+ *
+ * Implements exponential backoff (1s, 2s, 4s, 8s … capped at 30s) with full
+ * jitter, a transient-error classifier, and two preset policies:
+ *
+ *  - {@link VIEW_RETRY_POLICY} for idempotent read-only calls.
+ *  - {@link STATE_CHANGING_RETRY_POLICY} for write calls, which carry a
+ *    double-submission risk and are therefore retried conservatively.
+ *
+ * The {@link withRpcRetry} helper wraps a `SorobanRpc.Server` so every RPC
+ * method is automatically retried with the policy appropriate to it.
+ */
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 1000;
+const DEFAULT_MAX_DELAY_MS = 30000;
+
+/** Details about a single retry, passed to the {@link RetryLogger}. */
+export interface RetryAttempt {
+  /** 1-based index of the attempt that just failed. */
+  attempt: number;
+  /** Total retries allowed after the initial attempt. */
+  maxRetries: number;
+  /** Delay in milliseconds before the next attempt. */
+  delayMs: number;
+  /** The error that triggered the retry. */
+  error: unknown;
+}
+
+/** Receives one record per retry. Defaults to a no-op so the SDK stays quiet. */
+export type RetryLogger = (attempt: RetryAttempt) => void;
+
+/** Decides whether a thrown error is worth retrying. */
+export type RetryableClassifier = (error: unknown) => boolean;
+
+/** Options for the low-level {@link withRetry} wrapper. */
+export interface RetryOptions {
+  /** Max retries after the initial attempt. Default: 3. */
+  maxRetries?: number;
+  /** Base delay in ms for the first backoff step. Default: 1000. */
+  baseDelayMs?: number;
+  /** Upper bound for any single backoff delay. Default: 30000. */
+  maxDelayMs?: number;
+  /** Apply full jitter to each delay. Default: true. */
+  jitter?: boolean;
+  /** Error classifier. Default: {@link isRetryableRpcError}. */
+  isRetryable?: RetryableClassifier;
+  /** Retry logger. Default: no-op. */
+  onRetry?: RetryLogger;
+  /**
+   * Clock seam used to wait between attempts. Injectable for tests.
+   * Default: a `setTimeout`-based sleep.
+   * @internal
+   */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/** Tunable knobs for {@link withRpcRetry}, surfaced on `BridgeConfig.retry`. */
+export interface RpcRetryOptions {
+  /** Max retries for view calls (default 3). State calls are capped at 1. */
+  maxRetries?: number;
+  /** Base delay in ms for the first backoff step. Default: 1000. */
+  baseDelayMs?: number;
+  /** Upper bound for any single backoff delay. Default: 30000. */
+  maxDelayMs?: number;
+  /** Apply full jitter to each delay. Default: true. */
+  jitter?: boolean;
+  /** Retry logger. Default: no-op. */
+  onRetry?: RetryLogger;
+}
+
+const noopLogger: RetryLogger = () => {};
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Node network error codes that indicate a transient, retryable failure. */
+const RETRYABLE_ERROR_CODES = new Set([
+  'ECONNRESET',
+  'ECONNREFUSED',
+  'ECONNABORTED',
+  'ENOTFOUND',
+  'EAI_AGAIN',
+  'ETIMEDOUT',
+  'EPIPE',
+  'ENETUNREACH',
+  'EHOSTUNREACH',
+]);
+
+/** Transient HTTP status codes: rate limiting and gateway/upstream failures. */
+const RETRYABLE_HTTP_STATUS = new Set([429, 502, 503, 504]);
+
+const RETRYABLE_MESSAGE_PATTERN =
+  /(timeout|timed out|rate limit|too many requests|network error|socket hang up|fetch failed|service unavailable|temporarily unavailable|connection reset|connection refused|econnreset|econnrefused|enotfound|eai_again|etimedout)/i;
+
+/**
+ * Classify an error as transient (worth retrying) or permanent.
+ *
+ * Retries on network errors, timeouts, and rate-limit / transient gateway
+ * responses. Does NOT retry on validation errors, contract reverts, or other
+ * deterministic failures — retrying those only wastes time.
+ */
+export function isRetryableRpcError(error: unknown): boolean {
+  if (error == null) return false;
+
+  const err = error as {
+    code?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown };
+    message?: unknown;
+  };
+
+  if (typeof err.code === 'string' && RETRYABLE_ERROR_CODES.has(err.code)) {
+    return true;
+  }
+
+  const status = err.status ?? err.statusCode ?? err.response?.status;
+  if (typeof status === 'number' && RETRYABLE_HTTP_STATUS.has(status)) {
+    return true;
+  }
+
+  const message = typeof err.message === 'string' ? err.message : String(error);
+  return RETRYABLE_MESSAGE_PATTERN.test(message);
+}
+
+/**
+ * Compute the backoff delay for a given (0-based) retry attempt.
+ *
+ * Without jitter the sequence is `base, base*2, base*4, …` capped at `maxDelayMs`
+ * (i.e. 1s, 2s, 4s, 8s, 16s, 30s for the defaults). With full jitter the delay
+ * is a random value in `[0, cappedDelay]` to avoid a thundering herd.
+ */
+export function computeBackoffDelay(
+  attempt: number,
+  baseDelayMs: number = DEFAULT_BASE_DELAY_MS,
+  maxDelayMs: number = DEFAULT_MAX_DELAY_MS,
+  jitter: boolean = true,
+): number {
+  const exponential = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+  if (!jitter) return exponential;
+  // Full jitter (AWS "Exponential Backoff And Jitter"): pick uniformly in
+  // [0, exponential] so concurrent clients spread their retries out.
+  return Math.floor(Math.random() * (exponential + 1));
+}
+
+/**
+ * Run `fn`, retrying on transient errors with exponential backoff + jitter.
+ *
+ * The initial call counts as attempt 0; up to `maxRetries` further attempts are
+ * made. Permanent errors (per {@link isRetryableRpcError}) are re-thrown
+ * immediately. The last error is re-thrown once retries are exhausted.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs = options.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  const maxDelayMs = options.maxDelayMs ?? DEFAULT_MAX_DELAY_MS;
+  const jitter = options.jitter ?? true;
+  const isRetryable = options.isRetryable ?? isRetryableRpcError;
+  const onRetry = options.onRetry ?? noopLogger;
+  const sleep = options.sleep ?? defaultSleep;
+
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt >= maxRetries || !isRetryable(error)) {
+        throw error;
+      }
+      const delayMs = computeBackoffDelay(attempt, baseDelayMs, maxDelayMs, jitter);
+      onRetry({ attempt: attempt + 1, maxRetries, delayMs, error });
+      await sleep(delayMs);
+    }
+  }
+  // Unreachable: the loop either returns or throws, but TS needs a terminator.
+  throw lastError;
+}
+
+/**
+ * Retry policy for idempotent *view* (read-only) RPC calls such as
+ * `simulateTransaction`, `getAccount`, and `getTransaction`. These can be
+ * retried freely because they never mutate on-chain state.
+ */
+export const VIEW_RETRY_POLICY: Required<
+  Pick<RetryOptions, 'maxRetries' | 'baseDelayMs' | 'maxDelayMs' | 'jitter'>
+> = {
+  maxRetries: 3,
+  baseDelayMs: 1000,
+  maxDelayMs: 30000,
+  jitter: true,
+};
+
+/**
+ * Retry policy for *state-changing* RPC calls (`sendTransaction`).
+ *
+ * State-changing calls carry a double-submission risk: a request may time out
+ * on the client *after* the network already accepted the transaction. We
+ * therefore retry only once and rely on Soroban's hash-based deduplication —
+ * resubmitting the *same signed transaction* is safe, but a retry must NEVER
+ * rebuild the transaction with a fresh sequence number (that would double-spend).
+ */
+export const STATE_CHANGING_RETRY_POLICY: Required<
+  Pick<RetryOptions, 'maxRetries' | 'baseDelayMs' | 'maxDelayMs' | 'jitter'>
+> = {
+  maxRetries: 1,
+  baseDelayMs: 1000,
+  maxDelayMs: 30000,
+  jitter: true,
+};
+
+/** RPC methods that are idempotent reads — safe to retry with the view policy. */
+const VIEW_RPC_METHODS = new Set([
+  'getAccount',
+  'simulateTransaction',
+  'prepareTransaction',
+  'getTransaction',
+  'getTransactions',
+  'getLatestLedger',
+  'getNetwork',
+  'getHealth',
+  'getEvents',
+  'getLedgerEntries',
+  'getContractData',
+]);
+
+/** RPC methods that mutate on-chain state — retried with the conservative policy. */
+const STATE_CHANGING_RPC_METHODS = new Set(['sendTransaction']);
+
+function resolveViewOptions(o: RpcRetryOptions): RetryOptions {
+  return {
+    maxRetries: o.maxRetries ?? VIEW_RETRY_POLICY.maxRetries,
+    baseDelayMs: o.baseDelayMs ?? VIEW_RETRY_POLICY.baseDelayMs,
+    maxDelayMs: o.maxDelayMs ?? VIEW_RETRY_POLICY.maxDelayMs,
+    jitter: o.jitter ?? VIEW_RETRY_POLICY.jitter,
+    onRetry: o.onRetry,
+  };
+}
+
+function resolveStateOptions(o: RpcRetryOptions): RetryOptions {
+  const viewMax = o.maxRetries ?? VIEW_RETRY_POLICY.maxRetries;
+  return {
+    // State-changing retries never exceed the conservative cap, even if the
+    // caller raises maxRetries for view calls.
+    maxRetries: Math.min(viewMax, STATE_CHANGING_RETRY_POLICY.maxRetries),
+    baseDelayMs: o.baseDelayMs ?? STATE_CHANGING_RETRY_POLICY.baseDelayMs,
+    maxDelayMs: o.maxDelayMs ?? STATE_CHANGING_RETRY_POLICY.maxDelayMs,
+    jitter: o.jitter ?? STATE_CHANGING_RETRY_POLICY.jitter,
+    onRetry: o.onRetry,
+  };
+}
+
+/**
+ * Wrap an RPC provider so every method call is retried with the policy that
+ * matches its nature: read methods use {@link VIEW_RETRY_POLICY}, the
+ * `sendTransaction` write method uses {@link STATE_CHANGING_RETRY_POLICY}, and
+ * anything else is passed through untouched.
+ *
+ * The wrapper is transparent: method signatures and return values are
+ * unchanged, so it can replace the underlying provider in place.
+ */
+export function withRpcRetry<T extends object>(
+  provider: T,
+  options: RpcRetryOptions = {},
+): T {
+  const viewOptions = resolveViewOptions(options);
+  const stateOptions = resolveStateOptions(options);
+
+  return new Proxy(provider, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== 'function') return value;
+
+      const name = String(prop);
+      const policy = VIEW_RPC_METHODS.has(name)
+        ? viewOptions
+        : STATE_CHANGING_RPC_METHODS.has(name)
+          ? stateOptions
+          : undefined;
+
+      if (!policy) return value.bind(target);
+
+      return (...args: unknown[]): Promise<unknown> =>
+        withRetry(() => value.apply(target, args), policy);
+    },
+  });
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -1,3 +1,5 @@
+import type { RpcRetryOptions } from './retry';
+
 export interface BridgeConfig {
   /** Contract ID of the deployed OnboardingBridge Soroban contract */
   contractId: string;
@@ -7,6 +9,12 @@ export interface BridgeConfig {
   networkPassphrase: string;
   /** Optional timeout in seconds for Soroban operations */
   timeout?: number;
+  /**
+   * Automatic retry behaviour for RPC calls (exponential backoff + jitter).
+   * Omit to use the defaults (3 retries for reads, 1 for writes). Set
+   * `maxRetries: 0` to disable retries entirely.
+   */
+  retry?: RpcRetryOptions;
 }
 
 export interface FundCOptions {


### PR DESCRIPTION
## What

Adds automatic retry logic with exponential backoff for SDK RPC calls.

Closes #61

## How

- New `sdk/src/retry.ts`:
  - `withRetry(fn, options)` - retries a promise-returning fn on transient errors.
  - `isRetryableRpcError(error)` - classifies network / timeout / rate-limit (and `429/502/503/504`, `ECONNRESET`/`ETIMEDOUT`/...) as retryable; validation/contract/4xx errors are NOT retried.
  - `computeBackoffDelay(...)` - exponential `1s, 2s, 4s, 8s` capped at `30s`, with **full jitter** to avoid a thundering herd.
  - `withRpcRetry(provider, options)` - transparently wraps a `SorobanRpc.Server` so every RPC method is retried with the right policy.
- **Different policies for view vs. state-changing calls**: read methods (`simulateTransaction`, `getAccount`, `getTransaction`, ...) retry up to **3** times; `sendTransaction` retries at most **once**.
  - Idempotency safety: a write request can time out on the client *after* the network accepted it. Soroban dedupes by tx hash, so resubmitting the *same signed tx* is safe, but a retry must never rebuild the tx with a fresh sequence number (documented in `STATE_CHANGING_RETRY_POLICY`).
- **Configurable** via `BridgeConfig.retry` (`maxRetries` default 3, `baseDelayMs`, `maxDelayMs`, `jitter`, `onRetry` logger). Logging defaults to a no-op so the SDK stays quiet; `maxRetries: 0` disables retries.
- Wired in once in the `OnboardingBridgeSDK` constructor, so all existing RPC call sites benefit with no per-call changes.

## Tests

- New `sdk/src/__tests__/retry.test.ts`: retry-on-transient, no-retry-on-permanent, max-retries-exhausted-throws, exact backoff sequence, jitter bounds, logger metadata, view-vs-state policy difference, and provider-wrapper routing.
- Backoff waits are mocked (injected sleep / `baseDelayMs: 0`) so the suite stays fast.
- Full suite: **83 passed** (3 suites). `tsc --noEmit` clean.
