### PR TITLE
Fix 4 contract bugs: stale doc, batch error code, commit-reveal tests, strkey bounds check

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -147,6 +147,8 @@ pub enum BridgeError {
     ContractDeactivated = 40,
     /// The `targets` array passed to `batch_fund_c_address` exceeds `MAX_BATCH_SIZE` (100).
     BatchTooLarge = 41,
+    /// An address's strkey representation exceeds `MAX_STRKEY_LEN` (64) bytes.
+    InvalidAddress = 42,
 }
 
 // ---------------------------------------------------------------------------
@@ -227,6 +229,9 @@ const CRITICAL_ENTRY_TTL_THRESHOLD: u32 = 100_000;
 const UPGRADE_TIMELOCK_LEDGERS: u32 = 17_280;
 /// Minimum ledgers between commit_fund and reveal_fund (~25 s at 5 s/ledger).
 const COMMIT_REVEAL_MIN_DELAY_LEDGERS: u32 = 5;
+/// Size of the stack buffer used to hold an address's strkey while hashing it.
+/// Soroban strkeys are 56 bytes; anything longer is rejected rather than copied.
+const MAX_STRKEY_LEN: usize = 64;
 
 // ---------------------------------------------------------------------------
 // Structs
@@ -3280,6 +3285,7 @@ impl OnboardingBridge {
     ///   has already been processed.
     /// * [`BridgeError::NotRelayer`] — A signature's pubkey is not a registered relayer.
     /// * [`BridgeError::BelowThreshold`] — Fewer than `threshold` valid signatures.
+    /// * [`BridgeError::InvalidAddress`] — A strkey exceeds `MAX_STRKEY_LEN` (64) bytes.
     ///
     /// # Events
     ///
@@ -3331,15 +3337,21 @@ impl OnboardingBridge {
         // payload is still domain-separated and collision-resistant.
         let target_strkey = target.clone().to_string();
         let asset_strkey = asset.clone().to_string();
-        let mut addr_buf = [0u8; 64];
+        let mut addr_buf = [0u8; MAX_STRKEY_LEN];
 
         let tlen = target_strkey.len() as usize;
+        if tlen > MAX_STRKEY_LEN {
+            return Err(BridgeError::InvalidAddress);
+        }
         target_strkey.copy_into_slice(&mut addr_buf[..tlen]);
         let target_raw = soroban_sdk::Bytes::from_slice(&env, &addr_buf[..tlen]);
         let target_hash: BytesN<32> = env.crypto().sha256(&target_raw).into();
         let target_bytes: soroban_sdk::Bytes = target_hash.into();
 
         let alen = asset_strkey.len() as usize;
+        if alen > MAX_STRKEY_LEN {
+            return Err(BridgeError::InvalidAddress);
+        }
         asset_strkey.copy_into_slice(&mut addr_buf[..alen]);
         let asset_raw = soroban_sdk::Bytes::from_slice(&env, &addr_buf[..alen]);
         let asset_hash: BytesN<32> = env.crypto().sha256(&asset_raw).into();
@@ -4407,6 +4419,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::AddressNotAllowlisted`] — Allowlist mode and target not listed.
     /// * [`BridgeError::AssetNotWhitelisted`] — Asset not whitelisted.
     /// * [`BridgeError::DailyLimitExceeded`] — Daily limit exceeded.
+    /// * [`BridgeError::InvalidAddress`] — A strkey exceeds `MAX_STRKEY_LEN` (64) bytes.
     ///
     /// # Events
     ///
@@ -4455,22 +4468,31 @@ impl OnboardingBridge {
         //                     || amount_be16 || nonce_be8 || deadline_be8)
         let domain: soroban_sdk::Bytes = soroban_sdk::Bytes::from_slice(&env, b"meta_fund");
 
-        let mut addr_buf = [0u8; 64];
+        let mut addr_buf = [0u8; MAX_STRKEY_LEN];
 
         let src_str = params.source.clone().to_string();
         let slen = src_str.len() as usize;
+        if slen > MAX_STRKEY_LEN {
+            return Err(BridgeError::InvalidAddress);
+        }
         src_str.copy_into_slice(&mut addr_buf[..slen]);
         let src_raw = soroban_sdk::Bytes::from_slice(&env, &addr_buf[..slen]);
         let src_hash: BytesN<32> = env.crypto().sha256(&src_raw).into();
 
         let tgt_str = params.target.clone().to_string();
         let tlen = tgt_str.len() as usize;
+        if tlen > MAX_STRKEY_LEN {
+            return Err(BridgeError::InvalidAddress);
+        }
         tgt_str.copy_into_slice(&mut addr_buf[..tlen]);
         let tgt_raw = soroban_sdk::Bytes::from_slice(&env, &addr_buf[..tlen]);
         let tgt_hash: BytesN<32> = env.crypto().sha256(&tgt_raw).into();
 
         let ast_str = params.asset.clone().to_string();
         let alen = ast_str.len() as usize;
+        if alen > MAX_STRKEY_LEN {
+            return Err(BridgeError::InvalidAddress);
+        }
         ast_str.copy_into_slice(&mut addr_buf[..alen]);
         let ast_raw = soroban_sdk::Bytes::from_slice(&env, &addr_buf[..alen]);
         let ast_hash: BytesN<32> = env.crypto().sha256(&ast_raw).into();

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1839,8 +1839,10 @@ impl OnboardingBridge {
 
     /// Returns the configured minimum transfer amount.
     ///
-    /// > **Note:** Currently always returns `0` because the persistence layer
-    /// > is a stub. See `set_minimum_amount` for details.
+    /// Returns the value last stored by `set_minimum_amount`, or `0` (no
+    /// minimum) if it has never been called. The minimum is enforced by
+    /// `fund_c_address`, which rejects amounts below it with
+    /// [`BridgeError::InvalidAmount`].
     ///
     /// # Errors
     ///

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -145,6 +145,8 @@ pub enum BridgeError {
     MetaTxNonceAlreadyUsed = 39,
     /// The contract is deactivated (permanently paused/migrated).
     ContractDeactivated = 40,
+    /// The `targets` array passed to `batch_fund_c_address` exceeds `MAX_BATCH_SIZE` (100).
+    BatchTooLarge = 41,
 }
 
 // ---------------------------------------------------------------------------
@@ -1368,6 +1370,7 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::ContractPaused`] — Contract is paused.
+    /// * [`BridgeError::BatchTooLarge`] — `targets.len()` exceeds `MAX_BATCH_SIZE` (100).
     /// * [`BridgeError::TransactionExpired`] — `deadline` is in the past.
     /// * [`BridgeError::MismatchedArrays`] — `targets.len() != amounts.len()`.
     /// * [`BridgeError::AssetNotWhitelisted`] — `asset` has not been added.
@@ -1410,7 +1413,7 @@ impl OnboardingBridge {
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if targets.len() > MAX_BATCH_SIZE {
-            return Err(BridgeError::InvalidAmount);
+            return Err(BridgeError::BatchTooLarge);
         }
         if let Some(d) = deadline {
             if env.ledger().timestamp() > d {

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -2035,6 +2035,145 @@ mod timelocked_tests {
     }
 }
 
+/********** Commit-reveal funding tests **********/
+
+#[cfg(test)]
+mod commit_reveal_tests {
+    use super::*;
+
+    /// Minimum ledgers that must elapse between commit_fund and reveal_fund.
+    const MIN_DELAY_LEDGERS: u32 = 5;
+
+    fn setup_commit_reveal(env: &Env) -> (crate::OnboardingBridgeClient<'_>, Address, Address) {
+        let (bridge_id, token_id) = register_all_contracts_mocked(env);
+        let bridge = create_bridge_client(env, &bridge_id);
+        let (admin, user, fee_collector) = create_test_users(env);
+        init_token(env, &token_id, &admin);
+        bridge.initialize(&admin, &fee_collector, &100u32, &None); // 1% fee
+        bridge.add_asset(&token_id, &None);
+        mint_tokens(env, &token_id, &user, 10_000i128);
+        (bridge, user, token_id)
+    }
+
+    /// Mirrors the contract's `sha256(amount_be16 || nonce_be8)` commitment hash.
+    fn amount_hash(env: &Env, amount: i128, nonce: u64) -> BytesN<32> {
+        let mut preimage = Bytes::new(env);
+        preimage.extend_from_array(&amount.to_be_bytes());
+        preimage.extend_from_array(&nonce.to_be_bytes());
+        env.crypto().sha256(&preimage).into()
+    }
+
+    /// Advances the ledger past the commit-reveal minimum delay.
+    fn advance_past_min_delay(env: &Env) {
+        let seq = env.ledger().sequence();
+        env.ledger().set_sequence_number(seq + MIN_DELAY_LEDGERS);
+    }
+
+    #[test]
+    fn test_commit_reveal_happy_path() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (bridge, user, token_id) = setup_commit_reveal(&env);
+        let target = Address::generate(&env);
+
+        let hash = amount_hash(&env, 500i128, 42u64);
+        let id = bridge.commit_fund(&user, &target, &token_id, &hash, &2_000u64);
+
+        let entry = bridge.query_commitment(&id);
+        assert_eq!(entry.source, user);
+        assert_eq!(entry.target, target);
+        assert!(!entry.revealed);
+
+        advance_past_min_delay(&env);
+        bridge.reveal_fund(&id, &user, &target, &token_id, &500i128, &42u64);
+
+        assert_eq!(check_balance(&env, &token_id, &target), 495i128);
+        assert_eq!(check_balance(&env, &token_id, &user), 9_500i128);
+        assert_eq!(bridge.query_accrued_fees(&token_id), 5i128);
+        assert!(bridge.query_commitment(&id).revealed);
+    }
+
+    #[test]
+    fn test_reveal_before_min_delay_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (bridge, user, token_id) = setup_commit_reveal(&env);
+        let target = Address::generate(&env);
+
+        let hash = amount_hash(&env, 500i128, 7u64);
+        let id = bridge.commit_fund(&user, &target, &token_id, &hash, &2_000u64);
+
+        // Revealed in the same ledger the commitment was created in.
+        assert_eq!(
+            bridge.try_reveal_fund(&id, &user, &target, &token_id, &500i128, &7u64),
+            Err(Ok(BridgeError::CommitmentNotMatured))
+        );
+        assert_eq!(check_balance(&env, &token_id, &target), 0i128);
+    }
+
+    #[test]
+    fn test_reveal_after_deadline_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (bridge, user, token_id) = setup_commit_reveal(&env);
+        let target = Address::generate(&env);
+
+        let hash = amount_hash(&env, 500i128, 9u64);
+        let id = bridge.commit_fund(&user, &target, &token_id, &hash, &1_500u64);
+
+        advance_past_min_delay(&env);
+        env.ledger().set_timestamp(1_501);
+
+        assert_eq!(
+            bridge.try_reveal_fund(&id, &user, &target, &token_id, &500i128, &9u64),
+            Err(Ok(BridgeError::CommitmentExpired))
+        );
+        assert_eq!(check_balance(&env, &token_id, &target), 0i128);
+    }
+
+    #[test]
+    fn test_reveal_twice_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (bridge, user, token_id) = setup_commit_reveal(&env);
+        let target = Address::generate(&env);
+
+        let hash = amount_hash(&env, 500i128, 11u64);
+        let id = bridge.commit_fund(&user, &target, &token_id, &hash, &2_000u64);
+
+        advance_past_min_delay(&env);
+        bridge.reveal_fund(&id, &user, &target, &token_id, &500i128, &11u64);
+
+        assert_eq!(
+            bridge.try_reveal_fund(&id, &user, &target, &token_id, &500i128, &11u64),
+            Err(Ok(BridgeError::CommitmentAlreadyRevealed))
+        );
+        // Only the first reveal moved funds.
+        assert_eq!(check_balance(&env, &token_id, &target), 495i128);
+    }
+
+    #[test]
+    fn test_reveal_hash_mismatch_fails() {
+        let env = Env::default();
+        env.ledger().set_timestamp(1_000);
+        let (bridge, user, token_id) = setup_commit_reveal(&env);
+        let target = Address::generate(&env);
+
+        let hash = amount_hash(&env, 500i128, 13u64);
+        let id = bridge.commit_fund(&user, &target, &token_id, &hash, &2_000u64);
+
+        advance_past_min_delay(&env);
+
+        // Committed to 500, revealing 900 with the same nonce.
+        assert_eq!(
+            bridge.try_reveal_fund(&id, &user, &target, &token_id, &900i128, &13u64),
+            Err(Ok(BridgeError::CommitmentHashMismatch))
+        );
+        assert_eq!(check_balance(&env, &token_id, &target), 0i128);
+        assert!(!bridge.query_commitment(&id).revealed);
+    }
+}
+
 /********** Cross-chain Onboarding Tests **********/
 
 #[cfg(test)]

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1693,7 +1693,7 @@ fn test_batch_exceeds_max_size() {
 
     assert_eq!(
         bridge.try_batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None),
-        Err(Ok(BridgeError::InvalidAmount))
+        Err(Ok(BridgeError::BatchTooLarge))
     );
     assert_eq!(check_balance(&env, &token_id, &user), 1_000_000i128);
 }


