### PR TITLE
fix: resolve assigned bridge issues

### DIFF
--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1,8 +1,14 @@
-use crate::{BridgeError, FeeTier, MetaFundParams, OnboardingBridge};
+use crate::{
+    BridgeError, DataKey, FeeTier, MetaFundParams, OnboardingBridge,
+    CRITICAL_ENTRY_TTL_THRESHOLD, MAX_ALLOWED_TTL,
+};
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    testutils::{Address as _, Events, Ledger},
+    testutils::{
+        storage::{Instance as _, Persistent as _},
+        Address as _, Events, Ledger,
+    },
     Address, Bytes, BytesN, Env, IntoVal, Vec,
 };
 
@@ -3651,6 +3657,100 @@ fn test_batch_fund_applies_tiered_fee() {
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 1i128);
 }
 
+#[test]
+fn test_extend_instance_ttl_extends_instance_storage() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(MAX_ALLOWED_TTL - 10);
+
+    bridge.extend_instance_ttl(&200_000u32);
+
+    let ttl = env.as_contract(&bridge_id, || env.storage().instance().get_ttl());
+    assert!(ttl >= 200_000);
+}
+
+#[test]
+fn test_extend_persistent_ttl_extends_asset_keys() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    bridge.fund_c_address(
+        &user,
+        &Address::generate(&env),
+        &token_id,
+        &500i128,
+        &None,
+        &None,
+    );
+    bridge.set_asset_fee_cap(&token_id, &1000u32);
+
+    env.ledger().set_sequence_number(MAX_ALLOWED_TTL - 10);
+    bridge.extend_persistent_ttl(&token_id, &200_000u32);
+
+    let expected_keys = [
+        DataKey::AccruedFees(token_id.clone()),
+        DataKey::TotalBridged(token_id.clone()),
+        DataKey::TotalFeesCollected(token_id.clone()),
+        DataKey::AssetStats(token_id.clone()),
+        DataKey::AssetFeeCap(token_id.clone()),
+    ];
+    for key in expected_keys.iter() {
+        let ttl = env.as_contract(&bridge_id, || env.storage().persistent().get_ttl(key));
+        assert!(ttl >= 200_000);
+    }
+}
+
+#[test]
+fn test_set_max_ttl_updates_config() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(MAX_ALLOWED_TTL - 10);
+
+    bridge.set_max_instance_ttl(&200_000u32);
+    let instance_ttl = env.as_contract(&bridge_id, || env.storage().instance().get_ttl());
+    assert!(instance_ttl >= 200_000);
+
+    bridge.set_max_persistent_ttl(&300_000u32);
+
+    let (instance_ttl, persistent_ttl, hard_ceiling, critical_threshold) =
+        bridge.query_ttl_config();
+    assert_eq!(instance_ttl, 200_000);
+    assert_eq!(persistent_ttl, 300_000);
+    assert_eq!(hard_ceiling, MAX_ALLOWED_TTL);
+    assert_eq!(critical_threshold, CRITICAL_ENTRY_TTL_THRESHOLD);
+}
+
+#[test]
+fn test_query_ttl_config_returns_current_settings() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let (instance_ttl, persistent_ttl, hard_ceiling, critical_threshold) =
+        bridge.query_ttl_config();
+    assert_eq!(instance_ttl, MAX_ALLOWED_TTL);
+    assert_eq!(persistent_ttl, MAX_ALLOWED_TTL);
+    assert_eq!(hard_ceiling, MAX_ALLOWED_TTL);
+    assert_eq!(critical_threshold, CRITICAL_ENTRY_TTL_THRESHOLD);
+}
+
 // fund_c_address_with_referral computed its fee straight from the global rate via
 // get_effective_fee_bps, never consulting the caller's volume tier.
 #[test]
@@ -3682,4 +3782,3 @@ fn test_referral_fund_applies_tiered_fee() {
     assert_eq!(check_balance(&env, &token_id, &target), 999i128);
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 1i128);
 }
-

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -225,6 +225,7 @@ async function initialize(
         Address.fromString(admin.publicKey()).toScVal(),
         Address.fromString(cfg.feeCollectorPublicKey).toScVal(),
         nativeToScVal(cfg.feeBps, { type: 'u32' }),
+        nativeToScVal(null),
       ),
     )
     .setTimeout(30)

--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -373,6 +373,16 @@ describe('OnboardingBridgeSDK', () => {
       expect(result.status).toBe('pending');
       expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
     });
