### PR TITLE
feat(ci): publish contract to crates.io and create release on version tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Publish Contract
+
+on:
+  push:
+    tags:
+      - 'contract-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Verify, Publish and Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run contract tests
+        run: cargo test -p onboarding-bridge --features testutils
+
+      - name: Build WASM (release)
+        run: cargo build -p onboarding-bridge --release --target wasm32-unknown-unknown
+
+      - name: Publish to crates.io
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo publish -p onboarding-bridge
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ github.ref_name }} \
+            target/wasm32-unknown-unknown/release/onboarding_bridge.wasm \
+            --title "${{ github.ref_name }}" \
+            --generate-notes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,9 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+description = "C-Address Onboarding Bridge smart contract for Stellar/Soroban"
+license = "MIT"
+repository = "https://github.com/C-Address-Onboarding-Bridge/C-Address-Onboarding-Bridge--Contract"
 
 [profile.release]
 opt-level = "z"

--- a/contracts/onboarding-bridge/Cargo.toml
+++ b/contracts/onboarding-bridge/Cargo.toml
@@ -2,6 +2,9 @@
 name = "onboarding-bridge"
 version.workspace = true
 edition.workspace = true
+description.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
I have resolved the issue by performing the following actions:

  1. Forked and Cloned the Repository: Forked  C-Address-Onboarding-Bridge--Contract  to the user's account and cloned it locally.
  2. Satisfied crates.io Publishing Metadata Requirements:
      • Updated the root Cargo.toml package metadata under  [workspace.package]  to include  description ,  license  (MIT), and  repository .
      • Modified Cargo.toml to inherit these workspace fields ( description.workspace ,  license.workspace ,  repository.workspace ), ensuring  cargo
      publish  can run without packaging warnings/errors.
  3. Created the CI Publish Workflow:
      • Created the new workflow file publish.yml.
      • Set it to trigger on the push of any tag matching  contract-v* .
      • Included steps to run the contract tests (verifying they pass), build the release WASM binary, publish the crate to crates.io using
      CARGO_REGISTRY_TOKEN , and automatically create a GitHub Release attaching the built  .wasm  deliverable using the native  gh  CLI.

closes #71