### PR TITLE
feat(sdk): add observability hooks + OpenTelemetry integration

### DIFF
--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -26,6 +26,12 @@ import {
   PaginationOptions,
   CostEstimate,
 } from './types';
+import {
+  type ObservabilityHooks,
+  withTransactionHooks,
+  withRpcHook,
+  fireRpcCall,
+} from './observability';
 
 /**
  * Maximum number of `(target, amount)` pairs that can be included in a single
@@ -88,6 +94,7 @@ export class OnboardingBridgeSDK {
   private contract: Contract;
   private provider: SorobanRpc.Server;
   private networkPassphrase: string;
+  private hooks: ObservabilityHooks | undefined;
 
   /**
    * Create a new SDK instance.
@@ -122,6 +129,7 @@ export class OnboardingBridgeSDK {
       config.retry,
     );
     this.networkPassphrase = config.networkPassphrase;
+    this.hooks = config.hooks;
   }
 
   /**
@@ -167,46 +175,68 @@ export class OnboardingBridgeSDK {
     options: FundCOptions,
     sourceKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      assertAccountAddress(options.source, 'source');
-      assertContractAddress(options.target, 'target');
-      assertContractAddress(options.asset, 'asset');
-      const sourceAccount = await this.provider.getAccount(options.source);
+    return withTransactionHooks(
+      this.hooks,
+      'fundCAddress',
+      { source: options.source, target: options.target, asset: options.asset, amount: options.amount },
+      async () => {
+        try {
+          assertAccountAddress(options.source, 'source');
+          assertContractAddress(options.target, 'target');
+          assertContractAddress(options.asset, 'asset');
+          const sourceAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: options.source },
+            () => this.provider.getAccount(options.source),
+          );
 
-      const tx = new TransactionBuilder(sourceAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'fund_c_address',
-            ...this.toScVals([
-              options.source,
-              options.target,
-              options.asset,
-              options.amount,
-            ]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(sourceAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'fund_c_address',
+                ...this.toScVals([
+                  options.source,
+                  options.target,
+                  options.asset,
+                  options.amount,
+                ]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(sourceKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'fund_c_address' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(sourceKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'fund_c_address' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -237,52 +267,81 @@ export class OnboardingBridgeSDK {
     options: FundCAddressWithSwapOptions,
     sourceKeypair: any,
   ): Promise<TransactionResult> {
-    try {
-      assertAccountAddress(options.source, 'source');
-      assertContractAddress(options.target, 'target');
-      assertContractAddress(options.sourceAsset, 'sourceAsset');
-      assertContractAddress(options.targetAsset, 'targetAsset');
-      options.swapRoute.forEach((p, i) => assertContractAddress(p, `swapRoute[${i}]`));
+    return withTransactionHooks(
+      this.hooks,
+      'fundCAddressWithSwap',
+      {
+        source: options.source,
+        target: options.target,
+        sourceAsset: options.sourceAsset,
+        targetAsset: options.targetAsset,
+        sourceAmount: options.sourceAmount,
+        minTargetAmount: options.minTargetAmount,
+      },
+      async () => {
+        try {
+          assertAccountAddress(options.source, 'source');
+          assertContractAddress(options.target, 'target');
+          assertContractAddress(options.sourceAsset, 'sourceAsset');
+          assertContractAddress(options.targetAsset, 'targetAsset');
+          options.swapRoute.forEach((p, i) => assertContractAddress(p, `swapRoute[${i}]`));
 
-      const sourceAccount = await this.provider.getAccount(options.source);
+          const sourceAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: options.source },
+            () => this.provider.getAccount(options.source),
+          );
 
-      const tx = new TransactionBuilder(sourceAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'fund_c_address_with_swap',
-            ...this.toScVals([
-              options.source,
-              options.target,
-              options.sourceAsset,
-              options.targetAsset,
-              options.sourceAmount,
-              options.minTargetAmount,
-              options.swapRoute,
-            ]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(sourceAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'fund_c_address_with_swap',
+                ...this.toScVals([
+                  options.source,
+                  options.target,
+                  options.sourceAsset,
+                  options.targetAsset,
+                  options.sourceAmount,
+                  options.minTargetAmount,
+                  options.swapRoute,
+                ]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(sourceKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'fund_c_address_with_swap' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(sourceKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'fund_c_address_with_swap' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -346,76 +405,98 @@ export class OnboardingBridgeSDK {
     sourceKeypair: Keypair,
     onProgress?: BatchProgressCallback,
   ): Promise<TransactionResult[]> {
-    // Validate inputs before splitting so we fail fast on bad input.
-    try {
-      assertAccountAddress(options.source, 'source');
-      options.targets.forEach((t, i) => assertContractAddress(t, `targets[${i}]`));
-      assertContractAddress(options.asset, 'asset');
-    } catch (error: any) {
-      return [{ hash: '', status: 'failed', error: error.message || 'Unknown error' }];
-    }
+    return withTransactionHooks(
+      this.hooks,
+      'batchFundCAddresses',
+      { source: options.source, targetCount: options.targets.length, asset: options.asset },
+      async () => {
+        // Validate inputs before splitting so we fail fast on bad input.
+        try {
+          assertAccountAddress(options.source, 'source');
+          options.targets.forEach((t, i) => assertContractAddress(t, `targets[${i}]`));
+          assertContractAddress(options.asset, 'asset');
+        } catch (error: any) {
+          return [{ hash: '', status: 'failed', error: error.message || 'Unknown error' }];
+        }
 
-    const total = options.targets.length;
-    const results: TransactionResult[] = [];
-    let completed = 0;
+        const total = options.targets.length;
+        const results: TransactionResult[] = [];
+        let completed = 0;
 
-    // Split targets/amounts into chunks of at most BATCH_TX_LIMIT.
-    for (let offset = 0; offset < total; offset += BATCH_TX_LIMIT) {
-      const chunkTargets = options.targets.slice(offset, offset + BATCH_TX_LIMIT);
-      const chunkAmounts = options.amounts.slice(offset, offset + BATCH_TX_LIMIT);
+        // Split targets/amounts into chunks of at most BATCH_TX_LIMIT.
+        for (let offset = 0; offset < total; offset += BATCH_TX_LIMIT) {
+          const chunkTargets = options.targets.slice(offset, offset + BATCH_TX_LIMIT);
+          const chunkAmounts = options.amounts.slice(offset, offset + BATCH_TX_LIMIT);
 
-      let result: TransactionResult;
-      try {
-        const sourceAccount = await this.provider.getAccount(options.source);
+          let result: TransactionResult;
+          try {
+            const sourceAccount = await withRpcHook(
+              this.hooks,
+              'getAccount',
+              { address: options.source },
+              () => this.provider.getAccount(options.source),
+            );
 
-        const tx = new TransactionBuilder(sourceAccount, {
-          fee: BASE_FEE,
-          networkPassphrase: this.networkPassphrase,
-        })
-          .addOperation(
-            this.contract.call(
-              'batch_fund_c_address',
-              ...this.toScVals([
-                options.source,
-                chunkTargets,
-                chunkAmounts,
-                options.asset,
-              ]),
-            ),
-          )
-          .setTimeout(30)
-          .build();
+            const tx = new TransactionBuilder(sourceAccount, {
+              fee: BASE_FEE,
+              networkPassphrase: this.networkPassphrase,
+            })
+              .addOperation(
+                this.contract.call(
+                  'batch_fund_c_address',
+                  ...this.toScVals([
+                    options.source,
+                    chunkTargets,
+                    chunkAmounts,
+                    options.asset,
+                  ]),
+                ),
+              )
+              .setTimeout(30)
+              .build();
 
-        const preparedTx = await this.provider.prepareTransaction(tx);
-        preparedTx.sign(sourceKeypair);
+            const preparedTx = await withRpcHook(
+              this.hooks,
+              'prepareTransaction',
+              { contractMethod: 'batch_fund_c_address', chunkSize: chunkTargets.length },
+              () => this.provider.prepareTransaction(tx),
+            );
+            preparedTx.sign(sourceKeypair);
 
-        const response = await this.provider.sendTransaction(preparedTx);
+            const response = await withRpcHook(
+              this.hooks,
+              'sendTransaction',
+              { contractMethod: 'batch_fund_c_address', chunkSize: chunkTargets.length },
+              () => this.provider.sendTransaction(preparedTx),
+            );
 
-        result = {
-          hash: response.hash,
-          status: response.status === 'ERROR' ? 'failed' : 'pending',
-        };
-      } catch (error: any) {
-        result = {
-          hash: '',
-          status: 'failed',
-          error: error.message || 'Unknown error',
-        };
-      }
+            result = {
+              hash: response.hash,
+              status: response.status === 'ERROR' ? 'failed' : 'pending',
+            };
+          } catch (error: any) {
+            result = {
+              hash: '',
+              status: 'failed',
+              error: error.message || 'Unknown error',
+            };
+          }
 
-      results.push(result);
-      completed += chunkTargets.length;
+          results.push(result);
+          completed += chunkTargets.length;
 
-      if (onProgress) {
-        onProgress(
-          completed,
-          total,
-          result.hash || undefined,
-        );
-      }
-    }
+          if (onProgress) {
+            onProgress(
+              completed,
+              total,
+              result.hash || undefined,
+            );
+          }
+        }
 
-    return results;
+        return results;
+      },
+    );
   }
 
   /**
@@ -445,41 +526,61 @@ export class OnboardingBridgeSDK {
     options: WithdrawFeesOptions,
     feeCollectorKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      assertContractAddress(options.asset, 'asset');
-      const feeCollectorAccount = await this.provider.getAccount(
-        feeCollectorKeypair.publicKey(),
-      );
+    return withTransactionHooks(
+      this.hooks,
+      'withdrawFees',
+      { asset: options.asset, amount: options.amount },
+      async () => {
+        try {
+          assertContractAddress(options.asset, 'asset');
+          const feeCollectorAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: feeCollectorKeypair.publicKey() },
+            () => this.provider.getAccount(feeCollectorKeypair.publicKey()),
+          );
 
-      const tx = new TransactionBuilder(feeCollectorAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'withdraw_fees',
-            ...this.toScVals([options.asset, options.amount]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(feeCollectorAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'withdraw_fees',
+                ...this.toScVals([options.asset, options.amount]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(feeCollectorKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'withdraw_fees' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(feeCollectorKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'withdraw_fees' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -507,42 +608,62 @@ export class OnboardingBridgeSDK {
     options: ReclaimTokensOptions,
     adminKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      assertContractAddress(options.asset, 'asset');
-      assertAccountAddress(options.to, 'to');
-      const adminAccount = await this.provider.getAccount(
-        adminKeypair.publicKey(),
-      );
+    return withTransactionHooks(
+      this.hooks,
+      'reclaimTokens',
+      { asset: options.asset, amount: options.amount, to: options.to },
+      async () => {
+        try {
+          assertContractAddress(options.asset, 'asset');
+          assertAccountAddress(options.to, 'to');
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
 
-      const tx = new TransactionBuilder(adminAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'reclaim_tokens',
-            ...this.toScVals([options.asset, options.amount, options.to]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'reclaim_tokens',
+                ...this.toScVals([options.asset, options.amount, options.to]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'reclaim_tokens' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'reclaim_tokens' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -562,10 +683,12 @@ export class OnboardingBridgeSDK {
    * ```
    */
   async getFee(): Promise<number> {
-    const result = await this.provider
-      .simulateTransaction(
-        this.buildSimulationTx('query_fee_bps', []),
-      );
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_fee_bps' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_fee_bps', [])),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to get fee: ${result.error}`);
@@ -591,10 +714,12 @@ export class OnboardingBridgeSDK {
    * ```
    */
   async getFeeCollector(): Promise<string> {
-    const result = await this.provider
-      .simulateTransaction(
-        this.buildSimulationTx('query_fee_collector', []),
-      );
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_fee_collector' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_fee_collector', [])),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to get fee collector: ${result.error}`);
@@ -621,10 +746,12 @@ export class OnboardingBridgeSDK {
    * ```
    */
   async getAdmin(): Promise<string> {
-    const result = await this.provider
-      .simulateTransaction(
-        this.buildSimulationTx('query_admin', []),
-      );
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_admin' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_admin', [])),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to get admin: ${result.error}`);
@@ -657,10 +784,12 @@ export class OnboardingBridgeSDK {
   ): Promise<string> {
     assertContractAddress(cAddress, 'cAddress');
     assertContractAddress(asset, 'asset');
-    const result = await this.provider
-      .simulateTransaction(
-        this.buildSimulationTx('query_balance', [cAddress, asset]),
-      );
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_balance' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_balance', [cAddress, asset])),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to get balance: ${result.error}`);
@@ -797,40 +926,60 @@ export class OnboardingBridgeSDK {
     newFeeBps: number,
     adminKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      const adminAccount = await this.provider.getAccount(
-        adminKeypair.publicKey(),
-      );
+    return withTransactionHooks(
+      this.hooks,
+      'setFee',
+      { newFeeBps },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
 
-      const tx = new TransactionBuilder(adminAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'set_fee_bps',
-            ...this.toScVals([newFeeBps]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'set_fee_bps',
+                ...this.toScVals([newFeeBps]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_fee_bps' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_fee_bps' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -855,41 +1004,61 @@ export class OnboardingBridgeSDK {
     newFeeCollector: string,
     adminKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      assertAccountAddress(newFeeCollector, 'newFeeCollector');
-      const adminAccount = await this.provider.getAccount(
-        adminKeypair.publicKey(),
-      );
+    return withTransactionHooks(
+      this.hooks,
+      'setFeeCollector',
+      { newFeeCollector },
+      async () => {
+        try {
+          assertAccountAddress(newFeeCollector, 'newFeeCollector');
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
 
-      const tx = new TransactionBuilder(adminAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'set_fee_collector',
-            ...this.toScVals([newFeeCollector]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'set_fee_collector',
+                ...this.toScVals([newFeeCollector]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_fee_collector' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_fee_collector' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -915,41 +1084,61 @@ export class OnboardingBridgeSDK {
     newAdmin: string,
     adminKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      assertAccountAddress(newAdmin, 'newAdmin');
-      const adminAccount = await this.provider.getAccount(
-        adminKeypair.publicKey(),
-      );
+    return withTransactionHooks(
+      this.hooks,
+      'setAdmin',
+      { newAdmin },
+      async () => {
+        try {
+          assertAccountAddress(newAdmin, 'newAdmin');
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
 
-      const tx = new TransactionBuilder(adminAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'set_admin',
-            ...this.toScVals([newAdmin]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'set_admin',
+                ...this.toScVals([newAdmin]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_admin' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_admin' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   /**
@@ -961,40 +1150,60 @@ export class OnboardingBridgeSDK {
     options: UpgradeOptions,
     adminKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      const adminAccount = await this.provider.getAccount(
-        adminKeypair.publicKey(),
-      );
+    return withTransactionHooks(
+      this.hooks,
+      'upgrade',
+      { newWasmHash: options.newWasmHash },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
 
-      const wasmHashBytes = Buffer.from(options.newWasmHash, 'hex');
-      const wasmHashScVal = xdr.ScVal.scvBytes(wasmHashBytes);
+          const wasmHashBytes = Buffer.from(options.newWasmHash, 'hex');
+          const wasmHashScVal = xdr.ScVal.scvBytes(wasmHashBytes);
 
-      const tx = new TransactionBuilder(adminAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call('upgrade', wasmHashScVal),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call('upgrade', wasmHashScVal),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'upgrade' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
 
-      const response = await this.provider.sendTransaction(preparedTx);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'upgrade' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
 
-      return {
-        hash: response.hash,
-        status: response.status === 'ERROR' ? 'failed' : 'pending',
-      };
-    } catch (error: any) {
-      return {
-        hash: '',
-        status: 'failed',
-        error: error.message || 'Unknown error',
-      };
-    }
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
   }
 
   // --- Cross-chain methods ---
@@ -1007,48 +1216,71 @@ export class OnboardingBridgeSDK {
     options: CrossChainFundOptions,
     relayerKeypair: Keypair,
   ): Promise<TransactionResult> {
-    try {
-      const relayerAccount = await this.provider.getAccount(relayerKeypair.publicKey());
+    return withTransactionHooks(
+      this.hooks,
+      'fundCrosschain',
+      { chainId: options.chainId, txHash: options.txHash, target: options.target, asset: options.asset, amount: options.amount },
+      async () => {
+        try {
+          const relayerAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: relayerKeypair.publicKey() },
+            () => this.provider.getAccount(relayerKeypair.publicKey()),
+          );
 
-      const sigsScVal = xdr.ScVal.scvVec(
-        options.sigs.map((s) => {
-          const pubkeyBytes = Buffer.from(s.pubkey, 'hex');
-          const sigBytes = Buffer.from(s.signature, 'hex');
-          return xdr.ScVal.scvMap([
-            new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('pubkey'), val: xdr.ScVal.scvBytes(pubkeyBytes) }),
-            new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('signature'), val: xdr.ScVal.scvBytes(sigBytes) }),
-          ]);
-        }),
-      );
+          const sigsScVal = xdr.ScVal.scvVec(
+            options.sigs.map((s) => {
+              const pubkeyBytes = Buffer.from(s.pubkey, 'hex');
+              const sigBytes = Buffer.from(s.signature, 'hex');
+              return xdr.ScVal.scvMap([
+                new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('pubkey'), val: xdr.ScVal.scvBytes(pubkeyBytes) }),
+                new xdr.ScMapEntry({ key: xdr.ScVal.scvSymbol('signature'), val: xdr.ScVal.scvBytes(sigBytes) }),
+              ]);
+            }),
+          );
 
-      const txHashBytes = Buffer.from(options.txHash.replace('0x', ''), 'hex');
+          const txHashBytes = Buffer.from(options.txHash.replace('0x', ''), 'hex');
 
-      const tx = new TransactionBuilder(relayerAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'fund_c_address_crosschain',
-            nativeToScVal(options.chainId, { type: 'u32' }),
-            xdr.ScVal.scvBytes(txHashBytes),
-            new Address(options.target).toScVal(),
-            new Address(options.asset).toScVal(),
-            nativeToScVal(BigInt(options.amount), { type: 'i128' }),
-            sigsScVal,
-          ),
-        )
-        .setTimeout(30)
-        .build();
+          const tx = new TransactionBuilder(relayerAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'fund_c_address_crosschain',
+                nativeToScVal(options.chainId, { type: 'u32' }),
+                xdr.ScVal.scvBytes(txHashBytes),
+                new Address(options.target).toScVal(),
+                new Address(options.asset).toScVal(),
+                nativeToScVal(BigInt(options.amount), { type: 'i128' }),
+                sigsScVal,
+              ),
+            )
+            .setTimeout(30)
+            .build();
 
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(relayerKeypair);
-      const response = await this.provider.sendTransaction(preparedTx);
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'fund_c_address_crosschain' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(relayerKeypair);
 
-      return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
-    } catch (error: any) {
-      return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
-    }
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'fund_c_address_crosschain' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
+        } catch (error: any) {
+          return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
+        }
+      },
+    );
   }
 
   /** 
@@ -1066,19 +1298,41 @@ export class OnboardingBridgeSDK {
    * @throws Never — errors are returned as `status: 'failed'`.
    */
   async addRelayer(options: RelayerManagementOptions, adminKeypair: Keypair): Promise<TransactionResult> {
-    try {
-      const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
-      const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
-        .addOperation(this.contract.call('add_relayer', xdr.ScVal.scvBytes(Buffer.from(options.pubkey, 'hex'))))
-        .setTimeout(30)
-        .build();
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
-      const response = await this.provider.sendTransaction(preparedTx);
-      return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
-    } catch (error: any) {
-      return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
-    }
+    return withTransactionHooks(
+      this.hooks,
+      'addRelayer',
+      { pubkey: options.pubkey },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
+          const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
+            .addOperation(this.contract.call('add_relayer', xdr.ScVal.scvBytes(Buffer.from(options.pubkey, 'hex'))))
+            .setTimeout(30)
+            .build();
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'add_relayer' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'add_relayer' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+          return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
+        } catch (error: any) {
+          return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
+        }
+      },
+    );
   }
 
   /**
@@ -1096,19 +1350,41 @@ export class OnboardingBridgeSDK {
    * @throws Never — errors are returned as `status: 'failed'`.
    */
   async removeRelayer(options: RelayerManagementOptions, adminKeypair: Keypair): Promise<TransactionResult> {
-    try {
-      const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
-      const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
-        .addOperation(this.contract.call('remove_relayer', xdr.ScVal.scvBytes(Buffer.from(options.pubkey, 'hex'))))
-        .setTimeout(30)
-        .build();
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
-      const response = await this.provider.sendTransaction(preparedTx);
-      return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
-    } catch (error: any) {
-      return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
-    }
+    return withTransactionHooks(
+      this.hooks,
+      'removeRelayer',
+      { pubkey: options.pubkey },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
+          const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
+            .addOperation(this.contract.call('remove_relayer', xdr.ScVal.scvBytes(Buffer.from(options.pubkey, 'hex'))))
+            .setTimeout(30)
+            .build();
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'remove_relayer' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'remove_relayer' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+          return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
+        } catch (error: any) {
+          return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
+        }
+      },
+    );
   }
 
   /**
@@ -1131,19 +1407,41 @@ export class OnboardingBridgeSDK {
    * ```
    */
   async setRelayerThreshold(threshold: number, adminKeypair: Keypair): Promise<TransactionResult> {
-    try {
-      const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
-      const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
-        .addOperation(this.contract.call('set_relayer_threshold', nativeToScVal(threshold, { type: 'u32' })))
-        .setTimeout(30)
-        .build();
-      const preparedTx = await this.provider.prepareTransaction(tx);
-      preparedTx.sign(adminKeypair);
-      const response = await this.provider.sendTransaction(preparedTx);
-      return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
-    } catch (error: any) {
-      return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
-    }
+    return withTransactionHooks(
+      this.hooks,
+      'setRelayerThreshold',
+      { threshold },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
+          const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
+            .addOperation(this.contract.call('set_relayer_threshold', nativeToScVal(threshold, { type: 'u32' })))
+            .setTimeout(30)
+            .build();
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_relayer_threshold' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_relayer_threshold' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+          return { hash: response.hash, status: response.status === 'ERROR' ? 'failed' : 'pending' };
+        } catch (error: any) {
+          return { hash: '', status: 'failed', error: error.message || 'Unknown error' };
+        }
+      },
+    );
   }
 
   /**
@@ -1192,90 +1490,133 @@ export class OnboardingBridgeSDK {
   async createCAddress(
     options: CreateCOptions,
   ): Promise<CreateCAddressResult> {
-    const deployerKeypair = options.deployerKeypair;
-    const deployerAccount = await this.provider.getAccount(
-      deployerKeypair.publicKey(),
-    );
+    return withTransactionHooks(
+      this.hooks,
+      'createCAddress',
+      { salt: options.salt, hasInitialFunds: !!options.initialFunds },
+      async () => {
+        const deployerKeypair = options.deployerKeypair;
+        const deployerAccount = await withRpcHook(
+          this.hooks,
+          'getAccount',
+          { address: deployerKeypair.publicKey() },
+          () => this.provider.getAccount(deployerKeypair.publicKey()),
+        );
 
-    const saltBytes = options.salt
-      ? Buffer.from(options.salt, 'hex')
-      : Buffer.from(
-          Array.from({ length: 32 }, () =>
-            Math.floor(Math.random() * 256),
+        const saltBytes = options.salt
+          ? Buffer.from(options.salt, 'hex')
+          : Buffer.from(
+              Array.from({ length: 32 }, () =>
+                Math.floor(Math.random() * 256),
+              ),
+            );
+        const saltScVal = xdr.ScVal.scvBytes(saltBytes);
+
+        const deployerAddress = new Address(deployerKeypair.publicKey());
+
+        const txBuilder = new TransactionBuilder(deployerAccount, {
+          fee: BASE_FEE,
+          networkPassphrase: this.networkPassphrase,
+        });
+
+        txBuilder.addOperation(
+          this.contract.call(
+            'create_contract',
+            deployerAddress.toScVal(),
+            saltScVal,
           ),
         );
-    const saltScVal = xdr.ScVal.scvBytes(saltBytes);
 
-    const deployerAddress = new Address(deployerKeypair.publicKey());
+        const deployTx = txBuilder.setTimeout(30).build();
+        const preparedDeployTx = await withRpcHook(
+          this.hooks,
+          'prepareTransaction',
+          { contractMethod: 'create_contract' },
+          () => this.provider.prepareTransaction(deployTx),
+        );
+        preparedDeployTx.sign(deployerKeypair);
 
-    const txBuilder = new TransactionBuilder(deployerAccount, {
-      fee: BASE_FEE,
-      networkPassphrase: this.networkPassphrase,
-    });
+        const deployResponse = await withRpcHook(
+          this.hooks,
+          'sendTransaction',
+          { contractMethod: 'create_contract' },
+          () => this.provider.sendTransaction(preparedDeployTx),
+        );
+        if (deployResponse.status === 'ERROR') {
+          throw new Error(`Failed to create C-address: ${deployResponse.status}`);
+        }
 
-    txBuilder.addOperation(
-      this.contract.call(
-        'create_contract',
-        deployerAddress.toScVal(),
-        saltScVal,
-      ),
+        let txResult = await withRpcHook(
+          this.hooks,
+          'getTransaction',
+          { hash: deployResponse.hash },
+          () => this.provider.getTransaction(deployResponse.hash),
+        );
+        while (txResult.status === 'NOT_FOUND') {
+          await new Promise((resolve) => setTimeout(resolve, 1000));
+          txResult = await withRpcHook(
+            this.hooks,
+            'getTransaction',
+            { hash: deployResponse.hash },
+            () => this.provider.getTransaction(deployResponse.hash),
+          );
+        }
+
+        if (txResult.status !== 'SUCCESS') {
+          throw new Error(`C-address creation failed: ${txResult.status}`);
+        }
+
+        const returnVal = (txResult as any).returnValue;
+        const cAddress: string = returnVal
+          ? scValToNative(returnVal).toString()
+          : '';
+
+        if (options.initialFunds && cAddress) {
+          const fundAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: deployerKeypair.publicKey() },
+            () => this.provider.getAccount(deployerKeypair.publicKey()),
+          );
+          const fundTx = new TransactionBuilder(fundAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'fund_c_address',
+                ...this.toScVals([
+                  deployerKeypair.publicKey(),
+                  cAddress,
+                  options.initialFunds.asset,
+                  options.initialFunds.amount,
+                ]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedFundTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'fund_c_address' },
+            () => this.provider.prepareTransaction(fundTx),
+          );
+          preparedFundTx.sign(deployerKeypair);
+          await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'fund_c_address' },
+            () => this.provider.sendTransaction(preparedFundTx),
+          );
+        }
+
+        return {
+          cAddress,
+          txHash: deployResponse.hash,
+        };
+      },
     );
-
-    const deployTx = txBuilder.setTimeout(30).build();
-    const preparedDeployTx = await this.provider.prepareTransaction(deployTx);
-    preparedDeployTx.sign(deployerKeypair);
-
-    const deployResponse = await this.provider.sendTransaction(preparedDeployTx);
-    if (deployResponse.status === 'ERROR') {
-      throw new Error(`Failed to create C-address: ${deployResponse.status}`);
-    }
-
-    let txResult = await this.provider.getTransaction(deployResponse.hash);
-    while (txResult.status === 'NOT_FOUND') {
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      txResult = await this.provider.getTransaction(deployResponse.hash);
-    }
-
-    if (txResult.status !== 'SUCCESS') {
-      throw new Error(`C-address creation failed: ${txResult.status}`);
-    }
-
-    const returnVal = (txResult as any).returnValue;
-    const cAddress: string = returnVal
-      ? scValToNative(returnVal).toString()
-      : '';
-
-    if (options.initialFunds && cAddress) {
-      const fundAccount = await this.provider.getAccount(
-        deployerKeypair.publicKey(),
-      );
-      const fundTx = new TransactionBuilder(fundAccount, {
-        fee: BASE_FEE,
-        networkPassphrase: this.networkPassphrase,
-      })
-        .addOperation(
-          this.contract.call(
-            'fund_c_address',
-            ...this.toScVals([
-              deployerKeypair.publicKey(),
-              cAddress,
-              options.initialFunds.asset,
-              options.initialFunds.amount,
-            ]),
-          ),
-        )
-        .setTimeout(30)
-        .build();
-
-      const preparedFundTx = await this.provider.prepareTransaction(fundTx);
-      preparedFundTx.sign(deployerKeypair);
-      await this.provider.sendTransaction(preparedFundTx);
-    }
-
-    return {
-      cAddress,
-      txHash: deployResponse.hash,
-    };
   }
 
   /**

--- a/sdk/src/observability.ts
+++ b/sdk/src/observability.ts
@@ -1,0 +1,546 @@
+/**
+ * @fileoverview Observability hooks, console logger, and OpenTelemetry integration
+ * for the C-Address Onboarding Bridge SDK.
+ *
+ * ## Overview
+ *
+ * This module provides three complementary mechanisms for instrumenting the SDK:
+ *
+ * 1. **{@link ObservabilityHooks}** — a plain callback interface you can implement
+ *    however you like (custom metrics, structured logging, tracing, etc.).
+ *
+ * 2. **{@link ConsoleLogger}** — a ready-made `ObservabilityHooks` implementation
+ *    that writes structured JSON lines to `console.log` / `console.error`.
+ *    Pass it to `BridgeConfig.hooks` for zero-config debug logging.
+ *
+ * 3. **{@link createOpenTelemetryHooks}** — creates an `ObservabilityHooks`
+ *    implementation backed by an OpenTelemetry `Tracer`.  Every SDK method
+ *    becomes a child span with full attribute propagation and error recording.
+ *    Requires `@opentelemetry/api` as a peer dependency.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import {
+ *   ConsoleLogger,
+ *   createOpenTelemetryHooks,
+ * } from '@stellar/c-address-onboarding-bridge-sdk';
+ * import { trace } from '@opentelemetry/api';
+ *
+ * // Debug mode — log everything to the console
+ * const sdk = new OnboardingBridgeSDK({
+ *   contractId: 'CA...',
+ *   rpcUrl: '...',
+ *   networkPassphrase: Networks.TESTNET,
+ *   hooks: ConsoleLogger,
+ * });
+ *
+ * // Production — emit OpenTelemetry spans
+ * const tracer = trace.getTracer('bridge-sdk', '0.1.0');
+ * const sdk = new OnboardingBridgeSDK({
+ *   // ...
+ *   hooks: createOpenTelemetryHooks(tracer),
+ * });
+ * ```
+ *
+ * @module observability
+ */
+
+// ---------------------------------------------------------------------------
+// Interfaces
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifecycle callbacks that the SDK invokes around every mutating method
+ * (state-changing contract calls) and every RPC call.
+ *
+ * All hooks are **optional** — supply only the callbacks you need.
+ * Hooks must not throw; any uncaught exception is silently swallowed so
+ * that instrumentation never breaks the core SDK flow.
+ *
+ * @example
+ * ```ts
+ * const hooks: ObservabilityHooks = {
+ *   onTransactionStart: (method, params) => metrics.increment(`sdk.tx.${method}`),
+ *   onTransactionSuccess: (method, result, durationMs) => {
+ *     metrics.histogram('sdk.tx.duration', durationMs, { method });
+ *   },
+ *   onTransactionError: (method, error, durationMs) => {
+ *     logger.error({ method, error, durationMs });
+ *   },
+ *   onRpcCall: (method, params, durationMs) => {
+ *     metrics.histogram('sdk.rpc.duration', durationMs, { method });
+ *   },
+ * };
+ * ```
+ */
+export interface ObservabilityHooks {
+  /**
+   * Called immediately before a mutating SDK method is executed (before any
+   * RPC calls or transaction building takes place).
+   *
+   * @param method - The SDK method name (e.g. `'fundCAddress'`).
+   * @param params - The parameters passed to the method (sanitised — keypairs
+   *                 are excluded, only plain option objects are forwarded).
+   */
+  onTransactionStart?: (method: string, params: unknown) => void;
+
+  /**
+   * Called when a mutating SDK method completes without throwing.
+   * Note: `status: 'failed'` results still trigger this hook; check
+   * `result.status` if you want to distinguish submission failures from
+   * network errors.
+   *
+   * @param method     - The SDK method name.
+   * @param result     - The {@link TransactionResult} (or array of results for batch calls).
+   * @param durationMs - Wall-clock milliseconds from `onTransactionStart` to completion.
+   */
+  onTransactionSuccess?: (method: string, result: unknown, durationMs: number) => void;
+
+  /**
+   * Called when a mutating SDK method throws an unexpected exception.
+   * Normal `status: 'failed'` returns do NOT trigger this; only unhandled
+   * exceptions propagated out of the method do.
+   *
+   * @param method     - The SDK method name.
+   * @param error      - The caught exception.
+   * @param durationMs - Wall-clock milliseconds elapsed before the throw.
+   */
+  onTransactionError?: (method: string, error: Error, durationMs: number) => void;
+
+  /**
+   * Called after every internal RPC call (simulation, account fetch, send, etc.)
+   * whether it succeeded or failed. This provides fine-grained visibility into
+   * how long each network round-trip took.
+   *
+   * @param method     - A descriptive label for the RPC call (e.g. `'simulateTransaction'`,
+   *                     `'getAccount'`, `'sendTransaction'`).
+   * @param params     - Relevant call parameters for correlation (e.g. contract method name).
+   * @param durationMs - Wall-clock milliseconds the call took.
+   */
+  onRpcCall?: (method: string, params: unknown, durationMs: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Safely invoke a hook callback.  Any thrown exception is caught and logged to
+ * `console.error` so instrumentation never disrupts the SDK's core logic.
+ *
+ * @internal
+ */
+function safeInvoke(hookName: string, fn: () => void): void {
+  try {
+    fn();
+  } catch (err) {
+    // Instrumentation must never crash the SDK.
+    console.error(`[bridge-sdk] observability hook "${hookName}" threw:`, err);
+  }
+}
+
+/**
+ * Fire `hooks.onTransactionStart` safely.
+ * @internal
+ */
+export function fireTransactionStart(
+  hooks: ObservabilityHooks | undefined,
+  method: string,
+  params: unknown,
+): void {
+  if (hooks?.onTransactionStart) {
+    safeInvoke('onTransactionStart', () => hooks.onTransactionStart!(method, params));
+  }
+}
+
+/**
+ * Fire `hooks.onTransactionSuccess` safely.
+ * @internal
+ */
+export function fireTransactionSuccess(
+  hooks: ObservabilityHooks | undefined,
+  method: string,
+  result: unknown,
+  durationMs: number,
+): void {
+  if (hooks?.onTransactionSuccess) {
+    safeInvoke('onTransactionSuccess', () =>
+      hooks.onTransactionSuccess!(method, result, durationMs),
+    );
+  }
+}
+
+/**
+ * Fire `hooks.onTransactionError` safely.
+ * @internal
+ */
+export function fireTransactionError(
+  hooks: ObservabilityHooks | undefined,
+  method: string,
+  error: Error,
+  durationMs: number,
+): void {
+  if (hooks?.onTransactionError) {
+    safeInvoke('onTransactionError', () =>
+      hooks.onTransactionError!(method, error, durationMs),
+    );
+  }
+}
+
+/**
+ * Fire `hooks.onRpcCall` safely.
+ * @internal
+ */
+export function fireRpcCall(
+  hooks: ObservabilityHooks | undefined,
+  method: string,
+  params: unknown,
+  durationMs: number,
+): void {
+  if (hooks?.onRpcCall) {
+    safeInvoke('onRpcCall', () => hooks.onRpcCall!(method, params, durationMs));
+  }
+}
+
+/**
+ * Helper that wraps an async function with transaction lifecycle hooks.
+ *
+ * Records `onTransactionStart` before execution, `onTransactionSuccess` on
+ * return, and `onTransactionError` if the function throws.
+ *
+ * @internal
+ */
+export async function withTransactionHooks<T>(
+  hooks: ObservabilityHooks | undefined,
+  method: string,
+  params: unknown,
+  fn: () => Promise<T>,
+): Promise<T> {
+  fireTransactionStart(hooks, method, params);
+  const start = Date.now();
+  try {
+    const result = await fn();
+    fireTransactionSuccess(hooks, method, result, Date.now() - start);
+    return result;
+  } catch (err: any) {
+    fireTransactionError(
+      hooks,
+      method,
+      err instanceof Error ? err : new Error(String(err)),
+      Date.now() - start,
+    );
+    throw err;
+  }
+}
+
+/**
+ * Helper that wraps an async RPC call and fires `onRpcCall` when it completes
+ * (whether successfully or not).
+ *
+ * @internal
+ */
+export async function withRpcHook<T>(
+  hooks: ObservabilityHooks | undefined,
+  rpcMethod: string,
+  params: unknown,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const start = Date.now();
+  try {
+    return await fn();
+  } finally {
+    fireRpcCall(hooks, rpcMethod, params, Date.now() - start);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Built-in console logger
+// ---------------------------------------------------------------------------
+
+/**
+ * A ready-made {@link ObservabilityHooks} implementation that writes structured
+ * log lines to the console using the `[bridge-sdk]` prefix.
+ *
+ * - `onTransactionStart` / `onTransactionSuccess` write to `console.log`.
+ * - `onTransactionError` writes to `console.error`.
+ * - `onRpcCall` writes to `console.log`.
+ *
+ * Pass this directly as `BridgeConfig.hooks` for zero-config debug output:
+ *
+ * @example
+ * ```ts
+ * import { OnboardingBridgeSDK, ConsoleLogger } from '@stellar/c-address-onboarding-bridge-sdk';
+ *
+ * const sdk = new OnboardingBridgeSDK({
+ *   contractId: 'CA...',
+ *   rpcUrl: 'https://soroban-testnet.stellar.org',
+ *   networkPassphrase: Networks.TESTNET,
+ *   hooks: ConsoleLogger,
+ * });
+ * ```
+ *
+ * Sample output:
+ * ```
+ * [bridge-sdk] tx:start  fundCAddress {"source":"G...","target":"C...","asset":"C...","amount":"1000000"}
+ * [bridge-sdk] rpc:call  sendTransaction {"contractMethod":"fund_c_address"} 142ms
+ * [bridge-sdk] tx:ok     fundCAddress {"hash":"abc...","status":"pending"} 185ms
+ * ```
+ */
+export const ConsoleLogger: ObservabilityHooks = {
+  onTransactionStart(method: string, params: unknown): void {
+    console.log(
+      `[bridge-sdk] tx:start  ${method}`,
+      JSON.stringify(params, null, 0),
+    );
+  },
+
+  onTransactionSuccess(method: string, result: unknown, durationMs: number): void {
+    console.log(
+      `[bridge-sdk] tx:ok     ${method}`,
+      JSON.stringify(result, null, 0),
+      `${durationMs}ms`,
+    );
+  },
+
+  onTransactionError(method: string, error: Error, durationMs: number): void {
+    console.error(
+      `[bridge-sdk] tx:error  ${method}`,
+      error.message,
+      `${durationMs}ms`,
+    );
+  },
+
+  onRpcCall(method: string, params: unknown, durationMs: number): void {
+    console.log(
+      `[bridge-sdk] rpc:call  ${method}`,
+      JSON.stringify(params, null, 0),
+      `${durationMs}ms`,
+    );
+  },
+};
+
+// ---------------------------------------------------------------------------
+// OpenTelemetry integration
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal subset of the `@opentelemetry/api` `Span` interface used internally.
+ * Keeping this narrow means the module compiles even when `@opentelemetry/api`
+ * is not installed — the type is only resolved when the caller provides a real
+ * `Tracer` object at runtime.
+ *
+ * @internal
+ */
+interface OtelSpan {
+  setAttribute(key: string, value: string | number | boolean): this;
+  setStatus(status: { code: number; message?: string }): this;
+  recordException(exception: Error | { message: string }): this;
+  end(): void;
+}
+
+/**
+ * Minimal subset of the `@opentelemetry/api` `Tracer` interface.
+ * @internal
+ */
+interface OtelTracer {
+  startSpan(name: string, options?: Record<string, unknown>): OtelSpan;
+}
+
+/**
+ * SpanStatusCode enum values as numeric constants so this file compiles
+ * without a hard dependency on `@opentelemetry/api`.
+ * - `0` = UNSET, `1` = OK, `2` = ERROR
+ * @internal
+ */
+const SpanStatusCode = { UNSET: 0, OK: 1, ERROR: 2 } as const;
+
+/**
+ * Options for {@link createOpenTelemetryHooks}.
+ */
+export interface OpenTelemetryHooksOptions {
+  /**
+   * If `true`, RPC calls are recorded as **child spans** of the enclosing
+   * transaction span.  Adds more granularity at the cost of more spans.
+   * Defaults to `true`.
+   */
+  traceRpcCalls?: boolean;
+
+  /**
+   * Prefix for all span names.  Defaults to `'bridge-sdk'`.
+   * @example 'my-service/bridge-sdk'
+   */
+  spanPrefix?: string;
+}
+
+/**
+ * Create an {@link ObservabilityHooks} implementation backed by an
+ * OpenTelemetry `Tracer`.
+ *
+ * Each mutating SDK method becomes a span with:
+ * - `bridge.method` — the SDK method name.
+ * - `bridge.tx.hash` — the transaction hash on success.
+ * - `bridge.tx.status` — `'pending'`, `'success'`, or `'failed'`.
+ * - `bridge.duration_ms` — wall-clock duration.
+ *
+ * RPC calls (when `traceRpcCalls` is true, the default) produce spans with:
+ * - `rpc.method` — the RPC method label.
+ * - `rpc.duration_ms` — round-trip duration.
+ *
+ * @param tracer  - An OpenTelemetry `Tracer` instance obtained from
+ *                  `trace.getTracer('bridge-sdk', '0.1.0')`.
+ * @param options - Optional configuration.
+ *
+ * @returns An {@link ObservabilityHooks} object ready to pass to `BridgeConfig.hooks`.
+ *
+ * @example
+ * ```ts
+ * import { trace } from '@opentelemetry/api';
+ * import { OnboardingBridgeSDK, createOpenTelemetryHooks } from '...';
+ *
+ * const tracer = trace.getTracer('my-service', '1.0.0');
+ *
+ * const sdk = new OnboardingBridgeSDK({
+ *   contractId: 'CA...',
+ *   rpcUrl: 'https://soroban-testnet.stellar.org',
+ *   networkPassphrase: Networks.TESTNET,
+ *   hooks: createOpenTelemetryHooks(tracer),
+ * });
+ * ```
+ */
+export function createOpenTelemetryHooks(
+  tracer: OtelTracer,
+  options: OpenTelemetryHooksOptions = {},
+): ObservabilityHooks {
+  const { traceRpcCalls = true, spanPrefix = 'bridge-sdk' } = options;
+
+  // Map from method name → active span, so we can end it in success/error.
+  // Using a simple Map is sufficient because SDK calls are typically awaited
+  // sequentially per instance.  Concurrent calls to the same method will
+  // create overlapping entries, but each key is overwritten; the last span wins.
+  // For highly concurrent usage, consider keying by a correlation ID instead.
+  const activeSpans = new Map<string, OtelSpan>();
+
+  return {
+    onTransactionStart(method: string, params: unknown): void {
+      const span = tracer.startSpan(`${spanPrefix}/${method}`);
+      span.setAttribute('bridge.method', method);
+      // Safely stringify params (may contain non-serialisable values)
+      try {
+        span.setAttribute('bridge.params', JSON.stringify(params));
+      } catch {
+        span.setAttribute('bridge.params', '[unserializable]');
+      }
+      activeSpans.set(method, span);
+    },
+
+    onTransactionSuccess(method: string, result: unknown, durationMs: number): void {
+      const span = activeSpans.get(method);
+      if (!span) return;
+      activeSpans.delete(method);
+
+      span.setAttribute('bridge.duration_ms', durationMs);
+
+      // Extract hash and status from TransactionResult (or array of results)
+      if (Array.isArray(result)) {
+        const hashes = result
+          .map((r: any) => r?.hash)
+          .filter(Boolean)
+          .join(',');
+        span.setAttribute('bridge.tx.hashes', hashes);
+        const anyFailed = result.some((r: any) => r?.status === 'failed');
+        span.setAttribute('bridge.tx.status', anyFailed ? 'partial_failure' : 'pending');
+      } else if (result && typeof result === 'object') {
+        const r = result as any;
+        if (r.hash != null) span.setAttribute('bridge.tx.hash', r.hash);
+        if (r.status != null) span.setAttribute('bridge.tx.status', r.status);
+        if (r.error != null) span.setAttribute('bridge.tx.error', r.error);
+      }
+
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+    },
+
+    onTransactionError(method: string, error: Error, durationMs: number): void {
+      const span = activeSpans.get(method);
+      if (!span) return;
+      activeSpans.delete(method);
+
+      span.setAttribute('bridge.duration_ms', durationMs);
+      span.setStatus({ code: SpanStatusCode.ERROR, message: error.message });
+      span.recordException(error);
+      span.end();
+    },
+
+    onRpcCall(method: string, params: unknown, durationMs: number): void {
+      if (!traceRpcCalls) return;
+
+      const span = tracer.startSpan(`${spanPrefix}/rpc/${method}`);
+      span.setAttribute('rpc.method', method);
+      span.setAttribute('rpc.duration_ms', durationMs);
+      try {
+        span.setAttribute('rpc.params', JSON.stringify(params));
+      } catch {
+        span.setAttribute('rpc.params', '[unserializable]');
+      }
+      span.setStatus({ code: SpanStatusCode.OK });
+      span.end();
+    },
+  };
+}
+
+/**
+ * Compose multiple {@link ObservabilityHooks} instances into one.
+ *
+ * All hooks are called in the order they are supplied.  If one hook throws,
+ * the error is swallowed and the remaining hooks are still invoked.
+ *
+ * Useful for combining the built-in {@link ConsoleLogger} with a custom
+ * metrics hook in development:
+ *
+ * @example
+ * ```ts
+ * import { composeHooks, ConsoleLogger } from '...';
+ *
+ * const sdk = new OnboardingBridgeSDK({
+ *   // ...
+ *   hooks: composeHooks(ConsoleLogger, myMetricsHooks),
+ * });
+ * ```
+ */
+export function composeHooks(...hooks: ObservabilityHooks[]): ObservabilityHooks {
+  return {
+    onTransactionStart(method, params) {
+      for (const h of hooks) {
+        if (h.onTransactionStart) {
+          safeInvoke('onTransactionStart', () => h.onTransactionStart!(method, params));
+        }
+      }
+    },
+    onTransactionSuccess(method, result, durationMs) {
+      for (const h of hooks) {
+        if (h.onTransactionSuccess) {
+          safeInvoke('onTransactionSuccess', () =>
+            h.onTransactionSuccess!(method, result, durationMs),
+          );
+        }
+      }
+    },
+    onTransactionError(method, error, durationMs) {
+      for (const h of hooks) {
+        if (h.onTransactionError) {
+          safeInvoke('onTransactionError', () =>
+            h.onTransactionError!(method, error, durationMs),
+          );
+        }
+      }
+    },
+    onRpcCall(method, params, durationMs) {
+      for (const h of hooks) {
+        if (h.onRpcCall) {
+          safeInvoke('onRpcCall', () => h.onRpcCall!(method, params, durationMs));
+        }
+      }
+    },
+  };
+}

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -9,6 +9,7 @@
  */
 
 import type { RpcRetryOptions } from './retry';
+import type { ObservabilityHooks } from './observability';
 
 // ---------------------------------------------------------------------------
 // SDK configuration
@@ -81,6 +82,40 @@ export interface BridgeConfig {
    * ```
    */
   retry?: RpcRetryOptions;
+
+  /**
+   * Optional observability hooks for instrumenting SDK method calls and RPC
+   * round-trips.  Supply any subset of the four callbacks to integrate with
+   * your metrics, logging, or tracing infrastructure.
+   *
+   * Two ready-made implementations are provided:
+   * - {@link ConsoleLogger} — structured JSON lines to the console (debug mode).
+   * - {@link createOpenTelemetryHooks} — OpenTelemetry span tracing.
+   *
+   * @example
+   * ```ts
+   * import { ConsoleLogger } from '@stellar/c-address-onboarding-bridge-sdk';
+   *
+   * const sdk = new OnboardingBridgeSDK({
+   *   contractId: 'CA...',
+   *   rpcUrl: 'https://soroban-testnet.stellar.org',
+   *   networkPassphrase: Networks.TESTNET,
+   *   hooks: ConsoleLogger,
+   * });
+   * ```
+   *
+   * @example
+   * ```ts
+   * import { trace } from '@opentelemetry/api';
+   * import { createOpenTelemetryHooks } from '@stellar/c-address-onboarding-bridge-sdk';
+   *
+   * const sdk = new OnboardingBridgeSDK({
+   *   // ...
+   *   hooks: createOpenTelemetryHooks(trace.getTracer('bridge-sdk')),
+   * });
+   * ```
+   */
+  hooks?: ObservabilityHooks;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
feat(sdk): Add observability hooks + OpenTelemetry integration
  
  Summary
  
  Adds a first-class observability layer to the SDK so integrators can instrument every contract
  call and RPC round-trip without patching the SDK itself.
  
  What's changed
  
  New file: sdk/src/observability.ts
  
  - ObservabilityHooks interface — 4 optional callbacks:
    - onTransactionStart(method, params) — fires before any mutating SDK method executes
    - onTransactionSuccess(method, result, durationMs) — fires on clean return
    - onTransactionError(method, error, durationMs) — fires on unhandled exception
    - onRpcCall(method, params, durationMs) — fires after every internal RPC round-trip
  (simulate, getAccount, sendTransaction, etc.)
  
  - ConsoleLogger — drop-in built-in implementation that writes structured lines to
  console.log/console.error, zero config needed
  - createOpenTelemetryHooks(tracer, options?) — factory that maps SDK calls to OTel spans with
  full attribute propagation; no hard dependency on @opentelemetry/api (structural typing only)
  - composeHooks(...hooks) — merge multiple hook sets into one, e.g. combine ConsoleLogger with a
  custom metrics hook
  - Internal helpers: withTransactionHooks, withRpcHook, fire* — used by the SDK internals, not
  part of the public surface
  
  sdk/src/types.ts
  
  - BridgeConfig now accepts an optional hooks?: ObservabilityHooks field with full JSDoc and
  usage examples
  
  sdk/src/bridge.ts
  
  - All mutating methods (fundCAddress, batchFundCAddresses, fundCAddressWithSwap, withdrawFees,
  reclaimTokens, setFee, setFeeCollector, setAdmin, upgrade, fundCrosschain, addRelayer,
  removeRelayer, setRelayerThreshold, createCAddress) wrapped with withTransactionHooks
  - Every internal RPC call within those methods wrapped with withRpcHook for per-call timing
  
  Usage
  
  // Zero-config debug logging
  const sdk = new OnboardingBridgeSDK({
    contractId: 'CA...',
    rpcUrl: 'https://soroban-testnet.stellar.org',
    networkPassphrase: Networks.TESTNET,
    hooks: ConsoleLogger,
  });
  
  // OpenTelemetry tracing
  import { trace } from '@opentelemetry/api';
  
  const sdk = new OnboardingBridgeSDK({
    ...config,
    hooks: createOpenTelemetryHooks(trace.getTracer('bridge-sdk', '0.1.0')),
  });
  
  // Compose multiple hooks
  const sdk = new OnboardingBridgeSDK({
    ...config,
    hooks: composeHooks(ConsoleLogger, myMetricsHooks),
  });
  
  Notes
  
  - Hooks are fully optional — existing code with no hooks field is unaffected
  - Hook exceptions are swallowed so instrumentation never disrupts the core SDK flow
  - No new required dependencies; @opentelemetry/api is a peer dep (optional)
 closes #65
