### PR TITLE
test: add fund_c_address-level fuzz tests for funding amounts

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -423,6 +423,28 @@ cargo test -p onboarding-bridge --features testutils test_initialize --
 cargo test -p onboarding-bridge --features testutils bench_ --
 ```
 
+### Fuzz / Property-Based Testing
+
+The onboarding bridge includes `proptest` coverage for fee arithmetic and
+end-to-end funding amount behavior.
+
+```bash
+cd contracts/onboarding-bridge
+
+# Pure fee-function property tests
+cargo test --features testutils fee_fuzz_tests -- --nocapture
+
+# fund_c_address-level randomized funding amount tests
+cargo test --features testutils fund_amount_fuzz_tests -- --nocapture
+
+# Full contract suite
+cargo test --features testutils
+```
+
+If a property test fails, proptest may write a minimized counterexample under
+`contracts/onboarding-bridge/proptest-regressions/`. Commit that file with the
+fix so the failing case remains locked into the suite.
+
 ### SDK Tests
 
 ```bash

--- a/contracts/onboarding-bridge/Cargo.toml
+++ b/contracts/onboarding-bridge/Cargo.toml
@@ -13,6 +13,7 @@ soroban-sdk = "22.0.1"
 [dev-dependencies]
 soroban-sdk = { version = "22.0.1", features = ["testutils"] }
 ed25519-dalek = { version = "2.2.0", features = ["rand_core"] }
+proptest = "1.5"
 
 [features]
 testutils = ["soroban-sdk/testutils"]

--- a/contracts/onboarding-bridge/src/fee_fuzz_tests.rs
+++ b/contracts/onboarding-bridge/src/fee_fuzz_tests.rs
@@ -1,0 +1,98 @@
+use crate::{calculate_fee, BridgeError, FEE_DENOMINATOR, MAX_FEE_BPS};
+use proptest::prelude::*;
+
+fn max_safe_amount() -> i128 {
+    i128::MAX / MAX_FEE_BPS as i128
+}
+
+fn reference_fee(amount: i128, fee_bps: u32) -> Option<i128> {
+    amount
+        .checked_mul(fee_bps as i128)
+        .map(|product| product / FEE_DENOMINATOR)
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 512, .. ProptestConfig::default() })]
+
+    #[test]
+    fn fee_invariants_hold_for_valid_amounts(
+        amount in 0i128..=max_safe_amount(),
+        fee_bps in 0u32..=MAX_FEE_BPS,
+    ) {
+        let fee_result = calculate_fee(amount, fee_bps);
+        prop_assert!(
+            fee_result.is_ok(),
+            "calculate_fee failed for amount={amount}, fee_bps={fee_bps}: {fee_result:?}"
+        );
+        let fee = fee_result.unwrap();
+        let net = amount - fee;
+
+        prop_assert!(fee <= amount);
+        prop_assert_eq!(fee + net, amount);
+
+        if fee_bps == 0 {
+            prop_assert_eq!(fee, 0);
+        }
+
+        let max_fee = amount * MAX_FEE_BPS as i128 / FEE_DENOMINATOR;
+        prop_assert!(fee <= max_fee);
+        prop_assert_eq!(fee, reference_fee(amount, fee_bps).unwrap());
+    }
+
+    #[test]
+    fn fee_is_monotonic_in_amount(
+        lower in 0i128..=max_safe_amount(),
+        delta in 0i128..=1_000_000_000_000i128,
+        fee_bps in 0u32..=MAX_FEE_BPS,
+    ) {
+        let upper = lower.saturating_add(delta).min(max_safe_amount());
+        let lower_fee = calculate_fee(lower, fee_bps).unwrap();
+        let upper_fee = calculate_fee(upper, fee_bps).unwrap();
+
+        prop_assert!(lower_fee <= upper_fee);
+    }
+
+    #[test]
+    fn fee_is_monotonic_in_fee_bps(
+        amount in 0i128..=max_safe_amount(),
+        lower_bps in 0u32..=MAX_FEE_BPS,
+        upper_bps in 0u32..=MAX_FEE_BPS,
+    ) {
+        let low = lower_bps.min(upper_bps);
+        let high = lower_bps.max(upper_bps);
+        let lower_fee = calculate_fee(amount, low).unwrap();
+        let upper_fee = calculate_fee(amount, high).unwrap();
+
+        prop_assert!(lower_fee <= upper_fee);
+    }
+}
+
+#[test]
+fn fee_edge_case_matrix_matches_reference_or_overflows() {
+    let amounts = [
+        0,
+        1,
+        max_safe_amount() - 1,
+        max_safe_amount(),
+        i128::MAX / 2,
+        i128::MAX / MAX_FEE_BPS as i128,
+    ];
+    let fee_bps_values = [0, 1, MAX_FEE_BPS - 1, MAX_FEE_BPS];
+
+    for amount in amounts {
+        for fee_bps in fee_bps_values {
+            match reference_fee(amount, fee_bps) {
+                Some(expected) => assert_eq!(calculate_fee(amount, fee_bps), Ok(expected)),
+                None => assert_eq!(calculate_fee(amount, fee_bps), Err(BridgeError::Overflow)),
+            }
+        }
+    }
+}
+
+#[test]
+fn fee_overflow_boundary_returns_error() {
+    assert_eq!(
+        calculate_fee(i128::MAX, MAX_FEE_BPS),
+        Err(BridgeError::Overflow)
+    );
+}

