### PR TITLE
fix(sdk): strongly type deployerKeypair in CreateCOptions (fixes #271)

### DIFF
--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -8,6 +8,7 @@
  * @module types
  */
 
+import type { Keypair } from '@stellar/stellar-sdk';
 import type { RpcRetryOptions } from './retry';
 import type { ObservabilityHooks } from './observability';
 
@@ -665,7 +666,7 @@ export interface CreateCOptions {
    * Keypair used to sign the contract-creation transaction.
    * This account pays the deployment fees.
    */
-  deployerKeypair: any;
+  deployerKeypair: Keypair;
 
   /**
    * Optional 32-byte salt for deterministic address derivation, as a hex string.


### PR DESCRIPTION
## Summary
Fixes #271.

## Changes
- Updated `deployerKeypair` in `CreateCOptions` interface in `sdk/src/types.ts` from `any` to `Keypair` imported from `@stellar/stellar-sdk`.

## Verification
- Ran `npx tsc --noEmit` and `npm test` in `sdk/`, all 165 unit tests pass and TypeScript check passes cleanly.