### PR DESCRIPTION
Batch of four small contract fixes. Each issue is a separate commit.

- **#246** — `query_minimum_amount`'s doc claimed it "always returns 0 because the persistence layer is a stub". `save_minimum_amount`/`read_minimum_amount` do persist the value and `fund_c_address` enforces it, so the note is replaced with a description of the actual behaviour (returns the configured value, `0` when never set).
- **#247** — Added `BridgeError::BatchTooLarge = 41` and used it for the `targets.len() > MAX_BATCH_SIZE` check in `batch_fund_c_address`, which previously returned `InvalidAmount` and was indistinguishable from a zero/negative amount. Updated the `# Errors` doc list and the existing `test_batch_exceeds_max_size` assertion.
- **#248** — Added a `commit_reveal_tests` module covering `commit_fund`/`reveal_fund`: happy path, reveal before the minimum delay, reveal after the deadline, double reveal, and hash mismatch. Follows the existing `timelocked_tests` layout.
- **#249** — Added a `tlen <= MAX_STRKEY_LEN` guard before every `copy_into_slice` into the fixed `[0u8; 64]` address buffer in `fund_c_address_crosschain` (2 sites) and `execute_meta_fund` (3 sites), returning the new `BridgeError::InvalidAddress = 42` instead of trapping on an out-of-bounds slice. The literal `64` is now the named `MAX_STRKEY_LEN` constant.

### Notes

No regression test was added for #249. The issue scoped this to "if the test harness allows constructing one" — it does not: both `Address::generate` and `env.register` produce 56-byte strkeys, and there is no way to hand the contract a longer one through the client API, so the guard is unreachable from tests. It is defensive against a future address format (e.g. muxed `M...` strkeys, which are 69 bytes) that would otherwise trap.

Verified with `cargo test -p onboarding-bridge --features testutils` after building the WASM fixture: **174 passed, 0 failed** (169 before, +5 new commit-reveal tests).

Closes #246
Closes #247
Closes #248
Closes #249
