### PR TITLE
Fix/onboarding bridge ttl loyalty issues

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -151,6 +151,8 @@ pub enum BridgeError {
     MetaTxNonceAlreadyUsed = 39,
     /// The contract is deactivated (permanently paused/migrated).
     ContractDeactivated = 40,
+    /// A requested TTL value is outside `[MIN_ALLOWED_TTL, MAX_ALLOWED_TTL]`.
+    InvalidTtl = 41,
 }
 
 // ---------------------------------------------------------------------------
@@ -226,6 +228,14 @@ const MAX_FEE_BPS: u32 = 1_000;
 const FEE_DENOMINATOR: i128 = 10_000;
 const MAX_BATCH_SIZE: u32 = 100;
 const MAX_ALLOWED_TTL: u32 = 3_110_400; // ~1 year in ledgers (5s/ledger)
+/// Minimum configurable value for `MaxInstanceTtl` / `MaxPersistentTtl`.
+///
+/// Without a floor, an admin setting either max to `0` would make
+/// `extend_instance_ttl`'s `threshold = max_ttl / 4` evaluate to `0`, which
+/// effectively disables TTL extension and risks near-term expiry of all
+/// instance (or persistent) data. Set to roughly one week of ledgers
+/// (5 s/ledger) — comfortably above `CRITICAL_ENTRY_TTL_THRESHOLD`.
+const MIN_ALLOWED_TTL: u32 = 120_960;
 const CRITICAL_ENTRY_TTL_THRESHOLD: u32 = 100_000;
 /// Minimum ledgers that must pass before a scheduled upgrade becomes executable (~24 h at 5 s/ledger).
 const UPGRADE_TIMELOCK_LEDGERS: u32 = 17_280;