--- a/contracts/onboarding-bridge/src/fund_amount_fuzz_tests.rs
+++ b/contracts/onboarding-bridge/src/fund_amount_fuzz_tests.rs
@@ -1,0 +1,157 @@
+use crate::{OnboardingBridge, MAX_FEE_BPS};
+use proptest::prelude::*;
+use soroban_sdk::{
+    contract, contractimpl, contracttype,
+    testutils::Address as _,
+    Address, Env, IntoVal,
+};
+
+#[contracttype]
+enum TokenKey {
+    Admin,
+    Balance(Address),
+    Decimal,
+    Name,
+    Symbol,
+}
+
+#[contract]
+struct FuzzToken;
+
+#[contractimpl]
+impl FuzzToken {
+    pub fn initialize(
+        env: Env,
+        admin: Address,
+        decimal: u32,
+        name: soroban_sdk::String,
+        symbol: soroban_sdk::String,
+    ) {
+        env.storage().instance().set(&TokenKey::Admin, &admin);
+        env.storage().instance().set(&TokenKey::Decimal, &decimal);
+        env.storage().instance().set(&TokenKey::Name, &name);
+        env.storage().instance().set(&TokenKey::Symbol, &symbol);
+    }
+
+    pub fn mint(env: Env, to: Address, amount: i128) {
+        let admin: Address = env.storage().instance().get(&TokenKey::Admin).unwrap();
+        admin.require_auth();
+        let balance = Self::balance(env.clone(), to.clone());
+        env.storage()
+            .persistent()
+            .set(&TokenKey::Balance(to), &(balance + amount));
+    }
+
+    pub fn balance(env: Env, id: Address) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&TokenKey::Balance(id))
+            .unwrap_or(0)
+    }
+
+    pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+        from.require_auth();
+        if from == to {
+            return;
+        }
+
+        let from_balance = Self::balance(env.clone(), from.clone());
+        if from_balance < amount {
+            panic!("insufficient balance");
+        }
+
+        let to_balance = Self::balance(env.clone(), to.clone());
+        env.storage()
+            .persistent()
+            .set(&TokenKey::Balance(from), &(from_balance - amount));
+        env.storage()
+            .persistent()
+            .set(&TokenKey::Balance(to), &(to_balance + amount));
+    }
+}
+
+fn setup_bridge<'a>(
+    env: &'a Env,
+    fee_bps: u32,
+) -> (
+    crate::OnboardingBridgeClient<'a>,
+    Address,
+    Address,
+    Address,
+    FuzzTokenClient<'a>,
+) {
+    env.mock_all_auths();
+
+    let admin = Address::generate(env);
+    let user = Address::generate(env);
+    let fee_collector = Address::generate(env);
+    let bridge_id = env.register(OnboardingBridge, ());
+    let token_id = env.register(FuzzToken, ());
+
+    let token = FuzzTokenClient::new(env, &token_id);
+    token.initialize(
+        &admin,
+        &7u32,
+        &"Test".into_val(env),
+        &"TST".into_val(env),
+    );
+
+    let bridge = crate::OnboardingBridgeClient::new(env, &bridge_id);
+    bridge.initialize(&admin, &fee_collector, &fee_bps, &None);
+    bridge.add_asset(&token_id, &None);
+
+    (bridge, token_id, admin, user, token)
+}
+
+fn assert_funding_invariants(amount: i128, fee_bps: u32) -> Result<(), TestCaseError> {
+    let env = Env::default();
+    let (bridge, token_id, _admin, user, token) = setup_bridge(&env, fee_bps);
+    let target = Address::generate(&env);
+
+    token.mint(&user, &amount);
+    let pre_accrued = bridge.query_accrued_fees(&token_id);
+
+    let result = bridge.try_fund_c_address(&user, &target, &token_id, &amount, &None, &None);
+    prop_assert!(
+        matches!(result, Ok(Ok(()))),
+        "fund_c_address failed for amount={amount}, fee_bps={fee_bps}: {result:?}"
+    );
+
+    let post_accrued = bridge.query_accrued_fees(&token_id);
+    let target_balance = token.balance(&target);
+    let accrued_delta = post_accrued - pre_accrued;
+
+    prop_assert!(accrued_delta <= amount);
+    prop_assert_eq!(accrued_delta + target_balance, amount);
+    prop_assert_eq!(token.balance(&user), 0);
+
+    Ok(())
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, .. ProptestConfig::default() })]
+
+    #[test]
+    fn fund_c_address_fee_invariants_hold_for_random_amounts(
+        amount in 1i128..=1_000_000_000_000i128,
+        fee_bps in 0u32..=MAX_FEE_BPS,
+    ) {
+        assert_funding_invariants(amount, fee_bps)?;
+    }
+}
+
+#[test]
+fn fund_c_address_fee_invariants_hold_for_explicit_edges() {
+    let cases = [
+        (1i128, 0u32),
+        (1i128, 1u32),
+        (1i128, MAX_FEE_BPS),
+        (100i128, MAX_FEE_BPS),
+        (1_000_000_000_000i128, 1u32),
+        (1_000_000_000_000i128, MAX_FEE_BPS),
+    ];
+
+    for (amount, fee_bps) in cases {
+        assert_funding_invariants(amount, fee_bps).unwrap();
+    }
+}

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -4212,6 +4212,12 @@ impl OnboardingBridge {
 mod tests;
 
 #[cfg(test)]
+mod fee_fuzz_tests;
+
+#[cfg(test)]
+mod fund_amount_fuzz_tests;
+
+#[cfg(test)]
 mod benchmarks;
 
 #[cfg(test)]


### PR DESCRIPTION
closes #36 
**Title**

test: add fund_c_address-level fuzz tests for funding amounts

**Summary**

Adds property-based fuzz coverage for onboarding bridge fee behavior at both layers:

- Pure `calculate_fee` arithmetic invariants
- End-to-end `fund_c_address` funding amount invariants through real token transfers and accrued fee storage

Also documents the new fuzz test commands in `TESTING.md`.

**What Changed**

- Added `proptest` as a dev dependency.
- Registered new test modules in `src/lib.rs`.
- Added `fee_fuzz_tests.rs` for fee arithmetic properties:
  - fee never exceeds amount
  - fee plus net equals gross amount
  - zero fee bps produces zero fee
  - fee matches independent floor-division reference
  - monotonicity over amount and fee bps
  - explicit overflow boundary coverage
- Added `fund_amount_fuzz_tests.rs` for integration-level funding fuzzing:
  - deploys mocked bridge and token per generated case
  - fuzzes randomized funding amounts and fee bps values
  - verifies accrued fee delta plus target balance equals original amount
  - includes explicit edge cases for minimum and large valid amounts
- Updated `TESTING.md` with fuzz/property test instructions.

**Testing**

Unable to run locally in this environment because `cargo`/`rustc` are not installed or not on PATH.

Commands to run:

```bash
cd contracts/onboarding-bridge
cargo test --features testutils fee_fuzz_tests -- --nocapture
cargo test --features testutils fund_amount_fuzz_tests -- --nocapture
cargo test --features testutils
```

**Note**

The requested `test/fuzz-fee-calculation` branch did not exist locally or on origin when I started, so I created it from the current clean checkout and pushed it to origin.