### PR TITLE
Fix/bridge security hardening

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -145,6 +145,8 @@ pub enum BridgeError {
     MetaTxNonceAlreadyUsed = 39,
     /// The contract is deactivated (permanently paused/migrated).
     ContractDeactivated = 40,
+    /// The same relayer pubkey appeared more than once in `sigs`.
+    DuplicateRelayerSignature = 41,
 }
 
 // ---------------------------------------------------------------------------
@@ -3274,6 +3276,8 @@ impl OnboardingBridge {
     /// * [`BridgeError::ReplayedNonce`] — This `(chain_id, tx_hash)` combination
     ///   has already been processed.
     /// * [`BridgeError::NotRelayer`] — A signature's pubkey is not a registered relayer.
+    /// * [`BridgeError::DuplicateRelayerSignature`] — The same relayer pubkey
+    ///   appears more than once in `sigs`.
     /// * [`BridgeError::BelowThreshold`] — Fewer than `threshold` valid signatures.
     ///
     /// # Events
@@ -3286,10 +3290,10 @@ impl OnboardingBridge {
     /// marked used before the token transfer, preventing replay attacks. An
     /// invalid Ed25519 signature causes a host-level trap (panic) rather than
     /// returning an error code, so callers should pre-validate signatures
-    /// off-chain. The contract does not verify that `sigs` contains distinct
-    /// pubkeys — a single relayer submitting the same signature twice counts
-    /// as two signatures and could satisfy a threshold of 2. Callers and
-    /// relayer infrastructure should deduplicate signatures before submission.
+    /// off-chain. The contract verifies that `sigs` contains distinct
+    /// pubkeys — a relayer submitting the same signature twice only counts
+    /// once toward the threshold; duplicates are rejected with
+    /// [`BridgeError::DuplicateRelayerSignature`].
     pub fn fund_c_address_crosschain(
         env: Env,
         chain_id: u32,
@@ -3351,17 +3355,25 @@ impl OnboardingBridge {
 
         let payload_hash: BytesN<32> = env.crypto().sha256(&payload).into();
 
-        // Verify M-of-N relayer signatures
+        // Verify M-of-N relayer signatures. Each relayer pubkey may only be
+        // counted once — track pubkeys already seen and reject duplicates so
+        // a single relayer's signature submitted twice cannot satisfy a
+        // threshold of 2 (or more).
         let threshold = relayer_threshold(&env);
         let mut valid: u32 = 0;
+        let mut seen_pubkeys: Vec<BytesN<32>> = Vec::new(&env);
         for i in 0..sigs.len() {
             let sig = sigs.get(i).unwrap();
             if !is_relayer(&env, &sig.pubkey) {
                 return Err(BridgeError::NotRelayer);
             }
+            if seen_pubkeys.contains(&sig.pubkey) {
+                return Err(BridgeError::DuplicateRelayerSignature);
+            }
             // Panics (traps) on invalid sig — convert to error via try pattern
             env.crypto()
                 .ed25519_verify(&sig.pubkey, &payload_hash.clone().into(), &sig.signature);
+            seen_pubkeys.push_back(sig.pubkey.clone());
             valid += 1;
         }
         if valid < threshold {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -147,6 +147,8 @@ pub enum BridgeError {
     ContractDeactivated = 40,
     /// The same relayer pubkey appeared more than once in `sigs`.
     DuplicateRelayerSignature = 41,
+    /// A pool address in `swap_route` is not on the swap-pool whitelist.
+    PoolNotWhitelisted = 42,
 }
 
 // ---------------------------------------------------------------------------
@@ -212,6 +214,8 @@ pub enum DataKey {
     // Issue #35: EIP-712-style meta-transaction used nonces
     MetaTxNonce(Address, u64),
     Deactivated,
+    // Admin-managed whitelist of DEX pool addresses usable in `swap_route`.
+    PoolWhitelist,
 }
 
 // ---------------------------------------------------------------------------
@@ -655,6 +659,30 @@ fn save_whitelist(env: &Env, whitelist: &Map<Address, bool>) {
 fn check_asset_whitelisted(env: &Env, asset: &Address) -> Result<(), BridgeError> {
     if !read_whitelist(env).get(asset.clone()).unwrap_or(false) {
         return Err(BridgeError::AssetNotWhitelisted);
+    }
+    Ok(())
+}
+
+// fund_c_address_with_swap must not invoke arbitrary caller-supplied pool
+// addresses. Mirrors the asset whitelist pattern above.
+#[inline(never)]
+fn read_pool_whitelist(env: &Env) -> Map<Address, bool> {
+    env.storage()
+        .instance()
+        .get(&DataKey::PoolWhitelist)
+        .unwrap_or_else(|| Map::new(env))
+}
+
+#[inline(never)]
+fn save_pool_whitelist(env: &Env, whitelist: &Map<Address, bool>) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PoolWhitelist, whitelist);
+}
+
+fn check_pool_whitelisted(env: &Env, pool: &Address) -> Result<(), BridgeError> {
+    if !read_pool_whitelist(env).get(pool.clone()).unwrap_or(false) {
+        return Err(BridgeError::PoolNotWhitelisted);
     }
     Ok(())
 }
@@ -3057,6 +3085,81 @@ impl OnboardingBridge {
     }
 
     // -----------------------------------------------------------------------
+    // Swap pool whitelist
+    // -----------------------------------------------------------------------
+
+    /// Adds `pool` to the DEX swap-pool whitelist.
+    ///
+    /// Only whitelisted pool addresses may appear in the `swap_route` passed
+    /// to `fund_c_address_with_swap`. Adding a pool that is already
+    /// whitelisted is idempotent.
+    ///
+    /// # Arguments
+    ///
+    /// * `pool` (`Address`) — The DEX pool contract address to whitelist.
+    /// * `nonce` (`Option<u64>`) — Optional sequential nonce for the admin.
+    ///
+    /// # Authorization
+    ///
+    /// Requires the current admin's `require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
+    pub fn add_swap_pool(env: Env, pool: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        let mut whitelist = read_pool_whitelist(&env);
+        whitelist.set(pool, true);
+        save_pool_whitelist(&env, &whitelist);
+        Ok(())
+    }
+
+    /// Removes `pool` from the DEX swap-pool whitelist.
+    ///
+    /// After removal, any `fund_c_address_with_swap` call whose `swap_route`
+    /// references this pool returns [`BridgeError::PoolNotWhitelisted`].
+    ///
+    /// # Arguments
+    ///
+    /// * `pool` (`Address`) — The DEX pool contract address to remove.
+    /// * `nonce` (`Option<u64>`) — Optional sequential nonce for the admin.
+    ///
+    /// # Authorization
+    ///
+    /// Requires the current admin's `require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
+    pub fn remove_swap_pool(env: Env, pool: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        let mut whitelist = read_pool_whitelist(&env);
+        whitelist.remove(pool);
+        save_pool_whitelist(&env, &whitelist);
+        Ok(())
+    }
+
+    /// Returns `true` if `pool` is currently on the swap-pool whitelist.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    pub fn query_is_pool_whitelisted(env: Env, pool: Address) -> Result<bool, BridgeError> {
+        check_initialized(&env)?;
+        Ok(read_pool_whitelist(&env).get(pool).unwrap_or(false))
+    }
+
+    // -----------------------------------------------------------------------
     // Loyalty token
     // -----------------------------------------------------------------------
 
@@ -4228,8 +4331,9 @@ impl OnboardingBridge {
     /// * `source_amount` — Gross amount of `source_asset` to pull from source.
     /// * `min_target_amount` — Slippage guard: revert if the swap yields less.
     /// * `swap_route` — Ordered list of DEX pool contract addresses. At least
-    ///   one pool is required. Each pool must implement the interface:
-    ///   `swap(amount_in: i128, min_amount_out: i128, to: Address) -> i128`.
+    ///   one pool is required, and every pool must be on the swap-pool
+    ///   whitelist (see `add_swap_pool`). Each pool must implement the
+    ///   interface: `swap(amount_in: i128, min_amount_out: i128, to: Address) -> i128`.
     ///
     /// # Authorization
     ///
@@ -4243,8 +4347,22 @@ impl OnboardingBridge {
     /// * [`BridgeError::AddressBlocked`] — `target` is on the blocklist.
     /// * [`BridgeError::AddressNotAllowlisted`] — Allowlist mode is on and `target` is not listed.
     /// * [`BridgeError::AssetNotWhitelisted`] — `target_asset` is not whitelisted.
+    /// * [`BridgeError::PoolNotWhitelisted`] — A pool in `swap_route` is not
+    ///   on the swap-pool whitelist.
     /// * [`BridgeError::SwapFailed`] — A pool returned zero tokens out.
     /// * [`BridgeError::SlippageExceeded`] — Swap output < `min_target_amount`.
+    ///
+    /// # Security Considerations
+    ///
+    /// `swap_route` addresses are invoked with `env.invoke_contract` after
+    /// the contract has already transferred tokens to them. Without a
+    /// whitelist, a malicious or unvetted pool could keep the transferred
+    /// tokens and return a fabricated `amount_out`, effectively stealing
+    /// from the source. Every address in `swap_route` is therefore required
+    /// to be present in the admin-managed pool whitelist (`add_swap_pool` /
+    /// `remove_swap_pool`), which mirrors the existing asset whitelist
+    /// pattern. Only the admin should whitelist pools, and only after
+    /// auditing their `swap` implementation and token-return behavior.
     pub fn fund_c_address_with_swap(
         env: Env,
         source: Address,
@@ -4266,6 +4384,13 @@ impl OnboardingBridge {
         check_access(&env, &target)?;
         // Only the output asset needs to be whitelisted (what arrives at target).
         check_asset_whitelisted(&env, &target_asset)?;
+
+        // Every pool address in the route must be admin-whitelisted; otherwise
+        // a malicious/unvetted pool could keep the transferred tokens and
+        // return a fabricated amount_out. See "Security Considerations" above.
+        for pool in swap_route.iter() {
+            check_pool_whitelisted(&env, &pool)?;
+        }
 
         source.require_auth();
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -275,6 +275,10 @@ pub struct AssetCounters {
     pub total_bridged: i128,
     /// Cumulative gross fees collected since deployment.
     pub total_fees_collected: i128,
+    /// Sum of `TimelockEntry.amount` for entries not yet claimed. Sits in the
+    /// contract's token balance but is not owned by the fee collector or
+    /// available for `reclaim_tokens`.
+    pub locked_timelock: i128,
 }
 
 /// A volume-based fee tier.
@@ -712,7 +716,20 @@ fn read_asset_counters(env: &Env, asset: &Address) -> AssetCounters {
             accrued_fees: 0,
             total_bridged: 0,
             total_fees_collected: 0,
+            locked_timelock: 0,
         })
+}
+
+fn increment_locked_timelock(env: &Env, asset: &Address, amount: i128) {
+    let mut c = read_asset_counters(env, asset);
+    c.locked_timelock += amount;
+    save_asset_counters(env, asset, &c);
+}
+
+fn decrement_locked_timelock(env: &Env, asset: &Address, amount: i128) {
+    let mut c = read_asset_counters(env, asset);
+    c.locked_timelock -= amount;
+    save_asset_counters(env, asset, &c);
 }
 
 fn save_asset_counters(env: &Env, asset: &Address, counters: &AssetCounters) {
@@ -2965,10 +2982,16 @@ impl OnboardingBridge {
     ///
     /// # Security Considerations
     ///
-    /// The check `reclaimable = balance − accrued_fees` ensures that fee
-    /// reserves are ring-fenced. However, timelocked funds also sit in the
-    /// contract balance and are not tracked separately. Do not reclaim tokens
-    /// if there are active timelocks denominated in the same asset.
+    /// The check `reclaimable = balance − accrued_fees − locked_timelock`
+    /// ensures that both fee reserves and unclaimed `TimelockEntry` deposits
+    /// are ring-fenced: `locked_timelock` is a running per-asset total
+    /// incremented in `fund_c_address_timelocked` and decremented in
+    /// `claim_timelocked`, so admins cannot drain tokens that are owed to a
+    /// pending timelock claim. Unrevealed `CommitmentEntry` records created
+    /// by `commit_fund` never hold contract balance in the first place —
+    /// `reveal_fund` pulls the tokens from `source` and forwards them to
+    /// `target` atomically within a single call — so no separate accounting
+    /// is required for them.
     pub fn reclaim_tokens(
         env: Env,
         asset: Address,
@@ -2987,8 +3010,8 @@ impl OnboardingBridge {
 
         let token_client = token::Client::new(&env, &asset);
         let contract_balance = token_client.balance(&env.current_contract_address());
-        let accrued = read_accrued_fees(&env, &asset);
-        let reclaimable = contract_balance - accrued;
+        let counters = read_asset_counters(&env, &asset);
+        let reclaimable = contract_balance - counters.accrued_fees - counters.locked_timelock;
 
         if reclaimable < amount {
             return Err(BridgeError::InsufficientReclaimable);
@@ -3710,6 +3733,8 @@ impl OnboardingBridge {
                 claimed: false,
             },
         );
+        // Ring-fence this deposit so reclaim_tokens cannot drain it before claim.
+        increment_locked_timelock(&env, &asset, amount);
 
         env.events().publish(
             ("TimelockCreated", source, target),
@@ -3769,6 +3794,10 @@ impl OnboardingBridge {
 
         entry.claimed = true;
         save_timelock_entry(&env, id, &entry);
+        // This entry's full deposit is leaving the "locked" pool: the fee
+        // portion is now tracked in accrued_fees and net_amount leaves the
+        // contract balance entirely.
+        decrement_locked_timelock(&env, &entry.asset, entry.amount);
 
         let fee_bps = read_fee_bps(&env);
         let effective_fee_bps = get_effective_fee_bps(&env, &entry.asset, fee_bps);

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -149,6 +149,8 @@ pub enum BridgeError {
     DuplicateRelayerSignature = 41,
     /// A pool address in `swap_route` is not on the swap-pool whitelist.
     PoolNotWhitelisted = 42,
+    /// `swap_route` contained more than one hop; multi-hop swaps are not supported.
+    MultiHopNotSupported = 43,
 }
 
 // ---------------------------------------------------------------------------
@@ -4315,9 +4317,8 @@ impl OnboardingBridge {
     ///
     /// Flow:
     /// 1. Pull `source_amount` of `source_asset` from `source` into the contract.
-    /// 2. Walk `swap_route` (a sequence of DEX pool contract addresses) swapping
-    ///    the running balance through each pool using the standard two-token
-    ///    `swap(amount_in, min_amount_out, to)` interface.
+    /// 2. Invoke the single whitelisted pool in `swap_route` using the standard
+    ///    two-token `swap(min_amount_out, to)` interface.
     /// 3. Verify the final `target_asset` balance received ≥ `min_target_amount`.
     /// 4. Deduct the fee (in `target_asset`) and transfer the net amount to
     ///    `target`.
@@ -4330,10 +4331,10 @@ impl OnboardingBridge {
     /// * `target_asset` — Token contract the target should receive (e.g. XLM).
     /// * `source_amount` — Gross amount of `source_asset` to pull from source.
     /// * `min_target_amount` — Slippage guard: revert if the swap yields less.
-    /// * `swap_route` — Ordered list of DEX pool contract addresses. At least
-    ///   one pool is required, and every pool must be on the swap-pool
-    ///   whitelist (see `add_swap_pool`). Each pool must implement the
-    ///   interface: `swap(amount_in: i128, min_amount_out: i128, to: Address) -> i128`.
+    /// * `swap_route` — Must contain exactly one DEX pool contract address,
+    ///   and that address must be on the swap-pool whitelist (see
+    ///   `add_swap_pool`). The pool must implement:
+    ///   `swap(min_amount_out: i128, to: Address) -> i128`.
     ///
     /// # Authorization
     ///
@@ -4347,9 +4348,11 @@ impl OnboardingBridge {
     /// * [`BridgeError::AddressBlocked`] — `target` is on the blocklist.
     /// * [`BridgeError::AddressNotAllowlisted`] — Allowlist mode is on and `target` is not listed.
     /// * [`BridgeError::AssetNotWhitelisted`] — `target_asset` is not whitelisted.
-    /// * [`BridgeError::PoolNotWhitelisted`] — A pool in `swap_route` is not
+    /// * [`BridgeError::MultiHopNotSupported`] — `swap_route` does not contain
+    ///   exactly one pool.
+    /// * [`BridgeError::PoolNotWhitelisted`] — The pool in `swap_route` is not
     ///   on the swap-pool whitelist.
-    /// * [`BridgeError::SwapFailed`] — A pool returned zero tokens out.
+    /// * [`BridgeError::SwapFailed`] — The pool returned zero tokens out.
     /// * [`BridgeError::SlippageExceeded`] — Swap output < `min_target_amount`.
     ///
     /// # Security Considerations
@@ -4363,6 +4366,14 @@ impl OnboardingBridge {
     /// `remove_swap_pool`), which mirrors the existing asset whitelist
     /// pattern. Only the admin should whitelist pools, and only after
     /// auditing their `swap` implementation and token-return behavior.
+    ///
+    /// Multi-hop routes are intentionally out of scope: the contract cannot
+    /// generally know which token an intermediate pool actually returns, and
+    /// assuming it equals `target_asset` mid-route can cause the contract to
+    /// transfer the wrong token into the next pool. `swap_route` is therefore
+    /// restricted to exactly one hop; longer routes return
+    /// [`BridgeError::MultiHopNotSupported`] rather than silently
+    /// miscomputing the swap.
     pub fn fund_c_address_with_swap(
         env: Env,
         source: Address,
@@ -4385,12 +4396,14 @@ impl OnboardingBridge {
         // Only the output asset needs to be whitelisted (what arrives at target).
         check_asset_whitelisted(&env, &target_asset)?;
 
-        // Every pool address in the route must be admin-whitelisted; otherwise
-        // a malicious/unvetted pool could keep the transferred tokens and
-        // return a fabricated amount_out. See "Security Considerations" above.
-        for pool in swap_route.iter() {
-            check_pool_whitelisted(&env, &pool)?;
+        // Multi-hop routes are out of scope: the contract cannot verify which
+        // token an intermediate pool returns, so only a single, whitelisted
+        // pool is permitted. See "Security Considerations" above.
+        if swap_route.len() != 1 {
+            return Err(BridgeError::MultiHopNotSupported);
         }
+        let pool = swap_route.get(0).unwrap();
+        check_pool_whitelisted(&env, &pool)?;
 
         source.require_auth();
 
@@ -4400,55 +4413,26 @@ impl OnboardingBridge {
         let source_token = token::Client::new(&env, &source_asset);
         source_token.transfer(&source, &contract_addr, &source_amount);
 
-        // Step 2: walk the swap route.
+        // Step 2: invoke the single whitelisted pool.
         // Each pool must implement: swap(min_amount_out: i128, to: Address) -> i128
-        // The contract uses a push model: transfer amount_in to the pool first,
-        // then call swap. The pool detects its received balance and performs the swap.
-        //
-        // For single-hop: source_asset → pool → target_asset
-        // For multi-hop:  each pool's output token must be the next pool's input token;
-        //                 callers are responsible for constructing a valid route.
-        let mut amount_in: i128 = source_amount;
-        let route_len = swap_route.len();
+        // The contract uses a push model: transfer source_amount to the pool
+        // first, then call swap. The pool detects its received balance and
+        // performs the swap, transferring target_asset back to `to`.
+        source_token.transfer(&contract_addr, &pool, &source_amount);
 
-        // Track which token we currently hold in the contract.
-        // Hop 0 input = source_asset; subsequent inputs are determined by the route.
-        let mut current_token = source_asset.clone();
+        let swap_sym = soroban_sdk::Symbol::new(&env, "swap");
+        let swap_args: Vec<soroban_sdk::Val> = soroban_sdk::vec![
+            &env,
+            min_target_amount.into_val(&env),
+            contract_addr.into_val(&env),
+        ];
+        let amount_out: i128 = env.invoke_contract(&pool, &swap_sym, swap_args);
 
-        for (i, pool) in swap_route.iter().enumerate() {
-            let is_last = i as u32 == route_len - 1;
-            // Only enforce min_target_amount on the final hop.
-            let min_out: i128 = if is_last { min_target_amount } else { 1 };
-
-            // Push the current amount into the pool.
-            let input_token_client = token::Client::new(&env, &current_token);
-            input_token_client.transfer(&contract_addr, &pool, &amount_in);
-
-            // Call the pool's swap function. Interface: swap(min_amount_out, to) -> i128
-            // This matches the Phoenix Protocol / Soroswap pool interface.
-            let swap_sym = soroban_sdk::Symbol::new(&env, "swap");
-            let swap_args: Vec<soroban_sdk::Val> = soroban_sdk::vec![
-                &env,
-                min_out.into_val(&env),
-                contract_addr.into_val(&env),
-            ];
-            let amount_out: i128 = env.invoke_contract(&pool, &swap_sym, swap_args);
-
-            if amount_out <= 0 {
-                return Err(BridgeError::SwapFailed);
-            }
-
-            amount_in = amount_out;
-            // After this hop the contract holds the pool's output token.
-            // Update current_token for the next iteration (unused on last hop).
-            if !is_last {
-                // Intermediate token: for multi-hop routes callers construct pools
-                // such that each pool's output is the next pool's input.
-                // We advance current_token to target_asset as a reasonable default;
-                // for more complex routes the caller is responsible for matching tokens.
-                current_token = target_asset.clone();
-            }
+        if amount_out <= 0 {
+            return Err(BridgeError::SwapFailed);
         }
+
+        let amount_in = amount_out;
 
         // Step 3: slippage check on final output.
         if amount_in < min_target_amount {

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -774,6 +774,66 @@ fn test_reclaim_emits_event() {
     assert_eq!(contract_id, &bridge.address);
 }
 
+#[test]
+fn test_reclaim_cannot_drain_active_timelocks() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+    let destination = Address::generate(&env);
+
+    // 500 tokens locked in an unclaimed timelock; nothing else in the balance.
+    let release_time = 1_100u64;
+    let id =
+        bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &release_time, &0u64);
+    assert_eq!(check_balance(&env, &token_id, &bridge.address), 500i128);
+
+    // Locked funds cannot be reclaimed at all before the timelock is claimed.
+    assert_eq!(
+        bridge.try_reclaim_tokens(&token_id, &1i128, &destination, &None),
+        Err(Ok(crate::BridgeError::InsufficientReclaimable))
+    );
+
+    // Tokens sent to the contract by accident, on top of the locked timelock,
+    // remain reclaimable up to the excess only.
+    mint_tokens(&env, &token_id, &bridge.address, 200i128);
+    bridge.reclaim_tokens(&token_id, &200i128, &destination, &None);
+    assert_eq!(check_balance(&env, &token_id, &destination), 200i128);
+    assert_eq!(
+        bridge.try_reclaim_tokens(&token_id, &1i128, &destination, &None),
+        Err(Ok(crate::BridgeError::InsufficientReclaimable))
+    );
+
+    // Once claimed, the timelocked amount leaves the contract balance and is
+    // no longer ring-fenced: freshly accidental tokens are reclaimable again.
+    env.ledger().set_timestamp(release_time + 1);
+    bridge.claim_timelocked(&id);
+    mint_tokens(&env, &token_id, &bridge.address, 50i128);
+    bridge.reclaim_tokens(&token_id, &50i128, &destination, &None);
+}
+
+#[test]
+fn test_reclaim_cannot_drain_active_commitments() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+    let destination = Address::generate(&env);
+
+    // commit_fund never transfers tokens into the contract up front — the
+    // actual transfer happens atomically inside reveal_fund — so an
+    // unrevealed commitment holds no contract balance to protect.
+    let amount_hash: BytesN<32> =
+        env.crypto().sha256(&Bytes::from_array(&env, &[0u8; 24])).into();
+    bridge.commit_fund(&user, &target, &token_id, &amount_hash, &2_000u64);
+
+    // Tokens sent to the contract are fully reclaimable; the pending
+    // commitment does not reduce the reclaimable amount.
+    mint_tokens(&env, &token_id, &bridge.address, 300i128);
+    bridge.reclaim_tokens(&token_id, &300i128, &destination, &None);
+    assert_eq!(check_balance(&env, &token_id, &destination), 300i128);
+}
+
 /********** Asset whitelist tests **********/
 
 #[test]

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -2285,6 +2285,32 @@ mod crosschain_tests {
             Err(Ok(BridgeError::BelowThreshold))
         );
     }
+
+    #[test]
+    fn test_crosschain_duplicate_relayer_signature_rejected() {
+        let env = Env::default();
+        let (_bridge_id, token_id, _admin, bridge) = setup(&env);
+
+        let sk1 = make_signing_key([1u8; 32]);
+        let sk2 = make_signing_key([2u8; 32]);
+
+        bridge.add_relayer(&BytesN::from_array(&env, sk1.verifying_key().as_bytes()));
+        bridge.add_relayer(&BytesN::from_array(&env, sk2.verifying_key().as_bytes()));
+        bridge.set_relayer_threshold(&2u32);
+
+        let target = soroban_sdk::Address::generate(&env);
+        let tx_hash = BytesN::from_array(&env, &[0x33; 32]);
+
+        let payload_hash = build_payload_hash(&env, 1, &tx_hash, &target, &token_id, 100);
+        // Same relayer's signature submitted twice must not satisfy a threshold of 2.
+        let sig = make_relayer_sig(&env, &sk1, &payload_hash);
+        let sigs = Vec::from_array(&env, [sig.clone(), sig]);
+
+        assert_eq!(
+            bridge.try_fund_c_address_crosschain(&1u32, &tx_hash, &target, &token_id, &100i128, &sigs),
+            Err(Ok(BridgeError::DuplicateRelayerSignature))
+        );
+    }
 }
 
 /********** Referral system tests **********/

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1242,6 +1242,61 @@ fn test_swap_rejects_non_whitelisted_pool() {
     assert_eq!(check_balance(&env, &source_token_id, &user), 1_000i128);
 }
 
+#[test]
+fn test_swap_multi_hop_route_rejected() {
+    let env = Env::default();
+    let (bridge, user, source_token_id, target_token_id) = setup_swap(&env);
+
+    let pool1_id = env.register(SwapPool, ());
+    let pool2_id = env.register(SwapPool, ());
+    bridge.add_swap_pool(&pool1_id, &None);
+    bridge.add_swap_pool(&pool2_id, &None);
+
+    let target = Address::generate(&env);
+    // Even though both pools are whitelisted, multi-hop routes must be rejected
+    // rather than silently miscomputing which token the intermediate hop holds.
+    let swap_route = Vec::from_array(&env, [pool1_id, pool2_id]);
+
+    assert_eq!(
+        bridge.try_fund_c_address_with_swap(
+            &user,
+            &target,
+            &source_token_id,
+            &target_token_id,
+            &500i128,
+            &400i128,
+            &swap_route,
+        ),
+        Err(Ok(BridgeError::MultiHopNotSupported))
+    );
+}
+
+#[test]
+fn test_swap_happy_path_single_hop() {
+    let env = Env::default();
+    let (bridge, user, source_token_id, target_token_id) = setup_swap(&env);
+
+    let pool_id = env.register(SwapPool, ());
+    SwapPoolClient::new(&env, &pool_id).initialize(&source_token_id, &target_token_id, &1i128);
+    mint_tokens(&env, &target_token_id, &pool_id, 10_000i128);
+    bridge.add_swap_pool(&pool_id, &None);
+
+    let target = Address::generate(&env);
+    let swap_route = Vec::from_array(&env, [pool_id]);
+
+    bridge.fund_c_address_with_swap(
+        &user,
+        &target,
+        &source_token_id,
+        &target_token_id,
+        &500i128,
+        &400i128,
+        &swap_route,
+    );
+
+    assert_eq!(check_balance(&env, &target_token_id, &target), 500i128);
+}
+
 /********** query_calculate_fee tests **********/
 
 #[test]

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1188,6 +1188,60 @@ mod swap_pool_contract {
 
 use swap_pool_contract::{SwapPool, SwapPoolClient};
 
+/********** fund_c_address_with_swap tests **********/
+
+fn setup_swap(
+    env: &Env,
+) -> (
+    crate::OnboardingBridgeClient<'_>,
+    Address,
+    Address,
+    Address,
+) {
+    let (admin, user, fee_collector) = create_test_users(env);
+    let (bridge_id, source_token_id) = register_all_contracts_mocked(env);
+    let bridge = create_bridge_client(env, &bridge_id);
+    init_token(env, &source_token_id, &admin);
+
+    let target_token_id = env.register(TestToken, ());
+    init_token(env, &target_token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
+    bridge.add_asset(&target_token_id, &None);
+    mint_tokens(env, &source_token_id, &user, 1_000i128);
+
+    (bridge, user, source_token_id, target_token_id)
+}
+
+#[test]
+fn test_swap_rejects_non_whitelisted_pool() {
+    let env = Env::default();
+    let (bridge, user, source_token_id, target_token_id) = setup_swap(&env);
+
+    // A pool that would happily perform the swap, but was never whitelisted.
+    let pool_id = env.register(SwapPool, ());
+    SwapPoolClient::new(&env, &pool_id).initialize(&source_token_id, &target_token_id, &1i128);
+    mint_tokens(&env, &target_token_id, &pool_id, 10_000i128);
+
+    let target = Address::generate(&env);
+    let swap_route = Vec::from_array(&env, [pool_id]);
+
+    assert_eq!(
+        bridge.try_fund_c_address_with_swap(
+            &user,
+            &target,
+            &source_token_id,
+            &target_token_id,
+            &500i128,
+            &400i128,
+            &swap_route,
+        ),
+        Err(Ok(BridgeError::PoolNotWhitelisted))
+    );
+    // Nothing was pulled from the user since the whitelist check runs first.
+    assert_eq!(check_balance(&env, &source_token_id, &user), 1_000i128);
+}
+
 /********** query_calculate_fee tests **********/
 
 #[test]


### PR DESCRIPTION
Closes #226
Closes #227
Closes #228
Closes #229


1. fix(contract): reject duplicate relayer signatures (6c9e98e)

Problem: fund_c_address_crosschain's signature loop counted every valid signature toward the M-of-N threshold without checking whether the same relayer pubkey appeared twice. One relayer could submit the same signature twice and satisfy a threshold of 2.

Fix:
- Added BridgeError::DuplicateRelayerSignature = 41.
- In the verification loop, added a seen_pubkeys: Vec<BytesN<32>> scratch list. Before verifying each signature, checks seen_pubkeys.contains(&sig.pubkey) — if already seen, returns the new error instead of double-counting.
- Updated the function's doc comment (which previously admitted this gap) to state the guarantee instead of the warning.

Test: test_crosschain_duplicate_relayer_signature_rejected — same relayer's signature submitted twice against a threshold of 2 now fails with DuplicateRelayerSignature.

2. feat(contract): add admin-managed swap pool whitelist (e870249)

Problem: fund_c_address_with_swap transferred real tokens to caller-supplied swap_route pool addresses and invoked them via env.invoke_contract, with no restriction on which addresses could be called. Any address could be passed as a "pool," keep the tokens, and return a fabricated amount_out.

Fix:
- Added DataKey::PoolWhitelist and BridgeError::PoolNotWhitelisted = 42.
- Added read_pool_whitelist/save_pool_whitelist/check_pool_whitelisted helpers, mirroring the existing asset-whitelist pattern.
- Added admin functions add_swap_pool, remove_swap_pool, query_is_pool_whitelisted (same nonce/auth pattern as add_asset/remove_asset).
- fund_c_address_with_swap now checks every pool in swap_route against the whitelist before any funds move.
- Added a # Security Considerations section to the function's doc comment explaining the trust assumption and why whitelisting is required.

Test: test_swap_rejects_non_whitelisted_pool — a functioning-but-unwhitelisted pool is rejected before any tokens are pulled from the user.

3. fix(contract): restrict swap_route to a single hop (401e9fe)

Problem: After each non-final hop, the loop unconditionally set current_token = target_asset, even though the token actually returned by an intermediate pool isn't necessarily target_asset. Multi-hop routes would silently transfer the wrong token into the next pool.

Fix:
- Added BridgeError::MultiHopNotSupported = 43.
- Removed the multi-hop loop and its incorrect current_token tracking entirely.
- swap_route must now contain exactly one pool address (swap_route.len() != 1 → MultiHopNotSupported); the function performs a single push-transfer-then-swap() call.
- Updated the doc comment (Flow, Args, Errors, Security Considerations) to describe single-hop-only behavior and explain why multi-hop was cut rather than fixed (no reliable way to learn a pool's actual output token).

Tests:
- test_swap_multi_hop_route_rejected — a 2-pool route is rejected even when both pools are whitelisted.
- test_swap_happy_path_single_hop — a whitelisted single-hop swap still works end-to-end.

4. fix(contract): ring-fence unclaimed timelock deposits from reclaim_tokens (44804c8)

Problem: reclaim_tokens computed reclaimable = contract_balance - accrued_fees, ignoring that fund_c_address_timelocked deposits sit in the contract's token balance until claimed. The doc comment admitted this was an unenforced admin footgun.

Fix:
- Added locked_timelock: i128 to AssetCounters (persisted per-asset alongside accrued_fees/total_bridged/total_fees_collected).
- Added increment_locked_timelock/decrement_locked_timelock helpers.
- fund_c_address_timelocked now increments locked_timelock by the deposited amount when creating an entry.
- claim_timelocked now decrements it by the full entry amount when claimed (the fee portion moves into accrued_fees, the rest leaves the contract).
- reclaim_tokens formula changed to contract_balance - accrued_fees - locked_timelock.
- Rewrote the doc comment: explains the new formula, and clarifies that commit_fund/reveal_fund need no equivalent counter — reveal_fund pulls tokens from source and forwards them to target atomically in one call, so an unrevealed commitment never actually holds contract balance (the original warning about commitments was based on a false premise once you trace the code).

Tests:
- test_reclaim_cannot_drain_active_timelocks — reclaim is blocked while a timelock is outstanding, only the excess above it is reclaimable, and reclaim becomes available again once claimed.
- test_reclaim_cannot_drain_active_commitments — confirms a pending commitment doesn't reduce reclaimable balance (since it never holds funds).