@@ -4045,11 +4055,15 @@ impl OnboardingBridge {
     /// Overrides the maximum instance-storage TTL used by the internal
     /// `extend_instance_ttl` helper called on every mutating operation.
     ///
-    /// Values above `MAX_ALLOWED_TTL` are silently capped.
+    /// Values above `MAX_ALLOWED_TTL` are silently capped. Values below
+    /// `MIN_ALLOWED_TTL` are rejected outright: `extend_instance_ttl` derives
+    /// its extension threshold as `max_ttl / 4`, so a max of `0` (or any very
+    /// small value) would make the threshold `0` too, effectively disabling
+    /// TTL extension and risking near-term expiry of all instance data.
     ///
     /// # Arguments
     ///
-    /// * `ttl` (`u32`) — New maximum in ledgers.
+    /// * `ttl` (`u32`) — New maximum in ledgers. Must be ≥ `MIN_ALLOWED_TTL`.
     ///
     /// # Authorization
     ///
@@ -4058,11 +4072,15 @@ impl OnboardingBridge {
     /// # Errors
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::InvalidTtl`] — `ttl` is below `MIN_ALLOWED_TTL`.
     pub fn set_max_instance_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        if ttl < MIN_ALLOWED_TTL {
+            return Err(BridgeError::InvalidTtl);
+        }
         let capped = if ttl > MAX_ALLOWED_TTL {
             MAX_ALLOWED_TTL
         } else {
@@ -4077,11 +4095,14 @@ impl OnboardingBridge {
 
     /// Overrides the maximum persistent-storage TTL used by `extend_persistent_ttl`.
     ///
-    /// Values above `MAX_ALLOWED_TTL` are silently capped.
+    /// Values above `MAX_ALLOWED_TTL` are silently capped. Values below
+    /// `MIN_ALLOWED_TTL` are rejected for the same reason as
+    /// `set_max_instance_ttl`: a near-zero max would collapse the extension
+    /// threshold to zero and disable TTL extension entirely.
     ///
     /// # Arguments
     ///
-    /// * `ttl` (`u32`) — New maximum in ledgers.
+    /// * `ttl` (`u32`) — New maximum in ledgers. Must be ≥ `MIN_ALLOWED_TTL`.
     ///
     /// # Authorization
     ///
@@ -4090,11 +4111,15 @@ impl OnboardingBridge {
     /// # Errors
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::InvalidTtl`] — `ttl` is below `MIN_ALLOWED_TTL`.
     pub fn set_max_persistent_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        if ttl < MIN_ALLOWED_TTL {
+            return Err(BridgeError::InvalidTtl);
+        }
         let capped = if ttl > MAX_ALLOWED_TTL {
             MAX_ALLOWED_TTL
         } else {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -10,9 +10,15 @@
 //! All state lives in one of two Soroban storage tiers:
 //!
 //! - **Instance storage** — contract-wide singletons (admin, fee config, asset whitelist,
-//!   relayer threshold, pending upgrade). Extends its TTL on every mutating call.
+//!   relayer threshold, pending upgrade). Every state-mutating public function (all funding
+//!   paths, every admin setter, timelocked/commit-reveal/meta-tx flows, relayer and
+//!   blocklist/allowlist management, etc.) calls the private `extend_instance_ttl` helper
+//!   before returning, so instance storage — including the `Admin` entry — cannot expire
+//!   as long as the contract keeps receiving any mutating call.
 //! - **Persistent storage** — per-address or per-asset data (balances, nonces, daily
-//!   usage, timelock entries). Extended explicitly via `extend_persistent_ttl`.
+//!   usage, timelock entries). Extended explicitly via `extend_persistent_ttl`, which
+//!   covers per-asset counters, `AssetStats`, `Timelock`, `Commitment`, and `Relayer`
+//!   entries for a given key (see `extend_persistent_ttl` for the full key list).
 //!
 //! ## Fee Model
 //!
@@ -1328,6 +1334,7 @@ impl OnboardingBridge {
         check_daily_limit(&env, &source, &asset, amount)?;
         source.require_auth();
         consume_nonce(&env, &source, nonce)?;
+        extend_instance_ttl(&env);
 
         let token_client = token::Client::new(&env, &asset);
         let contract_addr = env.current_contract_address();
@@ -1443,6 +1450,7 @@ impl OnboardingBridge {
         check_asset_whitelisted(&env, &asset)?;
         source.require_auth();
         consume_nonce(&env, &source, nonce)?;
+        extend_instance_ttl(&env);
 
         let minimum_amount = read_minimum_amount(&env);
         let mut total: i128 = 0;
@@ -1571,6 +1579,7 @@ impl OnboardingBridge {
         let mut config = read_bridge_config(&env);
         config.admin.require_auth();
         consume_nonce(&env, &config.admin, nonce)?;
+        extend_instance_ttl(&env);
         let old_fee_bps = config.fee_bps;
         config.fee_bps = new_fee_bps;
         save_fee_bps(&env, &new_fee_bps);
@@ -1621,6 +1630,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_source_daily_limit(&env, &source, &asset, limit_amount);
         Ok(())
     }
@@ -1689,6 +1699,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_asset_fee_cap(&env, &asset, max_fee_bps);
         Ok(())
     }
@@ -1747,6 +1758,7 @@ impl OnboardingBridge {
         let mut config = read_bridge_config(&env);
         config.admin.require_auth();
         consume_nonce(&env, &config.admin, nonce)?;
+        extend_instance_ttl(&env);
         let old_collector = config.fee_collector.clone();
         config.fee_collector = new_fee_collector.clone();
         save_fee_collector(&env, &new_fee_collector);
@@ -1763,6 +1775,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_pending_fee_collector(&env, &new_collector);
         env.events()
             .publish(("FeeCollectorTransferProposed", admin, new_collector), ());
@@ -1775,6 +1788,7 @@ impl OnboardingBridge {
         check_not_paused(&env)?;
         let pending = read_pending_fee_collector(&env).ok_or(BridgeError::Unauthorized)?;
         pending.require_auth();
+        extend_instance_ttl(&env);
         let old_collector = read_fee_collector(&env);
         save_fee_collector(&env, &pending);
         let mut config = read_bridge_config(&env);
@@ -1798,6 +1812,7 @@ impl OnboardingBridge {
         let old_admin = config.admin.clone();
         config.admin.require_auth();
         consume_nonce(&env, &config.admin, nonce)?;
+        extend_instance_ttl(&env);
         config.admin = new_admin.clone();
         save_admin(&env, &new_admin);
         save_bridge_config(&env, &config);
@@ -1813,6 +1828,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_pending_admin(&env, &new_admin);
         env.events()
             .publish(("AdminTransferProposed", admin, new_admin), ());
@@ -1825,6 +1841,7 @@ impl OnboardingBridge {
         check_not_paused(&env)?;
         let pending = read_pending_admin(&env).ok_or(BridgeError::Unauthorized)?;
         pending.require_auth();
+        extend_instance_ttl(&env);
         let old_admin = read_admin(&env);
         save_admin(&env, &pending);
         let mut config = read_bridge_config(&env);
@@ -1850,6 +1867,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_minimum_amount(&env, &amount);
         Ok(())
     }
@@ -1926,6 +1944,7 @@ impl OnboardingBridge {
         let fee_collector = read_fee_collector(&env);
         fee_collector.require_auth();
         consume_nonce(&env, &fee_collector, nonce)?;
+        extend_instance_ttl(&env);
 
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&env.current_contract_address(), &fee_collector, &amount);
@@ -1945,6 +1964,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_max_withdraw_per_tx(&env, amount);
         env.events().publish(("MaxWithdrawPerTxSet", admin), (amount,));
         Ok(())
@@ -1994,6 +2014,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         save_referral_rate(&env, bps);
         env.events().publish(("ReferralRateChanged", bps), ());
         Ok(())
@@ -2088,6 +2109,7 @@ impl OnboardingBridge {
         check_asset_whitelisted(&env, &asset)?;
         check_daily_limit(&env, &source, &asset, amount)?;
         source.require_auth();
+        extend_instance_ttl(&env);
 
         let token_client = token::Client::new(&env, &asset);
         token_client.transfer(&source, &env.current_contract_address(), &amount);
@@ -2330,6 +2352,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         set_paused(&env, true);
         env.events().publish(("ContractPaused",), (admin,));
         Ok(())
@@ -2360,6 +2383,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         set_paused(&env, false);
         env.events().publish(("ContractUnpaused",), (admin,));
         Ok(())
@@ -2412,6 +2436,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
 
         // Record the hash we are replacing so the event contains both sides.
         let old_hash = read_current_wasm_hash(&env);
@@ -2492,6 +2517,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
 
         let executable_after_ledger = env
             .ledger()
@@ -2553,6 +2579,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
 
         let pending = read_pending_upgrade(&env)
             .ok_or(BridgeError::UpgradeNotScheduled)?;
@@ -2613,6 +2640,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
 
         let pending = read_pending_upgrade(&env)
             .ok_or(BridgeError::UpgradeNotScheduled)?;
@@ -2655,6 +2683,7 @@ impl OnboardingBridge {
 
         let admin = read_admin(&env);
         admin.require_auth();
+        extend_instance_ttl(&env);
 
         // Emit the main migration event
         env.events().publish(("EmergencyMigration",), new_contract.clone());
@@ -2774,6 +2803,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         env.storage()
             .persistent()
             .set(&DataKey::Blocked(address), &true);
@@ -2801,6 +2831,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         env.storage()
             .persistent()
             .remove(&DataKey::Blocked(address));
@@ -2832,6 +2863,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         env.storage()
             .persistent()
             .set(&DataKey::Allowlisted(address), &true);
@@ -2862,6 +2894,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         env.storage()
             .persistent()
             .remove(&DataKey::Allowlisted(address));
@@ -2895,6 +2928,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         set_allowlist_mode_flag(&env, enabled);
         Ok(())
     }
@@ -2969,6 +3003,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
 
         let token_client = token::Client::new(&env, &asset);
         let contract_balance = token_client.balance(&env.current_contract_address());
@@ -3014,6 +3049,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         let mut whitelist = read_whitelist(&env);
         whitelist.set(asset, true);
         save_whitelist(&env, &whitelist);
@@ -3045,6 +3081,7 @@ impl OnboardingBridge {
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
         let mut whitelist = read_whitelist(&env);
         whitelist.remove(asset);
         save_whitelist(&env, &whitelist);
@@ -3113,6 +3150,7 @@ impl OnboardingBridge {
         if amount_per_fund < 0 {
             return Err(BridgeError::InvalidAmount);
         }
+        extend_instance_ttl(&env);
         save_loyalty_token(&env, &token);
         save_loyalty_amount_per_fund(&env, &amount_per_fund);
         env.events()
@@ -3185,6 +3223,7 @@ impl OnboardingBridge {
                 return Err(BridgeError::FeeTooHigh);
             }
         }
+        extend_instance_ttl(&env);
         save_fee_tiers(&env, &tiers);
         env.events()
             .publish(("FeeTiersSet", admin), (tiers.len(),));
@@ -3387,6 +3426,7 @@ impl OnboardingBridge {
 
         // Consume nonce, apply fee, credit target
         mark_nonce_used(&env, &nonce);
+        extend_instance_ttl(&env);
 
         let fee_bps = read_fee_bps(&env);
         let effective_fee_bps = get_effective_fee_bps(&env, &asset, fee_bps);
@@ -3426,6 +3466,7 @@ impl OnboardingBridge {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         read_admin(&env).require_auth();
+        extend_instance_ttl(&env);
         add_relayer(&env, &pubkey);
         Ok(())
     }
@@ -3458,6 +3499,7 @@ impl OnboardingBridge {
         if new_count < relayer_threshold(&env) {
             return Err(BridgeError::BelowThreshold);
         }
+        extend_instance_ttl(&env);
         remove_relayer(&env, &pubkey);
         Ok(())
     }
@@ -3485,6 +3527,7 @@ impl OnboardingBridge {
         if threshold > relayer_count(&env) {
             return Err(BridgeError::ThresholdExceedsRelayers);
         }
+        extend_instance_ttl(&env);
         save_relayer_threshold(&env, threshold);
         Ok(())
     }
@@ -3592,6 +3635,7 @@ impl OnboardingBridge {
         check_access(&env, &target)?;
         check_asset_whitelisted(&env, &asset)?;
         source.require_auth();
+        extend_instance_ttl(&env);
 
         token::Client::new(&env, &asset)
             .transfer(&source, &env.current_contract_address(), &amount);
@@ -3669,6 +3713,7 @@ impl OnboardingBridge {
 
         entry.claimed = true;
         save_timelock_entry(&env, id, &entry);
+        extend_instance_ttl(&env);
 
         let fee_bps = read_fee_bps(&env);
         let effective_fee_bps = get_effective_fee_bps(&env, &entry.asset, fee_bps);
@@ -3826,6 +3871,7 @@ impl OnboardingBridge {
         env.storage()
             .instance()
             .set(&DataKey::MaxInstanceTtl, &capped);
+        extend_instance_ttl(&env);
         Ok(())
     }
 
@@ -3857,6 +3903,7 @@ impl OnboardingBridge {
         env.storage()
             .instance()
             .set(&DataKey::MaxPersistentTtl, &capped);
+        extend_instance_ttl(&env);
         Ok(())
     }
 
@@ -3952,6 +3999,7 @@ impl OnboardingBridge {
         check_initialized(&env)?;
         check_not_paused(&env)?;
         source.require_auth();
+        extend_instance_ttl(&env);
         consume_auth_nonce(&env, &source, nonce, valid_after_ledger, valid_before_ledger)
     }
 
@@ -4273,6 +4321,7 @@ impl OnboardingBridge {
         check_asset_whitelisted(&env, &target_asset)?;
 
         source.require_auth();
+        extend_instance_ttl(&env);
 
         let contract_addr = env.current_contract_address();
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3829,6 +3829,8 @@ impl OnboardingBridge {
             DataKey::AccruedFees(key_asset.clone()),
             DataKey::TotalBridged(key_asset.clone()),
             DataKey::TotalFeesCollected(key_asset.clone()),
+            DataKey::AssetStats(key_asset.clone()),
+            DataKey::AssetFeeCap(key_asset.clone()),
         ];
         for key in keys.iter() {
             if env.storage().persistent().has(key) {
@@ -3839,6 +3841,204 @@ impl OnboardingBridge {
         }
         env.events()
             .publish(("PersistentTtlExtended",), (admin, key_asset, max_ttl));
+        Ok(())
+    }
+
+    /// Extends the persistent-storage TTL for a specific timelock entry.
+    ///
+    /// `extend_persistent_ttl` only ever covered per-asset counter keys, so a
+    /// long-dated `TimelockEntry` (see `fund_c_address_timelocked`) had no way
+    /// to have its TTL refreshed and could be archived by the network before
+    /// `release_time`, making it permanently unclaimable. Call this
+    /// periodically for any timelock whose `release_time` is far in the future.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` (`u64`) — The timelock entry ID, as returned by
+    ///   `fund_c_address_timelocked`.
+    /// * `ttl` (`u32`) — Desired TTL in ledgers (capped at `MAX_ALLOWED_TTL`).
+    ///
+    /// # Authorization
+    ///
+    /// Requires the current admin's `require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::TimelockNotFound`] — No entry exists for `id`.
+    ///
+    /// # Events
+    ///
+    /// * `("TimelockTtlExtended",)` — data: `(admin, id, actual_ttl)`
+    pub fn extend_timelock_ttl(env: Env, id: u64, ttl: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        let key = DataKey::Timelock(id);
+        if !env.storage().persistent().has(&key) {
+            return Err(BridgeError::TimelockNotFound);
+        }
+        let max_ttl = if ttl > MAX_ALLOWED_TTL {
+            MAX_ALLOWED_TTL
+        } else {
+            ttl
+        };
+        let threshold = max_ttl / 4;
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, threshold, max_ttl);
+        env.events()
+            .publish(("TimelockTtlExtended",), (admin, id, max_ttl));
+        Ok(())
+    }
+
+    /// Extends the persistent-storage TTL for a specific commit-reveal entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` (`u64`) — The commitment ID, as returned by `commit_fund`.
+    /// * `ttl` (`u32`) — Desired TTL in ledgers (capped at `MAX_ALLOWED_TTL`).
+    ///
+    /// # Authorization
+    ///
+    /// Requires the current admin's `require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::CommitmentNotFound`] — No entry exists for `id`.
+    ///
+    /// # Events
+    ///
+    /// * `("CommitmentTtlExtended",)` — data: `(admin, id, actual_ttl)`
+    pub fn extend_commitment_ttl(env: Env, id: u64, ttl: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        let key = DataKey::Commitment(id);
+        if !env.storage().persistent().has(&key) {
+            return Err(BridgeError::CommitmentNotFound);
+        }
+        let max_ttl = if ttl > MAX_ALLOWED_TTL {
+            MAX_ALLOWED_TTL
+        } else {
+            ttl
+        };
+        let threshold = max_ttl / 4;
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, threshold, max_ttl);
+        env.events()
+            .publish(("CommitmentTtlExtended",), (admin, id, max_ttl));
+        Ok(())
+    }
+
+    /// Extends the persistent-storage TTL for a registered relayer's entry.
+    ///
+    /// # Arguments
+    ///
+    /// * `pubkey` (`BytesN<32>`) — The relayer's Ed25519 public key.
+    /// * `ttl` (`u32`) — Desired TTL in ledgers (capped at `MAX_ALLOWED_TTL`).
+    ///
+    /// # Authorization
+    ///
+    /// Requires the current admin's `require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::NotRelayer`] — `pubkey` is not a registered relayer.
+    ///
+    /// # Events
+    ///
+    /// * `("RelayerTtlExtended",)` — data: `(admin, pubkey, actual_ttl)`
+    pub fn extend_relayer_ttl(env: Env, pubkey: BytesN<32>, ttl: u32) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        let key = DataKey::Relayer(pubkey.clone());
+        if !env.storage().persistent().has(&key) {
+            return Err(BridgeError::NotRelayer);
+        }
+        let max_ttl = if ttl > MAX_ALLOWED_TTL {
+            MAX_ALLOWED_TTL
+        } else {
+            ttl
+        };
+        let threshold = max_ttl / 4;
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, threshold, max_ttl);
+        env.events()
+            .publish(("RelayerTtlExtended",), (admin, pubkey, max_ttl));
+        Ok(())
+    }
+
+    /// Extends the persistent-storage TTL for all per-`(source, asset)` and
+    /// per-`source` keys used by the core funding paths: `SourceDailyLimit`,
+    /// the current day's `DailyUsage`, `UserDeposit`, `SourceBridgedVolume`,
+    /// the sequential `Nonce`, and the auth-entry `AuthNonce` counter.
+    ///
+    /// Only keys that already exist in storage are extended; missing keys are
+    /// silently skipped, mirroring `extend_persistent_ttl`.
+    ///
+    /// # Arguments
+    ///
+    /// * `source` (`Address`) — The address whose per-source entries should
+    ///   have their TTL extended.
+    /// * `asset` (`Address`) — The asset half of the `(source, asset)` keys.
+    /// * `ttl` (`u32`) — Desired TTL in ledgers (capped at `MAX_ALLOWED_TTL`).
+    ///
+    /// # Authorization
+    ///
+    /// Requires the current admin's `require_auth()`.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    ///
+    /// # Events
+    ///
+    /// * `("SourcePersistentTtlExtended",)` — data: `(admin, source, asset, actual_ttl)`
+    pub fn extend_source_persistent_ttl(
+        env: Env,
+        source: Address,
+        asset: Address,
+        ttl: u32,
+    ) -> Result<(), BridgeError> {
+        let _guard = ReentrancyGuard::enter(&env);
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        let max_ttl = if ttl > MAX_ALLOWED_TTL {
+            MAX_ALLOWED_TTL
+        } else {
+            ttl
+        };
+        let threshold = max_ttl / 4;
+        let day = current_day(&env);
+        let keys = [
+            DataKey::SourceDailyLimit(source.clone(), asset.clone()),
+            DataKey::DailyUsage(source.clone(), asset.clone(), day),
+            DataKey::UserDeposit(source.clone(), asset.clone()),
+            DataKey::SourceBridgedVolume(source.clone()),
+            DataKey::Nonce(source.clone()),
+            DataKey::AuthNonce(source.clone()),
+        ];
+        for key in keys.iter() {
+            if env.storage().persistent().has(key) {
+                env.storage()
+                    .persistent()
+                    .extend_ttl(key, threshold, max_ttl);
+            }
+        }
+        env.events().publish(
+            ("SourcePersistentTtlExtended",),
+            (admin, source, asset, max_ttl),
+        );
         Ok(())
     }
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1054,12 +1054,29 @@ fn read_loyalty_amount_per_fund(env: &Env) -> i128 {
         .unwrap_or(0)
 }
 
+/// Mints (transfers) the configured loyalty reward to `recipient`, unless the
+/// contract's loyalty-token reserve is insufficient.
+///
+/// The contract's own loyalty-token balance is checked before attempting the
+/// transfer. If the reserve is depleted, minting is skipped and a
+/// `LoyaltyMintSkipped` event is emitted instead of letting the underlying
+/// token transfer trap — a depleted loyalty reserve must never revert the
+/// funding call that triggered it.
 fn mint_loyalty_tokens(env: &Env, recipient: &Address) {
     if let Some(loyalty_token) = read_loyalty_token(env) {
         let amount = read_loyalty_amount_per_fund(env);
         if amount > 0 {
             let token_client = token::Client::new(env, &loyalty_token);
-            token_client.transfer(&env.current_contract_address(), recipient, &amount);
+            let contract_addr = env.current_contract_address();
+            let reserve = token_client.balance(&contract_addr);
+            if reserve < amount {
+                env.events().publish(
+                    ("LoyaltyMintSkipped", recipient.clone()),
+                    (amount, reserve),
+                );
+                return;
+            }
+            token_client.transfer(&contract_addr, recipient, &amount);
         }
     }
 }

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3097,3 +3097,51 @@ fn test_emergency_migrate_non_admin_rejected() {
     bridge.emergency_migrate(&new_contract, &true);
 }
 
+// --------- Loyalty reserve depletion tests ---------
+
+#[test]
+fn test_fund_succeeds_when_loyalty_reserve_depleted() {
+    let env = Env::default();
+    let (bridge, user, token_id, admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    // Configure a loyalty token and reward, but never fund the bridge's
+    // loyalty-token reserve — it should be zero.
+    let loyalty_token_id = env.register(TestToken, ());
+    init_token(&env, &loyalty_token_id, &admin);
+    bridge.set_loyalty_token(&loyalty_token_id, &100i128);
+    assert_eq!(check_balance(&env, &loyalty_token_id, &bridge.address), 0i128);
+
+    // fund_c_address must still succeed end-to-end even though the loyalty
+    // transfer inside it cannot be satisfied.
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
+
+    assert_eq!(check_balance(&env, &token_id, &target), 500i128);
+    // No loyalty tokens were (or could be) minted.
+    assert_eq!(check_balance(&env, &loyalty_token_id, &user), 0i128);
+
+    // A LoyaltyMintSkipped event was emitted instead of a trap.
+    assert_eq!(
+        count_events_with_topic(&env, &bridge.address, "LoyaltyMintSkipped"),
+        1
+    );
+    assert_eq!(count_events_with_topic(&env, &bridge.address, "CAddressFunded"), 1);
+}
+
+#[test]
+fn test_fund_mints_loyalty_when_reserve_sufficient() {
+    let env = Env::default();
+    let (bridge, user, token_id, admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    let loyalty_token_id = env.register(TestToken, ());
+    init_token(&env, &loyalty_token_id, &admin);
+    bridge.set_loyalty_token(&loyalty_token_id, &100i128);
+    mint_tokens(&env, &loyalty_token_id, &bridge.address, 1000i128);
+
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
+
+    assert_eq!(check_balance(&env, &loyalty_token_id, &user), 100i128);
+    assert_eq!(check_balance(&env, &loyalty_token_id, &bridge.address), 900i128);
+}
+

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3224,3 +3224,76 @@ fn test_extend_timelock_ttl_rejects_unknown_id() {
     );
 }
 
+// --------- TTL floor validation tests ---------
+
+/// Without a floor, setting the max instance TTL to `0` would make
+/// `extend_instance_ttl`'s `threshold = max_ttl / 4` evaluate to `0`,
+/// effectively disabling TTL extension forever and risking near-term expiry
+/// of the entire instance (including the `Admin` entry).
+#[test]
+fn test_set_max_instance_ttl_rejects_zero() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let (before_instance, before_persistent, _, _) = bridge.query_ttl_config();
+
+    assert_eq!(
+        bridge.try_set_max_instance_ttl(&0u32),
+        Err(Ok(BridgeError::InvalidTtl))
+    );
+
+    // A too-low value below the floor is likewise rejected.
+    assert_eq!(
+        bridge.try_set_max_instance_ttl(&1u32),
+        Err(Ok(BridgeError::InvalidTtl))
+    );
+
+    // Config is left untouched by the rejected calls.
+    let (after_instance, after_persistent, _, _) = bridge.query_ttl_config();
+    assert_eq!(before_instance, after_instance);
+    assert_eq!(before_persistent, after_persistent);
+}
+
+#[test]
+fn test_set_max_persistent_ttl_rejects_zero() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let (before_instance, before_persistent, _, _) = bridge.query_ttl_config();
+
+    assert_eq!(
+        bridge.try_set_max_persistent_ttl(&0u32),
+        Err(Ok(BridgeError::InvalidTtl))
+    );
+    assert_eq!(
+        bridge.try_set_max_persistent_ttl(&1u32),
+        Err(Ok(BridgeError::InvalidTtl))
+    );
+
+    let (after_instance, after_persistent, _, _) = bridge.query_ttl_config();
+    assert_eq!(before_instance, after_instance);
+    assert_eq!(before_persistent, after_persistent);
+}
+
+#[test]
+fn test_set_max_instance_ttl_accepts_valid_value() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.set_max_instance_ttl(&500_000u32);
+
+    let (instance_ttl, _, _, _) = bridge.query_ttl_config();
+    assert_eq!(instance_ttl, 500_000u32);
+}
+

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3145,3 +3145,31 @@ fn test_fund_mints_loyalty_when_reserve_sufficient() {
     assert_eq!(check_balance(&env, &loyalty_token_id, &bridge.address), 900i128);
 }
 
+// --------- Instance TTL extension tests ---------
+
+/// `initialize` sets the instance TTL to `MAX_ALLOWED_TTL` (3_110_400 ledgers)
+/// from sequence 0, so the original live-until ledger is ~3_110_400. This test
+/// advances close to (but before) that boundary, calls only
+/// `fund_c_address` (never `extend_instance_ttl` directly), then advances
+/// well past the *original* boundary. If `fund_c_address` did not refresh
+/// the instance TTL, any instance-storage access below would panic on an
+/// expired contract instance, permanently bricking the contract.
+#[test]
+fn test_fund_c_address_extends_instance_ttl_past_original_threshold() {
+    let env = Env::default();
+    let (bridge, user, token_id, admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    // Close to, but still before, the TTL boundary set by `initialize` alone.
+    env.ledger().set_sequence_number(3_000_000);
+    bridge.fund_c_address(&user, &target, &token_id, &500i128, &None, &None);
+
+    // Well past the *original* boundary (3_110_400). Only reachable without a
+    // panic if fund_c_address refreshed the instance TTL above.
+    env.ledger().set_sequence_number(6_000_000);
+
+    assert_eq!(bridge.query_admin(), admin);
+    assert!(bridge.query_is_initialized());
+    assert_eq!(check_balance(&env, &token_id, &target), 500i128);
+}
+

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3173,3 +3173,54 @@ fn test_fund_c_address_extends_instance_ttl_past_original_threshold() {
     assert_eq!(check_balance(&env, &token_id, &target), 500i128);
 }
 
+// --------- Persistent TTL extension tests ---------
+
+/// `extend_persistent_ttl` only ever refreshed the three per-asset counter
+/// keys. A `TimelockEntry` created via `fund_c_address_timelocked` had no
+/// admin-callable way to have its own TTL refreshed, so a long-dated
+/// timelock's persistent entry could be archived by the network before
+/// `release_time`, making it permanently unclaimable. This test exercises
+/// the new `extend_timelock_ttl` companion function and confirms the entry
+/// survives a ledger advance far past the default (unextended) persistent
+/// TTL window.
+#[test]
+fn test_extend_persistent_ttl_covers_timelock_entries() {
+    let env = Env::default();
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    let release_time = 1_000_000u64;
+    let id = bridge.fund_c_address_timelocked(
+        &user,
+        &target,
+        &token_id,
+        &500i128,
+        &release_time,
+        &0u64,
+    );
+
+    // Refresh the entry's persistent TTL well beyond the default
+    // (network-baseline) window it was created with.
+    bridge.extend_timelock_ttl(&id, &3_000_000u32);
+
+    // Advance far past where the *default* persistent TTL would have expired
+    // the entry, but still within the window granted above.
+    env.ledger().set_sequence_number(2_500_000);
+
+    let entry = bridge.query_timelocked(&id);
+    assert_eq!(entry.target, target);
+    assert_eq!(entry.amount, 500i128);
+    assert!(!entry.claimed);
+}
+
+#[test]
+fn test_extend_timelock_ttl_rejects_unknown_id() {
+    let env = Env::default();
+    let (bridge, _user, _token_id, _admin) = setup_bridge(&env);
+
+    assert_eq!(
+        bridge.try_extend_timelock_ttl(&999u64, &1_000u32),
+        Err(Ok(BridgeError::TimelockNotFound))
+    );
+}
+


### PR DESCRIPTION
closes #230 
closes #231 
closes #232 
closes #233

1. Loyalty mint reserve guard — mint_loyalty_tokens now checks the contract's loyalty-token balance before transferring; if depleted it skips the mint and emits LoyaltyMintSkipped instead of trapping and reverting the whole funding call.
2. Instance TTL on every mutating call — extend_instance_ttl(&env) added to ~40 previously-uncovered mutating functions (all funding paths, admin setters, relayer/blocklist/allowlist management, etc.), matching the module doc's claim.
3. Persistent TTL coverage expanded — extend_persistent_ttl now also covers AssetStats/AssetFeeCap; added extend_timelock_ttl, extend_commitment_ttl, extend_relayer_ttl, and extend_source_persistent_ttl for the previously-uncovered keys.
4. TTL floor validation — set_max_instance_ttl/set_max_persistent_ttl now reject ttl < MIN_ALLOWED_TTL via a new BridgeError::InvalidTtl, preventing a zero-TTL from disabling extension entirely.