### PR TITLE
fix(sdk): strongly type parameters for fundCAddressWithSwap (fixes #272)

### DIFF
--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -265,7 +265,7 @@ export class OnboardingBridgeSDK {
    */
   async fundCAddressWithSwap(
     options: FundCAddressWithSwapOptions,
-    sourceKeypair: any,
+    sourceKeypair: Keypair,
   ): Promise<TransactionResult> {
     return withTransactionHooks(
       this.hooks,

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -6,6 +6,7 @@
  */
 import {
   BridgeConfig,
+  FundCAddressWithSwapOptions,
   TransactionResult,
 } from './types';
 import { assertAccountAddress, assertContractAddress } from './validate';
@@ -264,7 +265,7 @@ class ContractClient {
     return this.submitMutation('fundCAddress', tx, sourceKeypair);
   }
 
-  async fundCAddressWithSwap(options: any, sourceKeypair: Keypair): Promise<TransactionResult> {
+  async fundCAddressWithSwap(options: FundCAddressWithSwapOptions, sourceKeypair: Keypair): Promise<TransactionResult> {
     assertAccountAddress(options.source, 'source');
     assertContractAddress(options.target, 'target');
     assertContractAddress(options.sourceAsset, 'sourceAsset');


### PR DESCRIPTION
## Summary
Fixes #272.

## Changes
- Updated `sourceKeypair` parameter type in `OnboardingBridgeSDK.fundCAddressWithSwap` (`sdk/src/bridge.ts`) from `any` to `Keypair`.
- Updated `options` parameter type in `CachedOnboardingBridgeSDK.fundCAddressWithSwap` (`sdk/src/cachedBridge.ts`) from `any` to `FundCAddressWithSwapOptions`.

## Verification
- Ran `npx tsc --noEmit` and `npm test` in `sdk/`, all 165 unit tests pass and TypeScript check passes cleanly.