+
+    it('rejects fee bps outside the documented range before RPC', async () => {
+      await expect(sdk.setFee(-1, mockKeypair)).rejects.toThrow(
+        'Fee basis points must be between 0 and 1000',
+      );
+      await expect(sdk.setFee(1001, mockKeypair)).rejects.toThrow(
+        'Fee basis points must be between 0 and 1000',
+      );
+      expect(mockProvider.getAccount).not.toHaveBeenCalled();
+    });
   });
 
   describe('setFeeCollector', () => {
@@ -812,11 +822,12 @@ describe('address validation', () => {
 describe('Error handling - invalid inputs', () => {
   let sdk: OnboardingBridgeSDK;
   let mockKeypair: any;
+  let mockProvider: any;
 
   beforeEach(() => {
     jest.clearAllMocks();
     mockKeypair = { publicKey: jest.fn().mockReturnValue(MOCK_ADDRESS), sign: jest.fn() };
-    const mockProvider = {
+    mockProvider = {
       getAccount: jest.fn().mockResolvedValue({}),
       prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
       sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
@@ -883,9 +894,11 @@ describe('Error handling - invalid inputs', () => {
     expect(result.status).toBe('pending');
   });
 
-  it('setFee passes negative fee bps to contract (no client-side validation)', async () => {
-    const result = await sdk.setFee(-100, mockKeypair);
-    expect(result.status).toBe('pending');
+  it('setFee rejects negative fee bps before RPC', async () => {
+    await expect(sdk.setFee(-100, mockKeypair)).rejects.toThrow(
+      'Fee basis points must be between 0 and 1000',
+    );
+    expect(mockProvider.getAccount).not.toHaveBeenCalled();
   });
 
   it('reclaimTokens rejects invalid to address (C-address)', async () => {

--- a/sdk/src/__tests__/cachedBridge.test.ts
+++ b/sdk/src/__tests__/cachedBridge.test.ts
@@ -58,11 +58,13 @@ describe('CachedContractClient', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    (scValToNative as jest.Mock).mockReset();
 
     mockProvider = {
       getAccount: jest.fn().mockResolvedValue({}),
       prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
       sendTransaction: jest.fn().mockResolvedValue({ hash: 'mock_tx_hash', status: 'PENDING' }),
+      getTransaction: jest.fn().mockResolvedValue({ status: 'SUCCESS' }),
       simulateTransaction: jest.fn(),
     };
 
@@ -112,6 +114,35 @@ describe('CachedContractClient', () => {
 
     await wrapper.getFee();
     expect(mockProvider.simulateTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates cache again after confirmation if a racing read repopulates it', async () => {
+    let confirm!: () => void;
+    const confirmation = new Promise<void>((resolve) => {
+      confirm = resolve;
+    });
+    mockProvider.getTransaction.mockImplementation(() =>
+      confirmation.then(() => ({ status: 'SUCCESS' })),
+    );
+
+    (scValToNative as jest.Mock)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(50)
+      .mockReturnValueOnce(60);
+    mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+    await wrapper.getFee();
+    await wrapper.client.setAdmin(MOCK_ADDRESS, { publicKey: () => MOCK_ADDRESS, sign: jest.fn() });
+    await wrapper.getFee();
+    expect(await cache.get('getFee')).toBe(50);
+
+    confirm();
+    await confirmation;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(await cache.get('getFee')).toBeUndefined();
+    await expect(wrapper.getFee()).resolves.toBe(60);
   });
 
   it('allows manual invalidation via invalidateCache', async () => {

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -926,6 +926,10 @@ export class OnboardingBridgeSDK {
     newFeeBps: number,
     adminKeypair: Keypair,
   ): Promise<TransactionResult> {
+    if (newFeeBps < 0 || newFeeBps > 1000) {
+      throw new Error('Fee basis points must be between 0 and 1000');
+    }
+
     return withTransactionHooks(
       this.hooks,
       'setFee',

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -236,12 +236,27 @@ class ContractClient {
 
     if (response.status !== 'ERROR') {
       await Promise.all(CACHE_KEYS.map((key) => this.cache.delete(key)));
+      void this.invalidateAfterConfirmation(response.hash);
     }
 
     return {
       hash: response.hash,
       status: response.status === 'ERROR' ? 'failed' : 'pending',
     };
+  }
+
+  private async invalidateAfterConfirmation(hash: string): Promise<void> {
+    try {
+      let result = await this.provider.getTransaction(hash);
+      while (result.status === 'NOT_FOUND') {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        result = await this.provider.getTransaction(hash);
+      }
+      await Promise.all(CACHE_KEYS.map((key) => this.cache.delete(key)));
+    } catch {
+      // Cache was already invalidated on submission; confirmation invalidation
+      // is best-effort and must not surface as an unhandled background error.
+    }
   }
 
   async fundCAddress(options: any, sourceKeypair: Keypair): Promise<TransactionResult> {


### PR DESCRIPTION
Summary:
- Add missing initialize nonce argument in deploy script.
- Validate setFee bps client-side and update SDK tests.
- Invalidate cached bridge reads again after transaction confirmation.
- Add TTL admin coverage for instance, persistent, max TTL, and query config paths.

Closes: #267
Closes: #351
Closes: #352
Closes: #353

Validation:
- npm test -- --runTestsByPath src/__tests__/bridge.test.ts src/__tests__/cachedBridge.test.ts
- npm run build

Not run:
- cargo test -p onboarding-bridge --features testutils (cargo/rust toolchain unavailable in this environment)
- npm run lint (repository script references eslint, but eslint is not installed in dependencies)