### PR TITLE
Fix/onboarding bridge security issues

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -145,6 +145,9 @@ pub enum BridgeError {
     MetaTxNonceAlreadyUsed = 39,
     /// The contract is deactivated (permanently paused/migrated).
     ContractDeactivated = 40,
+    /// `execute_meta_fund`'s `pubkey` is not the one `params.source` registered
+    /// via `register_meta_signer` — the signature is valid but not for this source.
+    MetaTxPubkeySourceMismatch = 41,
 }
 
 // ---------------------------------------------------------------------------
@@ -210,6 +213,8 @@ pub enum DataKey {
     // Issue #35: EIP-712-style meta-transaction used nonces
     MetaTxNonce(Address, u64),
     Deactivated,
+    // The Ed25519 pubkey registered by a given source address for meta-tx auth
+    MetaSigner(Address),
 }
 
 // ---------------------------------------------------------------------------
@@ -895,6 +900,26 @@ fn remove_relayer(env: &Env, pubkey: &BytesN<32>) {
             .instance()
             .set(&DataKey::RelayerCount, &(count.saturating_sub(1)));
     }
+}
+
+// --- Meta-transaction signer registry ---
+//
+// `execute_meta_fund` authenticates purely via Ed25519 signature (no
+// `require_auth`), so nothing inherently ties the supplied `pubkey` to
+// `params.source`. This registry lets `source` bind the one pubkey it will
+// accept meta-tx signatures from, via `register_meta_signer` (which itself
+// requires `source.require_auth()` once, on-chain).
+
+fn save_meta_signer(env: &Env, source: &Address, pubkey: &BytesN<32>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::MetaSigner(source.clone()), pubkey);
+}
+
+fn read_meta_signer(env: &Env, source: &Address) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MetaSigner(source.clone()))
 }
 
 fn relayer_threshold(env: &Env) -> u32 {
@@ -4351,6 +4376,57 @@ impl OnboardingBridge {
     // Issue #35: EIP-712-style meta-transaction (gasless / relayer-submitted)
     // -----------------------------------------------------------------------
 
+    /// Binds an Ed25519 public key to `source` for use with `execute_meta_fund`.
+    ///
+    /// `execute_meta_fund` authenticates purely via an Ed25519 signature check —
+    /// it never calls `require_auth`. Without this registry, verifying that
+    /// *some* keypair signed the payload proves nothing about whose funds are
+    /// being moved: any keypair holder could submit a validly-signed meta-tx
+    /// naming an arbitrary `params.source`. Calling this once (authorised by
+    /// `source` itself) establishes the binding that `execute_meta_fund` then
+    /// enforces on every subsequent call.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` (`Address`) — The account this pubkey is allowed to sign for.
+    /// * `pubkey` (`BytesN<32>`) — The Ed25519 public key to bind to `source`.
+    ///
+    /// # Authorization
+    ///
+    /// Requires `source.require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::ContractPaused`] — Contract is paused.
+    ///
+    /// # Events
+    ///
+    /// * `("MetaSignerRegistered", source)` — data: `(pubkey,)`
+    pub fn register_meta_signer(
+        env: Env,
+        source: Address,
+        pubkey: BytesN<32>,
+    ) -> Result<(), BridgeError> {
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        source.require_auth();
+        save_meta_signer(&env, &source, &pubkey);
+        env.events()
+            .publish(("MetaSignerRegistered", source), (pubkey,));
+        Ok(())
+    }
+
+    /// Returns the Ed25519 public key currently bound to `source` via
+    /// `register_meta_signer`, or `None` if no key has been registered.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` (`Address`) — The address to query.
+    pub fn query_meta_signer(env: Env, source: Address) -> Option<BytesN<32>> {
+        read_meta_signer(&env, &source)
+    }
+
     /// Execute a fund_c_address on behalf of a user who signed the parameters
     /// off-chain.
     ///
@@ -4380,7 +4456,8 @@ impl OnboardingBridge {
     /// # Arguments
     ///
     /// * `params` — Funding parameters signed by the user.
-    /// * `pubkey` — The user's Ed25519 public key (`BytesN<32>`).
+    /// * `pubkey` — The user's Ed25519 public key (`BytesN<32>`). Must already be
+    ///   bound to `params.source` via `register_meta_signer`.
     /// * `signature` — Ed25519 signature over the canonical payload hash.
     ///
     /// # Authorization
@@ -4402,6 +4479,8 @@ impl OnboardingBridge {
     /// * [`BridgeError::AddressNotAllowlisted`] — Allowlist mode and target not listed.
     /// * [`BridgeError::AssetNotWhitelisted`] — Asset not whitelisted.
     /// * [`BridgeError::DailyLimitExceeded`] — Daily limit exceeded.
+    /// * [`BridgeError::MetaTxPubkeySourceMismatch`] — `pubkey` is not the key
+    ///   `params.source` registered via `register_meta_signer`.
     ///
     /// # Events
     ///
@@ -4444,6 +4523,15 @@ impl OnboardingBridge {
         check_access(&env, &params.target)?;
         check_asset_whitelisted(&env, &params.asset)?;
         check_daily_limit(&env, &params.source, &params.asset, params.amount)?;
+
+        // 4b. Bind the signature to `params.source`: verifying the Ed25519
+        //     signature alone only proves *some* keypair signed the payload,
+        //     not that it belongs to `params.source`. Require `pubkey` to be
+        //     the one `params.source` registered via `register_meta_signer`.
+        match read_meta_signer(&env, &params.source) {
+            Some(registered) if registered == pubkey => {}
+            _ => return Err(BridgeError::MetaTxPubkeySourceMismatch),
+        }
 
         // 5. Build canonical payload hash and verify signature
         //    payload = sha256(domain || source_hash || target_hash || asset_hash
@@ -4545,7 +4633,9 @@ impl OnboardingBridge {
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MetaFundParams {
-    /// The user's Stellar address (source of funds). Must match `pubkey`.
+    /// The user's Stellar address (source of funds). `pubkey` must be the key
+    /// registered for this address via `register_meta_signer` — enforced by
+    /// `execute_meta_fund`, not merely documented here.
     pub source: Address,
     /// Destination C-address.
     pub target: Address,

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1396,7 +1396,8 @@ impl OnboardingBridge {
     /// * [`BridgeError::TransactionExpired`] — `deadline` is in the past.
     /// * [`BridgeError::MismatchedArrays`] — `targets.len() != amounts.len()`.
     /// * [`BridgeError::AssetNotWhitelisted`] — `asset` has not been added.
-    /// * [`BridgeError::InvalidAmount`] — Any element of `amounts` is ≤ 0.
+    /// * [`BridgeError::InvalidAmount`] — Any element of `amounts` is ≤ 0 or below
+    ///   the configured minimum transfer amount.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     ///
     /// # Events
@@ -1456,7 +1457,9 @@ impl OnboardingBridge {
         let mut total: i128 = 0;
         for i in 0..targets.len() {
             let amount = amounts.get(i).unwrap();
-            if amount <= 0 {
+            // Enforce the same per-transfer minimum as `fund_c_address` — otherwise
+            // a source could evade it entirely by routing through the batch path.
+            if amount <= 0 || amount < minimum_amount {
                 return Err(BridgeError::InvalidAmount);
             }
             total = safe_math::safe_add(total, amount)?;

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1477,7 +1477,10 @@ impl OnboardingBridge {
         token_client.transfer(&source, &contract_addr, &total);
 
         let config = read_bridge_config(&env);
-        let effective_fee_bps = get_effective_fee_bps(&env, &asset, config.fee_bps);
+        // Route through the same volume-tiered fee lookup as the other funding
+        // entry points, instead of the flat global rate.
+        let tiered_fee_bps = get_tiered_fee_bps(&env, &source, config.fee_bps);
+        let effective_fee_bps = get_effective_fee_bps(&env, &asset, tiered_fee_bps);
         let mut num_success = 0u32;
         let mut num_failures = 0u32;
         let mut refund_amount = 0i128;
@@ -1530,6 +1533,13 @@ impl OnboardingBridge {
         // Batch-update all counters in a single storage read+write
         if total_fees > 0 || total_bridged > 0 {
             update_asset_counters(&env, &asset, total_fees, total_bridged);
+        }
+
+        // Track bridged volume for the tiered-fee lookup, mirroring the other
+        // funding entry points. Only the amount that actually succeeded counts.
+        let successful_amount = total - refund_amount;
+        if successful_amount > 0 {
+            increment_source_bridged_volume(&env, &source, successful_amount);
         }
 
         if refund_amount > 0 {
@@ -2111,7 +2121,11 @@ impl OnboardingBridge {
         token_client.transfer(&source, &env.current_contract_address(), &amount);
 
         let global_fee_bps = read_fee_bps(&env);
-        let effective_fee_bps = get_effective_fee_bps(&env, &asset, global_fee_bps);
+        // Route through the volume-tiered fee lookup, same as fund_c_address /
+        // reveal_fund / fund_c_address_with_swap / execute_meta_fund — otherwise
+        // a source could bypass their tier by using the referral path instead.
+        let tiered_fee_bps = get_tiered_fee_bps(&env, &source, global_fee_bps);
+        let effective_fee_bps = get_effective_fee_bps(&env, &asset, tiered_fee_bps);
         let fee = calculate_fee(amount, effective_fee_bps)?;
         let net_amount = safe_math::safe_sub(amount, fee)?;
 
@@ -2139,6 +2153,7 @@ impl OnboardingBridge {
         increment_accrued_fees(&env, &asset, protocol_fee);
         increment_total_bridged(&env, &asset, net_amount);
         increment_total_fees_collected(&env, &asset, fee);
+        increment_source_bridged_volume(&env, &source, amount);
 
         env.events().publish(
             ("CAddressFunded", asset, source, target),

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1398,6 +1398,8 @@ impl OnboardingBridge {
     /// * [`BridgeError::AssetNotWhitelisted`] — `asset` has not been added.
     /// * [`BridgeError::InvalidAmount`] — Any element of `amounts` is ≤ 0 or below
     ///   the configured minimum transfer amount.
+    /// * [`BridgeError::DailyLimitExceeded`] — The aggregate batch amount would
+    ///   exceed `source`'s daily limit for this asset.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     ///
     /// # Events
@@ -1464,6 +1466,11 @@ impl OnboardingBridge {
             }
             total = safe_math::safe_add(total, amount)?;
         }
+
+        // Enforce the source's daily limit against the aggregate batch amount,
+        // same as `fund_c_address` / `fund_c_address_with_referral` / `execute_meta_fund` —
+        // otherwise a source could evade a configured limit via the batch path.
+        check_daily_limit(&env, &source, &asset, total)?;
 
         let token_client = token::Client::new(&env, &asset);
         let contract_addr = env.current_contract_address();

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{BridgeError, OnboardingBridge};
+use crate::{BridgeError, MetaFundParams, OnboardingBridge};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
@@ -3095,5 +3095,88 @@ fn test_emergency_migrate_non_admin_rejected() {
     use soroban_sdk::xdr::SorobanAuthorizationEntry;
     env.set_auths(&[] as &[SorobanAuthorizationEntry]);
     bridge.emergency_migrate(&new_contract, &true);
+}
+
+/********** Meta-fund pubkey/source binding **********/
+
+// execute_meta_fund verified the Ed25519 signature but never checked that the
+// supplied `pubkey` actually corresponds to `params.source` — any keypair holder
+// could submit a validly-signed meta-tx naming an arbitrary source. The check
+// against the `register_meta_signer` registry happens before signature
+// verification, so a bogus/zeroed signature is enough to exercise this path.
+#[test]
+fn test_meta_fund_rejects_pubkey_source_mismatch() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target = Address::generate(&env);
+
+    // `user` registers pubkey_a as their meta-tx signer.
+    let pubkey_a = BytesN::from_array(&env, &[0xAAu8; 32]);
+    bridge.register_meta_signer(&user, &pubkey_a);
+
+    // A relayer attempts to submit a meta-tx for `user` using an unrelated
+    // pubkey_b. The signature is bogus, but the source/pubkey binding check
+    // runs first, so the call never reaches Ed25519 verification.
+    let pubkey_b = BytesN::from_array(&env, &[0xBBu8; 32]);
+    let bogus_signature = BytesN::from_array(&env, &[0u8; 64]);
+
+    let params = MetaFundParams {
+        source: user.clone(),
+        target,
+        asset: token_id.clone(),
+        amount: 500i128,
+        nonce: 0u64,
+        deadline: 1_000_000u64,
+    };
+
+    assert_eq!(
+        bridge.try_execute_meta_fund(&params, &pubkey_b, &bogus_signature),
+        Err(Ok(BridgeError::MetaTxPubkeySourceMismatch))
+    );
+
+    // No tokens should have moved.
+    assert_eq!(check_balance(&env, &token_id, &user), 1000i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 0i128);
+}
+
+// Same scenario, but no pubkey was ever registered for `source` — must also
+// be rejected rather than silently accepting any signer.
+#[test]
+fn test_meta_fund_rejects_unregistered_source() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[0xCCu8; 32]);
+    let bogus_signature = BytesN::from_array(&env, &[0u8; 64]);
+
+    let params = MetaFundParams {
+        source: user.clone(),
+        target,
+        asset: token_id.clone(),
+        amount: 500i128,
+        nonce: 0u64,
+        deadline: 1_000_000u64,
+    };
+
+    assert_eq!(
+        bridge.try_execute_meta_fund(&params, &pubkey, &bogus_signature),
+        Err(Ok(BridgeError::MetaTxPubkeySourceMismatch))
+    );
 }
 

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3213,3 +3213,68 @@ fn test_batch_fund_rejects_amount_below_minimum() {
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 0i128);
 }
 
+/********** Batch fund daily-limit enforcement **********/
+
+// check_daily_limit was only wired into fund_c_address, fund_c_address_with_referral,
+// and execute_meta_fund — never batch_fund_c_address, so a source could evade a
+// configured SourceDailyLimit entirely by using the batch path.
+#[test]
+fn test_batch_fund_respects_daily_limit() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_source_daily_limit(&user, &token_id, &500i128, &None);
+
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let targets = Vec::from_array(&env, [Address::generate(&env), Address::generate(&env)]);
+    // 300 + 300 = 600 exceeds the configured daily limit of 500, even though
+    // no single amount would trip a per-transfer check.
+    let amounts = Vec::from_array(&env, [300i128, 300i128]);
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
+        Err(Ok(BridgeError::DailyLimitExceeded))
+    );
+
+    assert_eq!(check_balance(&env, &token_id, &user), 1000i128);
+}
+
+// A batch within the daily limit should still succeed and consume the usage,
+// so a subsequent batch that would push cumulative usage over the limit fails.
+#[test]
+fn test_batch_fund_within_daily_limit_succeeds() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_source_daily_limit(&user, &token_id, &500i128, &None);
+
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target1 = Address::generate(&env);
+    let target2 = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target1.clone(), target2.clone()]);
+    let amounts = Vec::from_array(&env, [200i128, 200i128]);
+
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
+
+    assert_eq!(check_balance(&env, &token_id, &user), 600i128);
+
+    let more_targets = Vec::from_array(&env, [Address::generate(&env)]);
+    let more_amounts = Vec::from_array(&env, [200i128]);
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &more_targets, &more_amounts, &token_id, &None, &None),
+        Err(Ok(BridgeError::DailyLimitExceeded))
+    );
+}
+

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3180,3 +3180,36 @@ fn test_meta_fund_rejects_unregistered_source() {
     );
 }
 
+/********** Batch fund minimum-amount enforcement **********/
+
+// batch_fund_c_address computed `minimum_amount` but never checked it against
+// each target's amount — a per-target amount below the configured minimum
+// silently succeeded in a batch even though `fund_c_address` would reject it.
+#[test]
+fn test_batch_fund_rejects_amount_below_minimum() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_minimum_amount(&50i128, &None);
+
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let targets = Vec::from_array(&env, [Address::generate(&env), Address::generate(&env)]);
+    // Second amount (10) is below the configured minimum of 50.
+    let amounts = Vec::from_array(&env, [100i128, 10i128]);
+
+    assert_eq!(
+        bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
+
+    // The whole batch is rejected before any token pull, so nothing moved.
+    assert_eq!(check_balance(&env, &token_id, &user), 1000i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 0i128);
+}
+

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1,4 +1,4 @@
-use crate::{BridgeError, MetaFundParams, OnboardingBridge};
+use crate::{BridgeError, FeeTier, MetaFundParams, OnboardingBridge};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
@@ -3276,5 +3276,76 @@ fn test_batch_fund_within_daily_limit_succeeds() {
         bridge.try_batch_fund_c_address(&user, &more_targets, &more_amounts, &token_id, &None, &None),
         Err(Ok(BridgeError::DailyLimitExceeded))
     );
+}
+
+/********** Tiered fee applied to batch/referral funding paths **********/
+
+// get_tiered_fee_bps was only consulted by fund_c_address, reveal_fund,
+// fund_c_address_with_swap, and execute_meta_fund — batch_fund_c_address computed
+// its fee from the flat global rate, silently bypassing the volume-tier discount.
+#[test]
+fn test_batch_fund_applies_tiered_fee() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    // Global fee is 100 bps (1%), but a volume tier discounts it to 10 bps (0.1%)
+    // for cumulative volume in [0, 1_000_000] — i.e. every source by default.
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    let tiers = Vec::from_array(
+        &env,
+        [FeeTier {
+            min_volume: 0,
+            max_volume: 1_000_000i128,
+            fee_bps: 10u32,
+        }],
+    );
+    bridge.set_fee_tiers(&tiers);
+
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    let target = Address::generate(&env);
+    let targets = Vec::from_array(&env, [target.clone()]);
+    let amounts = Vec::from_array(&env, [1000i128]);
+
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
+
+    // Tiered fee (10 bps) on 1000 = 1, not the flat global rate (100 bps = 10).
+    assert_eq!(check_balance(&env, &token_id, &target), 999i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 1i128);
+}
+
+// fund_c_address_with_referral computed its fee straight from the global rate via
+// get_effective_fee_bps, never consulting the caller's volume tier.
+#[test]
+fn test_referral_fund_applies_tiered_fee() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    let tiers = Vec::from_array(
+        &env,
+        [FeeTier {
+            min_volume: 0,
+            max_volume: 1_000_000i128,
+            fee_bps: 10u32,
+        }],
+    );
+    bridge.set_fee_tiers(&tiers);
+
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    let target = Address::generate(&env);
+
+    bridge.fund_c_address_with_referral(&user, &target, &token_id, &1000i128, &None);
+
+    // Tiered fee (10 bps) on 1000 = 1, not the flat global rate (100 bps = 10).
+    assert_eq!(check_balance(&env, &token_id, &target), 999i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 1i128);
 }
 


### PR DESCRIPTION
closes #234
closes #235
closes #236
closes #237

Summary of changes

Branch fix/onboarding-bridge-security-issues, 4 commits, 374 lines changed across contracts/onboarding-bridge/src/lib.rs and src/tests.rs.

1. d8d1bc2 — Meta-fund pubkey/source binding

Problem: execute_meta_fund verified an Ed25519 signature but never checked that the pubkey belonged to params.source. Since this function skips require_auth() entirely (auth is the signature itself), anyone holding any keypair could forge a valid signature over a payload naming someone else's address as source, and the contract would happily move that person's funds.

Fix: Added a MetaSigner(Address) -> BytesN<32> storage mapping and a new register_meta_signer(source, pubkey) entry point that requires source.require_auth() to bind a key once. execute_meta_fund now rejects the call with the new MetaTxPubkeySourceMismatch error unless the supplied pubkey matches what source registered — checked before the expensive signature verification. Also added query_meta_signer for introspection.

Tests: test_meta_fund_rejects_pubkey_source_mismatch, test_meta_fund_rejects_unregistered_source.

2. a67090d — Minimum-amount enforcement in batch funding

Problem: batch_fund_c_address read minimum_amount from storage but never used it — dead code. A source could funnel amounts below the configured minimum through the batch path even though fund_c_address would reject them individually.

Fix: The per-target validation loop now rejects the whole batch with InvalidAmount if any element is below minimum_amount, mirroring fund_c_address.

Test: test_batch_fund_rejects_amount_below_minimum.

3. 5d08c46 — Daily-limit enforcement in batch funding

Problem: check_daily_limit was wired into fund_c_address, fund_c_address_with_rd, but never batch_fund_c_address — a source could bypass a configuredSourceDailyLimit entirely by batching instead of sending single transfers.

Fix: check_daily_limit is now called against the aggregate batch total before the token pull.

Tests: test_batch_fund_respects_daily_limit, test_batch_fund_within_daily_limit_succeeds.                                                                                                   
4. 97bf536 — Tiered fee applied to batch/referral paths                                                                                                                                     
Problem: get_tiered_fee_bps (volume-based fee discounts) was only consulted by 4 of the 7 funding entry points. batch_fund_c_address and fund_c_address_with_referral computed fees from the flat global rate via get_effective_fee_bps directly, silently ignoring the call

Fix: Both paths now route through get_tiered_fee_bps first, and both now call ie afterward so usage through these paths actually counts toward future tierlookups (previously neither path tracked volume at all).
