### PR TITLE
feat(sdk): add batchFundCAddresses progress callback and auto-splitting

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -117,8 +117,8 @@ describe('OnboardingBridgeSDK', () => {
   });
 
   describe('batchFundCAddresses', () => {
-    it('returns pending status on success', async () => {
-      const result = await sdk.batchFundCAddresses(
+    it('returns array with one pending result on success', async () => {
+      const results = await sdk.batchFundCAddresses(
         {
           source: MOCK_ADDRESS,
           targets: [MOCK_ASSET, MOCK_ASSET],
@@ -128,14 +128,32 @@ describe('OnboardingBridgeSDK', () => {
         mockKeypair,
       );
 
-      expect(result.status).toBe('pending');
-      expect(result.hash).toBe('mock_tx_hash');
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('pending');
+      expect(results[0].hash).toBe('mock_tx_hash');
     });
 
-    it('returns failed status when transaction errors (e.g. mismatched arrays on-chain)', async () => {
+    it('returns array with one failed result on ERROR response', async () => {
       mockProvider.sendTransaction.mockResolvedValue({ hash: 'err_hash', status: 'ERROR' });
 
-      const result = await sdk.batchFundCAddresses(
+      const results = await sdk.batchFundCAddresses(
+        {
+          source: MOCK_ADDRESS,
+          targets: [MOCK_ASSET],
+          amounts: ['500'],
+          asset: MOCK_ASSET,
+        },
+        mockKeypair,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('failed');
+    });
+
+    it('returns array with one failed result on mismatched array lengths (on-chain error)', async () => {
+      mockProvider.sendTransaction.mockResolvedValue({ hash: 'err_hash', status: 'ERROR' });
+
+      const results = await sdk.batchFundCAddresses(
         {
           source: MOCK_ADDRESS,
           targets: [MOCK_ASSET],
@@ -145,7 +163,193 @@ describe('OnboardingBridgeSDK', () => {
         mockKeypair,
       );
 
-      expect(result.status).toBe('failed');
+      expect(results[0].status).toBe('failed');
+    });
+
+    // -----------------------------------------------------------------------
+    // Auto-splitting
+    // -----------------------------------------------------------------------
+
+    it('splits a batch exceeding BATCH_TX_LIMIT into multiple transactions', async () => {
+      const count = 250; // 3 chunks: 100, 100, 50
+      const targets = Array(count).fill(MOCK_ASSET);
+      const amounts = Array(count).fill('100');
+
+      let txCounter = 0;
+      mockProvider.sendTransaction.mockImplementation(() => {
+        txCounter++;
+        return Promise.resolve({ hash: `tx_hash_${txCounter}`, status: 'PENDING' });
+      });
+
+      const results = await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+      );
+
+      expect(results).toHaveLength(3);
+      expect(mockProvider.sendTransaction).toHaveBeenCalledTimes(3);
+      expect(results[0].hash).toBe('tx_hash_1');
+      expect(results[1].hash).toBe('tx_hash_2');
+      expect(results[2].hash).toBe('tx_hash_3');
+      results.forEach((r) => expect(r.status).toBe('pending'));
+    });
+
+    it('does not split when targets count equals BATCH_TX_LIMIT exactly', async () => {
+      const targets = Array(100).fill(MOCK_ASSET);
+      const amounts = Array(100).fill('100');
+
+      const results = await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+      );
+
+      expect(results).toHaveLength(1);
+      expect(mockProvider.sendTransaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not split when targets count is below BATCH_TX_LIMIT', async () => {
+      const targets = Array(50).fill(MOCK_ASSET);
+      const amounts = Array(50).fill('100');
+
+      const results = await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+      );
+
+      expect(results).toHaveLength(1);
+    });
+
+    // -----------------------------------------------------------------------
+    // Progress callback
+    // -----------------------------------------------------------------------
+
+    it('calls onProgress once per chunk with correct (completed, total, txHash)', async () => {
+      const count = 250;
+      const targets = Array(count).fill(MOCK_ASSET);
+      const amounts = Array(count).fill('100');
+
+      let callIdx = 0;
+      mockProvider.sendTransaction.mockImplementation(() => {
+        callIdx++;
+        return Promise.resolve({ hash: `h${callIdx}`, status: 'PENDING' });
+      });
+
+      const progressCalls: Array<[number, number, string | undefined]> = [];
+      const onProgress = jest.fn((completed: number, total: number, txHash?: string) => {
+        progressCalls.push([completed, total, txHash]);
+      });
+
+      await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+        onProgress,
+      );
+
+      expect(onProgress).toHaveBeenCalledTimes(3);
+      // After chunk 1: 100 of 250 processed
+      expect(progressCalls[0]).toEqual([100, 250, 'h1']);
+      // After chunk 2: 200 of 250 processed
+      expect(progressCalls[1]).toEqual([200, 250, 'h2']);
+      // After chunk 3: 250 of 250 processed
+      expect(progressCalls[2]).toEqual([250, 250, 'h3']);
+    });
+
+    it('calls onProgress even when total fits in one tx', async () => {
+      const targets = [MOCK_ASSET, MOCK_ASSET];
+      const amounts = ['500', '500'];
+
+      const onProgress = jest.fn();
+
+      await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+        onProgress,
+      );
+
+      expect(onProgress).toHaveBeenCalledTimes(1);
+      expect(onProgress).toHaveBeenCalledWith(2, 2, 'mock_tx_hash');
+    });
+
+    it('does not call onProgress when callback is omitted', async () => {
+      // Just verifies there is no crash when onProgress is undefined.
+      const results = await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets: [MOCK_ASSET], amounts: ['500'], asset: MOCK_ASSET },
+        mockKeypair,
+        // no callback
+      );
+      expect(results[0].status).toBe('pending');
+    });
+
+    it('passes undefined as txHash to onProgress when submission fails', async () => {
+      mockProvider.sendTransaction.mockRejectedValue(new Error('RPC error'));
+
+      const onProgress = jest.fn();
+
+      await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets: [MOCK_ASSET], amounts: ['100'], asset: MOCK_ASSET },
+        mockKeypair,
+        onProgress,
+      );
+
+      expect(onProgress).toHaveBeenCalledTimes(1);
+      // hash is '' which evaluates to undefined in the implementation
+      const [completed, total, txHash] = onProgress.mock.calls[0];
+      expect(completed).toBe(1);
+      expect(total).toBe(1);
+      expect(txHash).toBeUndefined();
+    });
+
+    it('continues remaining chunks even when one chunk fails', async () => {
+      const count = 250;
+      const targets = Array(count).fill(MOCK_ASSET);
+      const amounts = Array(count).fill('100');
+
+      let callIdx = 0;
+      mockProvider.sendTransaction.mockImplementation(() => {
+        callIdx++;
+        if (callIdx === 2) {
+          return Promise.resolve({ hash: 'fail_hash', status: 'ERROR' });
+        }
+        return Promise.resolve({ hash: `h${callIdx}`, status: 'PENDING' });
+      });
+
+      const results = await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+      );
+
+      expect(results).toHaveLength(3);
+      expect(results[0].status).toBe('pending');
+      expect(results[1].status).toBe('failed');
+      expect(results[2].status).toBe('pending');
+    });
+
+    it('calls onProgress for all chunks even when one fails mid-way', async () => {
+      const count = 250;
+      const targets = Array(count).fill(MOCK_ASSET);
+      const amounts = Array(count).fill('100');
+
+      let callIdx = 0;
+      mockProvider.sendTransaction.mockImplementation(() => {
+        callIdx++;
+        if (callIdx === 2) {
+          return Promise.resolve({ hash: 'fail_hash', status: 'ERROR' });
+        }
+        return Promise.resolve({ hash: `h${callIdx}`, status: 'PENDING' });
+      });
+
+      const onProgress = jest.fn();
+      await sdk.batchFundCAddresses(
+        { source: MOCK_ADDRESS, targets, amounts, asset: MOCK_ASSET },
+        mockKeypair,
+        onProgress,
+      );
+
+      // onProgress must be called for all 3 chunks regardless of failures
+      expect(onProgress).toHaveBeenCalledTimes(3);
+      expect(onProgress).toHaveBeenNthCalledWith(1, 100, 250, 'h1');
+      expect(onProgress).toHaveBeenNthCalledWith(2, 200, 250, 'fail_hash');
+      expect(onProgress).toHaveBeenNthCalledWith(3, 250, 250, 'h3');
     });
   });
 
@@ -531,21 +735,21 @@ describe('address validation', () => {
   });
 
   it('batchFundCAddresses rejects invalid source', async () => {
-    const result = await sdk.batchFundCAddresses(
+    const results = await sdk.batchFundCAddresses(
       { source: 'bad', targets: [MOCK_ASSET], amounts: ['100'], asset: MOCK_ASSET },
       mockKeypair,
     );
-    expect(result.status).toBe('failed');
-    expect(result.error).toMatch(/Invalid account address for "source"/);
+    expect(results[0].status).toBe('failed');
+    expect(results[0].error).toMatch(/Invalid account address for "source"/);
   });
 
   it('batchFundCAddresses rejects G-address in targets', async () => {
-    const result = await sdk.batchFundCAddresses(
+    const results = await sdk.batchFundCAddresses(
       { source: MOCK_ADDRESS, targets: [MOCK_ADDRESS], amounts: ['100'], asset: MOCK_ASSET },
       mockKeypair,
     );
-    expect(result.status).toBe('failed');
-    expect(result.error).toMatch(/Invalid contract address for "targets\[0\]"/);
+    expect(results[0].status).toBe('failed');
+    expect(results[0].error).toMatch(/Invalid contract address for "targets\[0\]"/);
   });
 
   it('withdrawFees rejects G-address as asset', async () => {
@@ -658,19 +862,20 @@ describe('Error handling - invalid inputs', () => {
   });
 
   it('batchFundCAddresses passes mismatched targets and amounts to contract (no client-side validation)', async () => {
-    const result = await sdk.batchFundCAddresses(
+    const results = await sdk.batchFundCAddresses(
       { source: MOCK_ADDRESS, targets: [MOCK_ASSET, MOCK_ASSET], amounts: ['100'], asset: MOCK_ASSET },
       mockKeypair,
     );
-    expect(result.status).toBe('pending');
+    expect(results[0].status).toBe('pending');
   });
 
   it('batchFundCAddresses passes empty targets array to contract (no client-side validation)', async () => {
-    const result = await sdk.batchFundCAddresses(
+    const results = await sdk.batchFundCAddresses(
       { source: MOCK_ADDRESS, targets: [], amounts: [], asset: MOCK_ASSET },
       mockKeypair,
     );
-    expect(result.status).toBe('pending');
+    // Empty targets: no chunks, no transactions submitted; returns empty array
+    expect(results).toHaveLength(0);
   });
 
   it('withdrawFees passes negative amount to contract (no client-side validation)', async () => {

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -12,6 +12,7 @@ import {
   BridgeConfig,
   FundCOptions,
   BatchFundCOptions,
+  BatchProgressCallback,
   WithdrawFeesOptions,
   UpgradeOptions,
   ReclaimTokensOptions,
@@ -25,6 +26,17 @@ import {
   PaginationOptions,
   CostEstimate,
 } from './types';
+
+/**
+ * Maximum number of `(target, amount)` pairs that can be included in a single
+ * `batch_fund_c_address` contract call.  Matches the `MAX_BATCH_SIZE` constant
+ * enforced on-chain (100).
+ *
+ * When {@link OnboardingBridgeSDK.batchFundCAddresses} is called with more
+ * entries than this limit, it automatically splits the list into chunks of this
+ * size and submits one transaction per chunk.
+ */
+export const BATCH_TX_LIMIT = 100;
 import { assertAccountAddress, assertContractAddress } from './validate';
 import { withRpcRetry } from './retry';
 import {
@@ -274,27 +286,42 @@ export class OnboardingBridgeSDK {
   }
 
   /**
-   * Fund multiple C-addresses from a single source account in one transaction.
+   * Fund multiple C-addresses from a single source account, automatically
+   * splitting large batches across multiple transactions.
    *
-   * The source is charged the sum of all `options.amounts` up front.  For each
-   * target that fails access control (blocked, not allowlisted), the
-   * corresponding amount is refunded to `source` and a `BatchTransferFailed`
-   * event is emitted.  A `BatchCompleted` event is emitted at the end with
-   * aggregate totals.
+   * When the number of `options.targets` exceeds {@link BATCH_TX_LIMIT}, the
+   * list is split into chunks of at most `BATCH_TX_LIMIT` entries and one
+   * on-chain `batch_fund_c_address` transaction is submitted per chunk.  This
+   * means a single call to `batchFundCAddresses` may submit **multiple**
+   * transactions and returns an array of {@link TransactionResult} — one entry
+   * per submitted transaction, in order.
+   *
+   * Within each chunk the contract pulls the sum of that chunk's amounts from
+   * `source` upfront.  For targets that fail access control the corresponding
+   * amount is refunded to `source` and a `BatchTransferFailed` event is emitted.
+   * A `BatchCompleted` event is emitted at the end of each on-chain transaction.
    *
    * `options.targets` and `options.amounts` must be the same length.
    *
    * @param options       - Batch transfer parameters: source, targets, amounts, asset.
-   * @param sourceKeypair - Keypair of the source account used to sign the transaction.
+   * @param sourceKeypair - Keypair of the source account used to sign every transaction.
+   * @param onProgress    - Optional callback invoked after each transaction is
+   *                        submitted.  Receives the cumulative count of recipients
+   *                        processed, the total recipient count, and the tx hash
+   *                        (or `undefined` if submission failed before a hash was
+   *                        returned).
    *
-   * @returns A {@link TransactionResult} with `status: 'pending'` on successful
-   *          submission, or `status: 'failed'` with an error message.
+   * @returns An array of {@link TransactionResult}, one per submitted transaction.
+   *          If the entire batch fits in a single transaction the array has one
+   *          element.  On a per-chunk submission error the corresponding element
+   *          has `status: 'failed'`; processing continues with the remaining chunks.
    *
-   * @throws Never — errors are returned as `status: 'failed'`.
+   * @throws Never — errors are returned as `status: 'failed'` in the results array.
    *
    * @example
    * ```ts
-   * const result = await sdk.batchFundCAddresses(
+   * // Small batch — fits in one tx
+   * const [result] = await sdk.batchFundCAddresses(
    *   {
    *     source:  keypair.publicKey(),
    *     targets: ['CC...1', 'CC...2', 'CC...3'],
@@ -303,52 +330,92 @@ export class OnboardingBridgeSDK {
    *   },
    *   keypair,
    * );
+   *
+   * // Large batch — auto-split with progress reporting
+   * const results = await sdk.batchFundCAddresses(
+   *   { source: keypair.publicKey(), targets: largeTargetList, amounts: largeAmountList, asset: 'CD...' },
+   *   keypair,
+   *   (completed, total, txHash) => {
+   *     console.log(`Processed ${completed}/${total} recipients — tx: ${txHash}`);
+   *   },
+   * );
    * ```
    */
   async batchFundCAddresses(
     options: BatchFundCOptions,
     sourceKeypair: Keypair,
-  ): Promise<TransactionResult> {
+    onProgress?: BatchProgressCallback,
+  ): Promise<TransactionResult[]> {
+    // Validate inputs before splitting so we fail fast on bad input.
     try {
       assertAccountAddress(options.source, 'source');
       options.targets.forEach((t, i) => assertContractAddress(t, `targets[${i}]`));
       assertContractAddress(options.asset, 'asset');
-      const sourceAccount = await this.provider.getAccount(options.source);
-
-      const tx = new TransactionBuilder(sourceAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'batch_fund_c_address',
-            ...this.toScVals([
-              options.source,
-              options.targets,
-              options.amounts,
-              options.asset,
-            ]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
-
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(sourceKeypair);
-
-      const response = await this.provider.sendTransaction(preparedTx);
-
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
     } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
+      return [{ hash: '', status: 'failed', error: error.message || 'Unknown error' }];
     }
+
+    const total = options.targets.length;
+    const results: TransactionResult[] = [];
+    let completed = 0;
+
+    // Split targets/amounts into chunks of at most BATCH_TX_LIMIT.
+    for (let offset = 0; offset < total; offset += BATCH_TX_LIMIT) {
+      const chunkTargets = options.targets.slice(offset, offset + BATCH_TX_LIMIT);
+      const chunkAmounts = options.amounts.slice(offset, offset + BATCH_TX_LIMIT);
+
+      let result: TransactionResult;
+      try {
+        const sourceAccount = await this.provider.getAccount(options.source);
+
+        const tx = new TransactionBuilder(sourceAccount, {
+          fee: BASE_FEE,
+          networkPassphrase: this.networkPassphrase,
+        })
+          .addOperation(
+            this.contract.call(
+              'batch_fund_c_address',
+              ...this.toScVals([
+                options.source,
+                chunkTargets,
+                chunkAmounts,
+                options.asset,
+              ]),
+            ),
+          )
+          .setTimeout(30)
+          .build();
+
+        const preparedTx = await this.provider.prepareTransaction(tx);
+        preparedTx.sign(sourceKeypair);
+
+        const response = await this.provider.sendTransaction(preparedTx);
+
+        result = {
+          hash: response.hash,
+          status: response.status === 'ERROR' ? 'failed' : 'pending',
+        };
+      } catch (error: any) {
+        result = {
+          hash: '',
+          status: 'failed',
+          error: error.message || 'Unknown error',
+        };
+      }
+
+      results.push(result);
+      completed += chunkTargets.length;
+
+      if (onProgress) {
+        onProgress(
+          completed,
+          total,
+          result.hash || undefined,
+        );
+      }
+    }
+
+    return results;
   }
 
   /**

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -49,7 +49,7 @@
  * @packageDocumentation
  */
 
-export { OnboardingBridgeSDK } from './bridge';
+export { OnboardingBridgeSDK, BATCH_TX_LIMIT } from './bridge';
 export { OffRampIntegration } from './offramp';
 export { assertAccountAddress, assertContractAddress } from './validate';
 export { CachedContractClient } from './cachedBridge';

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -131,12 +131,18 @@ export interface FundCOptions {
 }
 
 /**
- * Options for funding multiple C-addresses in a single transaction via
+ * Options for funding multiple C-addresses in one or more transactions via
  * {@link OnboardingBridgeSDK.batchFundCAddresses}.
  *
- * The source account is charged the sum of all `amounts` in one transfer.
- * For any target that fails (blocked, not allowlisted), the corresponding
- * amount is refunded to `source`.
+ * The source account is charged the sum of all `amounts` in one transfer per
+ * transaction chunk.  For any target that fails (blocked, not allowlisted), the
+ * corresponding amount is refunded to `source`.
+ *
+ * When the number of targets exceeds {@link BATCH_TX_LIMIT} the SDK automatically
+ * splits the list into chunks of at most `BATCH_TX_LIMIT` and submits one
+ * transaction per chunk.  The optional `onProgress` callback (passed as the
+ * third argument to `batchFundCAddresses`) is called after each transaction
+ * with the running total of recipients processed.
  *
  * @example
  * ```ts
@@ -148,6 +154,9 @@ export interface FundCOptions {
  *     asset:   'CD...',
  *   },
  *   keypair,
+ *   (completed, total, txHash) => {
+ *     console.log(`Progress: ${completed}/${total} — tx: ${txHash}`);
+ *   },
  * );
  * ```
  */
@@ -173,6 +182,23 @@ export interface BatchFundCOptions {
    */
   asset: string;
 }
+
+/**
+ * Progress callback invoked by {@link OnboardingBridgeSDK.batchFundCAddresses}
+ * after each on-chain transaction completes (or fails).
+ *
+ * @param completed - Number of individual recipients processed so far across
+ *                    all submitted transactions (whether each transfer succeeded
+ *                    inside the contract or was refunded due to access-control).
+ * @param total     - Total number of recipients in the original request.
+ * @param txHash    - Transaction hash of the just-submitted transaction.
+ *                    `undefined` when the transaction failed before submission.
+ */
+export type BatchProgressCallback = (
+  completed: number,
+  total: number,
+  txHash?: string,
+) => void;
 
 // ---------------------------------------------------------------------------
 // Admin operations


### PR DESCRIPTION
- Add BATCH_TX_LIMIT = 100 constant (matches on-chain MAX_BATCH_SIZE)
- Change batchFundCAddresses return type to Promise<TransactionResult[]>
- Accept optional onProgress callback invoked after each tx chunk
- Auto-split batches exceeding BATCH_TX_LIMIT into multiple transactions
- Add BatchProgressCallback type to types.ts
- Export BATCH_TX_LIMIT from package root
- Update and expand tests (80 passing)

Closes #52