### PR TITLE
feat(sdk): add missing bridge wrappers

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -1,6 +1,6 @@
 import { OnboardingBridgeSDK } from '../bridge';
 import { OffRampIntegration } from '../offramp';
-import { SorobanRpc, scValToNative, xdr, Address, nativeToScVal } from '@stellar/stellar-sdk';
+import { SorobanRpc, Contract, scValToNative, xdr, Address, nativeToScVal } from '@stellar/stellar-sdk';
 
 jest.mock('@stellar/stellar-sdk', () => ({
   SorobanRpc: {
@@ -113,6 +113,81 @@ describe('OnboardingBridgeSDK', () => {
       expect(result.status).toBe('failed');
       expect(result.error).toBe('Network timeout');
       expect(result.hash).toBe('');
+    });
+  });
+
+  describe('fundCAddressWithReferral', () => {
+    it('submits fund_c_address_with_referral', async () => {
+      const result = await sdk.fundCAddressWithReferral(
+        { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000', referrer: MOCK_ADDRESS },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'fund_c_address_with_referral',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('commitFund', () => {
+    it('submits commit_fund', async () => {
+      const result = await sdk.commitFund(
+        {
+          source: MOCK_ADDRESS,
+          target: MOCK_ASSET,
+          asset: MOCK_ASSET,
+          amount: '1000',
+          amountHash: 'ab'.repeat(32),
+          deadline: 123456,
+        },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'commit_fund',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('revealFund', () => {
+    it('submits reveal_fund', async () => {
+      const result = await sdk.revealFund(
+        {
+          commitmentId: 1,
+          source: MOCK_ADDRESS,
+          target: MOCK_ASSET,
+          asset: MOCK_ASSET,
+          amount: '1000',
+          nonce: 42,
+        },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'reveal_fund',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
     });
   });
 
@@ -375,6 +450,47 @@ describe('OnboardingBridgeSDK', () => {
     });
   });
 
+  describe('setReferralRate', () => {
+    it('submits set_referral_rate', async () => {
+      const result = await sdk.setReferralRate(2000, mockKeypair);
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'set_referral_rate',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('setLoyaltyToken', () => {
+    it('submits set_loyalty_token', async () => {
+      const result = await sdk.setLoyaltyToken(MOCK_ASSET, '10', mockKeypair);
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'set_loyalty_token',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('setFeeTiers', () => {
+    it('submits set_fee_tiers', async () => {
+      const result = await sdk.setFeeTiers(
+        [{ min_volume: '0', max_volume: '1000', fee_bps: 50 }],
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith('set_fee_tiers', expect.anything());
+    });
+  });
+
   describe('setFeeCollector', () => {
     it('returns pending status on success', async () => {
       const result = await sdk.setFeeCollector(MOCK_ADDRESS, mockKeypair);
@@ -416,6 +532,55 @@ describe('OnboardingBridgeSDK', () => {
       mockProvider.simulateTransaction.mockResolvedValue({ error: 'contract error' });
 
       await expect(sdk.getFee()).rejects.toThrow('Failed to get fee');
+    });
+  });
+
+  describe('queryReferralRate', () => {
+    it('returns referral rate as a number', async () => {
+      (scValToNative as jest.Mock).mockReturnValue(2000);
+      mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+      await expect(sdk.queryReferralRate()).resolves.toBe(2000);
+    });
+  });
+
+  describe('queryCommitment', () => {
+    it('returns commitment entry from simulation result', async () => {
+      const entry = { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, revealed: false };
+      (scValToNative as jest.Mock).mockReturnValue(entry);
+      mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+      await expect(sdk.queryCommitment(1)).resolves.toBe(entry);
+    });
+  });
+
+  describe('queryLoyaltyToken', () => {
+    it('returns loyalty token config from simulation result', async () => {
+      const config = { token: MOCK_ASSET, amount_per_fund: '10' };
+      (scValToNative as jest.Mock).mockReturnValue(config);
+      mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+      await expect(sdk.queryLoyaltyToken()).resolves.toBe(config);
+    });
+  });
+
+  describe('queryFeeTiers', () => {
+    it('returns configured fee tiers from simulation result', async () => {
+      const tiers = [{ min_volume: '0', max_volume: '1000', fee_bps: 50 }];
+      (scValToNative as jest.Mock).mockReturnValue(tiers);
+      mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+      await expect(sdk.queryFeeTiers()).resolves.toBe(tiers);
+    });
+  });
+
+  describe('queryCurrentTier', () => {
+    it('returns current fee tier from simulation result', async () => {
+      const tier = { min_volume: '0', max_volume: '1000', fee_bps: 50 };
+      (scValToNative as jest.Mock).mockReturnValue(tier);
+      mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+      await expect(sdk.queryCurrentTier(MOCK_ADDRESS)).resolves.toBe(tier);
     });
   });
 

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -11,8 +11,14 @@
 import {
   BridgeConfig,
   FundCOptions,
+  FundCAddressWithReferralOptions,
   BatchFundCOptions,
   BatchProgressCallback,
+  CommitFundOptions,
+  RevealFundOptions,
+  CommitmentEntry,
+  LoyaltyToken,
+  FeeTier,
   WithdrawFeesOptions,
   UpgradeOptions,
   ReclaimTokensOptions,
@@ -221,6 +227,216 @@ export class OnboardingBridgeSDK {
             this.hooks,
             'sendTransaction',
             { contractMethod: 'fund_c_address' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  async fundCAddressWithReferral(
+    options: FundCAddressWithReferralOptions,
+    sourceKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'fundCAddressWithReferral',
+      { source: options.source, target: options.target, asset: options.asset, amount: options.amount, referrer: options.referrer },
+      async () => {
+        try {
+          assertAccountAddress(options.source, 'source');
+          assertContractAddress(options.target, 'target');
+          assertContractAddress(options.asset, 'asset');
+          if (options.referrer) {
+            assertAccountAddress(options.referrer, 'referrer');
+          }
+
+          const sourceAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: options.source },
+            () => this.provider.getAccount(options.source),
+          );
+
+          const tx = new TransactionBuilder(sourceAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'fund_c_address_with_referral',
+                ...this.toScVals([
+                  options.source,
+                  options.target,
+                  options.asset,
+                  options.amount,
+                  options.referrer,
+                ]),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'fund_c_address_with_referral' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(sourceKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'fund_c_address_with_referral' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  async commitFund(
+    options: CommitFundOptions,
+    sourceKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'commitFund',
+      { source: options.source, target: options.target, asset: options.asset, deadline: options.deadline },
+      async () => {
+        try {
+          assertAccountAddress(options.source, 'source');
+          assertContractAddress(options.target, 'target');
+          assertContractAddress(options.asset, 'asset');
+
+          const sourceAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: options.source },
+            () => this.provider.getAccount(options.source),
+          );
+
+          const tx = new TransactionBuilder(sourceAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'commit_fund',
+                new Address(options.source).toScVal(),
+                new Address(options.target).toScVal(),
+                new Address(options.asset).toScVal(),
+                xdr.ScVal.scvBytes(Buffer.from(options.amountHash.replace(/^0x/, ''), 'hex')),
+                nativeToScVal(BigInt(options.deadline), { type: 'u64' }),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'commit_fund' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(sourceKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'commit_fund' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  async revealFund(
+    options: RevealFundOptions,
+    sourceKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'revealFund',
+      { commitmentId: options.commitmentId, source: options.source, target: options.target, asset: options.asset, amount: options.amount },
+      async () => {
+        try {
+          assertAccountAddress(options.source, 'source');
+          assertContractAddress(options.target, 'target');
+          assertContractAddress(options.asset, 'asset');
+
+          const sourceAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: options.source },
+            () => this.provider.getAccount(options.source),
+          );
+
+          const tx = new TransactionBuilder(sourceAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'reveal_fund',
+                nativeToScVal(BigInt(options.commitmentId), { type: 'u64' }),
+                new Address(options.source).toScVal(),
+                new Address(options.target).toScVal(),
+                new Address(options.asset).toScVal(),
+                nativeToScVal(BigInt(options.amount), { type: 'i128' }),
+                nativeToScVal(BigInt(options.nonce), { type: 'u64' }),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'reveal_fund' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(sourceKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'reveal_fund' },
             () => this.provider.sendTransaction(preparedTx),
           );
 
@@ -698,6 +914,22 @@ export class OnboardingBridgeSDK {
     return scVal ? Number(scValToNative(scVal)) : 0;
   }
 
+  async queryReferralRate(): Promise<number> {
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_referral_rate' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_referral_rate', [])),
+    );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to get referral rate: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    return scVal ? Number(scValToNative(scVal)) : 0;
+  }
+
   /**
    * Get the current fee-collector G-address.
    *
@@ -797,6 +1029,76 @@ export class OnboardingBridgeSDK {
 
     const scVal = (result as any).results?.[0]?.retval;
     return scVal ? scValToNative(scVal).toString() : '0';
+  }
+
+  async queryCommitment(id: string | number | bigint): Promise<CommitmentEntry | null> {
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_commitment' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTxWithScVals(
+          'query_commitment',
+          [nativeToScVal(BigInt(id), { type: 'u64' })],
+        ),
+      ),
+    );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to get commitment: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    return scVal ? scValToNative(scVal) as CommitmentEntry : null;
+  }
+
+  async queryLoyaltyToken(): Promise<LoyaltyToken | null> {
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_loyalty_token' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_loyalty_token', [])),
+    );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to get loyalty token: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    return scVal ? scValToNative(scVal) as LoyaltyToken : null;
+  }
+
+  async queryFeeTiers(): Promise<FeeTier[]> {
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_fee_tiers' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_fee_tiers', [])),
+    );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to get fee tiers: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    return scVal ? scValToNative(scVal) as FeeTier[] : [];
+  }
+
+  async queryCurrentTier(source: string): Promise<FeeTier | null> {
+    assertAccountAddress(source, 'source');
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_current_tier' },
+      () => this.provider.simulateTransaction(this.buildSimulationTx('query_current_tier', [source])),
+    );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to get current tier: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    return scVal ? scValToNative(scVal) as FeeTier : null;
   }
 
   /**
@@ -964,6 +1266,191 @@ export class OnboardingBridgeSDK {
             this.hooks,
             'sendTransaction',
             { contractMethod: 'set_fee_bps' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  async setReferralRate(
+    bps: number,
+    adminKeypair: Keypair,
+    nonce?: string | number | bigint,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'setReferralRate',
+      { bps, nonce },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
+
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'set_referral_rate',
+                nativeToScVal(bps, { type: 'u32' }),
+                nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(nonce), { type: 'u64' }),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_referral_rate' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_referral_rate' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  async setLoyaltyToken(
+    token: string,
+    amountPerFund: string | number | bigint,
+    adminKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'setLoyaltyToken',
+      { token, amountPerFund },
+      async () => {
+        try {
+          assertContractAddress(token, 'token');
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
+
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'set_loyalty_token',
+                new Address(token).toScVal(),
+                nativeToScVal(BigInt(amountPerFund), { type: 'i128' }),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_loyalty_token' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_loyalty_token' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  async setFeeTiers(
+    tiers: FeeTier[],
+    adminKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'setFeeTiers',
+      { tierCount: tiers.length },
+      async () => {
+        try {
+          const adminAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: adminKeypair.publicKey() },
+            () => this.provider.getAccount(adminKeypair.publicKey()),
+          );
+
+          const tx = new TransactionBuilder(adminAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'set_fee_tiers',
+                xdr.ScVal.scvVec(tiers.map((tier) => this.feeTierToScVal(tier))),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'set_fee_tiers' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(adminKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'set_fee_tiers' },
             () => this.provider.sendTransaction(preparedTx),
           );
 
@@ -1957,5 +2444,34 @@ export class OnboardingBridgeSDK {
       .addOperation(this.contract.call(method, ...this.toScVals(args)))
       .setTimeout(30)
       .build();
+  }
+
+  private buildSimulationTxWithScVals(method: string, args: xdr.ScVal[]) {
+    const source = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const account = new Account(source, '0');
+    return new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(this.contract.call(method, ...args))
+      .setTimeout(30)
+      .build();
+  }
+
+  private feeTierToScVal(tier: FeeTier): xdr.ScVal {
+    return xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({
+        key: xdr.ScVal.scvSymbol('fee_bps'),
+        val: nativeToScVal(tier.fee_bps, { type: 'u32' }),
+      }),
+      new xdr.ScMapEntry({
+        key: xdr.ScVal.scvSymbol('max_volume'),
+        val: nativeToScVal(BigInt(tier.max_volume), { type: 'i128' }),
+      }),
+      new xdr.ScMapEntry({
+        key: xdr.ScVal.scvSymbol('min_volume'),
+        val: nativeToScVal(BigInt(tier.min_volume), { type: 'i128' }),
+      }),
+    ]);
   }
 }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -165,6 +165,48 @@ export interface FundCOptions {
   amount: string;
 }
 
+export interface FundCAddressWithReferralOptions extends FundCOptions {
+  /** Optional referrer address that receives a configured share of the fee. */
+  referrer?: string;
+}
+
+export interface CommitFundOptions extends FundCOptions {
+  /** 32-byte sha256(amount_be16 || nonce_be8) commitment hash as hex. */
+  amountHash: string;
+
+  /** Unix timestamp deadline for revealing the commitment. */
+  deadline: string | number | bigint;
+}
+
+export interface RevealFundOptions extends FundCOptions {
+  /** Commitment ID returned by commitFund. */
+  commitmentId: string | number | bigint;
+
+  /** Blinding nonce used to compute amountHash. */
+  nonce: string | number | bigint;
+}
+
+export interface CommitmentEntry {
+  source: string;
+  target: string;
+  asset: string;
+  amount_hash: unknown;
+  deadline: string | number | bigint;
+  committed_at_ledger: number;
+  revealed: boolean;
+}
+
+export interface LoyaltyToken {
+  token: string;
+  amount_per_fund: string | number | bigint;
+}
+
+export interface FeeTier {
+  min_volume: string | number | bigint;
+  max_volume: string | number | bigint;
+  fee_bps: number;
+}
+
 /**
  * Options for funding multiple C-addresses in one or more transactions via
  * {@link OnboardingBridgeSDK.batchFundCAddresses}.


### PR DESCRIPTION
Summary:
- Add SDK wrappers for commit/reveal funding, referral funding, loyalty token config, and fee tiers.
- Add focused Jest coverage for each new wrapper.

Closes: #343
Closes: #344
Closes: #345
Closes: #346

Validation:
- npm run build
- npm test -- --runInBand bridge.test.ts
- npm run lint (blocked: sdk lint script references eslint, but eslint is not installed/declared in sdk dependencies)