### PR TITLE
Fix/loyalty min amount reentrancy safemath

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -151,6 +151,8 @@ pub enum BridgeError {
     PoolNotWhitelisted = 42,
     /// `swap_route` contained more than one hop; multi-hop swaps are not supported.
     MultiHopNotSupported = 43,
+    /// A mutating call was re-entered while another call was already in progress.
+    Reentrant = 44,
 }
 
 // ---------------------------------------------------------------------------
@@ -1183,16 +1185,16 @@ struct ReentrancyGuard {
 }
 
 impl ReentrancyGuard {
-    fn enter(env: &Env) -> Self {
+    fn enter(env: &Env) -> Result<Self, BridgeError> {
         let entered: bool = env.storage()
             .instance()
             .get(&DataKey::Entered)
             .unwrap_or(false);
         if entered {
-            panic!("reentrant call");
+            return Err(BridgeError::Reentrant);
         }
         env.storage().instance().set(&DataKey::Entered, &true);
-        Self { env: env.clone() }
+        Ok(Self { env: env.clone() })
     }
 }
 
@@ -1261,7 +1263,7 @@ impl OnboardingBridge {
         fee_bps: u32,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         if read_initialized(&env) {
             return Err(BridgeError::AlreadyInitialized);
         }
@@ -1353,7 +1355,7 @@ impl OnboardingBridge {
         nonce: Option<u64>,
         deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if let Some(d) = deadline {
@@ -1468,7 +1470,7 @@ impl OnboardingBridge {
         nonce: Option<u64>,
         deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if targets.len() > MAX_BATCH_SIZE {
@@ -1613,7 +1615,7 @@ impl OnboardingBridge {
     /// // assert_eq!(bridge.query_fee_bps(), 200u32);
     /// ```
     pub fn set_fee_bps(env: Env, new_fee_bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if new_fee_bps > MAX_FEE_BPS {
@@ -1667,7 +1669,7 @@ impl OnboardingBridge {
         limit_amount: i128,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -1732,7 +1734,7 @@ impl OnboardingBridge {
         max_fee_bps: u32,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         if max_fee_bps > MAX_FEE_BPS {
             return Err(BridgeError::FeeTooHigh);
@@ -1792,7 +1794,7 @@ impl OnboardingBridge {
     /// // assert_eq!(bridge.query_fee_collector(), new_collector);
     /// ```
     pub fn set_fee_collector(env: Env, new_fee_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let mut config = read_bridge_config(&env);
@@ -1808,7 +1810,7 @@ impl OnboardingBridge {
     }
 
     pub fn propose_new_fee_collector(env: Env, new_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let admin = read_admin(&env);
@@ -1821,7 +1823,7 @@ impl OnboardingBridge {
     }
 
     pub fn accept_fee_collector(env: Env) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let pending = read_pending_fee_collector(&env).ok_or(BridgeError::Unauthorized)?;
@@ -1842,7 +1844,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let mut config = read_bridge_config(&env);
@@ -1858,7 +1860,7 @@ impl OnboardingBridge {
     }
 
     pub fn propose_new_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let admin = read_admin(&env);
@@ -1871,7 +1873,7 @@ impl OnboardingBridge {
     }
 
     pub fn accept_admin(env: Env) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         let pending = read_pending_admin(&env).ok_or(BridgeError::Unauthorized)?;
@@ -1892,7 +1894,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_minimum_amount(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         if amount < 0 {
@@ -1960,7 +1962,7 @@ impl OnboardingBridge {
     /// // bridge.withdraw_fees(&usdc, &5i128, &None);
     /// ```
     pub fn withdraw_fees(env: Env, asset: Address, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -1988,7 +1990,7 @@ impl OnboardingBridge {
     }
 
     pub fn set_max_withdraw_per_tx(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         if amount < 0 {
             return Err(BridgeError::InvalidAmount);
@@ -2037,7 +2039,7 @@ impl OnboardingBridge {
     ///
     /// * `("ReferralRateChanged", bps)` — no additional data.
     pub fn set_referral_rate(env: Env, bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         if bps > 10_000 {
             return Err(BridgeError::FeeTooHigh);
@@ -2129,7 +2131,7 @@ impl OnboardingBridge {
         amount: i128,
         referrer: Option<Address>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -2381,7 +2383,7 @@ impl OnboardingBridge {
     /// scheduling or executing upgrades, which are intentionally not pause-gated
     /// so that an upgrade can fix whatever condition required the pause.
     pub fn pause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         let admin = read_admin(&env);
@@ -2411,7 +2413,7 @@ impl OnboardingBridge {
     ///
     /// * `("ContractUnpaused",)` — data: `(admin,)`
     pub fn unpause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         let admin = read_admin(&env);
@@ -2463,7 +2465,7 @@ impl OnboardingBridge {
     /// The `old_hash` in the event lets off-chain monitors detect unexpected
     /// upgrades. Consider using the timelocked path for mainnet deployments.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         let admin = read_admin(&env);
@@ -2543,7 +2545,7 @@ impl OnboardingBridge {
         new_wasm_hash: BytesN<32>,
         nonce: Option<u64>,
     ) -> Result<u32, BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         let admin = read_admin(&env);
@@ -2604,7 +2606,7 @@ impl OnboardingBridge {
         expected_hash: BytesN<32>,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         let admin = read_admin(&env);
@@ -2664,7 +2666,7 @@ impl OnboardingBridge {
     ///
     /// * `("UpgradeCancelled",)` — data: `(cancelled_wasm_hash, admin)`
     pub fn cancel_upgrade(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
         let admin = read_admin(&env);
@@ -2706,7 +2708,7 @@ impl OnboardingBridge {
         new_contract: Address,
         migrate_data: bool,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_deactivated(&env)?;
 
@@ -2826,7 +2828,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_to_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2853,7 +2855,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_from_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2884,7 +2886,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_to_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2914,7 +2916,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_from_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -2947,7 +2949,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn set_allowlist_mode(env: Env, enabled: bool, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3024,7 +3026,7 @@ impl OnboardingBridge {
         destination: Address,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
@@ -3072,7 +3074,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3103,7 +3105,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3158,7 +3160,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_swap_pool(env: Env, pool: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3188,7 +3190,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_swap_pool(env: Env, pool: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3244,7 +3246,7 @@ impl OnboardingBridge {
         token: Address,
         amount_per_fund: i128,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3313,7 +3315,7 @@ impl OnboardingBridge {
     ///
     /// * `("FeeTiersSet", admin)` — data: `(tiers.len(),)`
     pub fn set_fee_tiers(env: Env, tiers: Vec<FeeTier>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3456,7 +3458,7 @@ impl OnboardingBridge {
         amount: i128,
         sigs: Vec<RelayerSig>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -3576,7 +3578,7 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn add_relayer(env: Env, pubkey: BytesN<32>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         read_admin(&env).require_auth();
         add_relayer(&env, &pubkey);
@@ -3603,7 +3605,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::BelowThreshold`] — Removing this relayer would drop the
     ///   count below the required threshold.
     pub fn remove_relayer(env: Env, pubkey: BytesN<32>) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         read_admin(&env).require_auth();
         // Prevent removing below threshold
@@ -3632,7 +3634,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::ThresholdExceedsRelayers`] — `threshold` is greater than
     ///   the number of registered relayers.
     pub fn set_relayer_threshold(env: Env, threshold: u32) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         read_admin(&env).require_auth();
         if threshold > relayer_count(&env) {
@@ -3729,7 +3731,7 @@ impl OnboardingBridge {
         release_time: u64,
         cliff_time: u64,
     ) -> Result<u64, BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if amount <= 0 {
@@ -3811,7 +3813,7 @@ impl OnboardingBridge {
     /// prevents re-entrancy. The fee rate is the **current** global rate at
     /// claim time, which may differ from the rate at deposit time.
     pub fn claim_timelocked(env: Env, id: u64) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
 
@@ -3890,7 +3892,7 @@ impl OnboardingBridge {
     ///
     /// * `("InstanceTtlExtended",)` — data: `(admin, actual_ttl)`
     pub fn extend_instance_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3934,7 +3936,7 @@ impl OnboardingBridge {
         key_asset: Address,
         ttl: u32,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -3978,7 +3980,7 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn set_max_instance_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -4009,7 +4011,7 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn set_max_persistent_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
@@ -4112,7 +4114,7 @@ impl OnboardingBridge {
         valid_after_ledger: u32,
         valid_before_ledger: u32,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         source.require_auth();
@@ -4210,7 +4212,7 @@ impl OnboardingBridge {
         amount_hash: BytesN<32>,
         deadline: u64,
     ) -> Result<u64, BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
         if env.ledger().timestamp() >= deadline {
@@ -4291,7 +4293,7 @@ impl OnboardingBridge {
         amount: i128,
         nonce: u64,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
 
@@ -4454,7 +4456,7 @@ impl OnboardingBridge {
         min_target_amount: i128,
         swap_route: Vec<Address>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
 
@@ -4603,7 +4605,7 @@ impl OnboardingBridge {
         pubkey: BytesN<32>,
         signature: BytesN<64>,
     ) -> Result<(), BridgeError> {
-        let _guard = ReentrancyGuard::enter(&env);
+        let _guard = ReentrancyGuard::enter(&env)?;
         check_initialized(&env)?;
         check_not_paused(&env)?;
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -487,12 +487,14 @@ fn read_timelock_entry(env: &Env, id: u64) -> Option<TimelockEntry> {
     env.storage().persistent().get(&DataKey::Timelock(id))
 }
 
-fn increment_user_deposit(env: &Env, source: &Address, asset: &Address, amount: i128) {
+fn increment_user_deposit(env: &Env, source: &Address, asset: &Address, amount: i128) -> Result<(), BridgeError> {
     let key = DataKey::UserDeposit(source.clone(), asset.clone());
     let current: i128 = env.storage().persistent().get(&key).unwrap_or(0);
+    let updated = safe_math::safe_add(current, amount)?;
     env.storage()
         .persistent()
-        .set(&key, &(current + amount));
+        .set(&key, &updated);
+    Ok(())
 }
 
 #[inline(never)]
@@ -756,10 +758,11 @@ fn read_accrued_fees(env: &Env, asset: &Address) -> i128 {
     read_asset_counters(env, asset).accrued_fees
 }
 
-fn increment_accrued_fees(env: &Env, asset: &Address, amount: i128) {
+fn increment_accrued_fees(env: &Env, asset: &Address, amount: i128) -> Result<(), BridgeError> {
     let mut c = read_asset_counters(env, asset);
-    c.accrued_fees += amount;
+    c.accrued_fees = safe_math::safe_add(c.accrued_fees, amount)?;
     save_asset_counters(env, asset, &c);
+    Ok(())
 }
 
 fn decrement_accrued_fees(env: &Env, asset: &Address, amount: i128) {
@@ -772,29 +775,32 @@ fn read_total_bridged(env: &Env, asset: &Address) -> i128 {
     read_asset_counters(env, asset).total_bridged
 }
 
-fn increment_total_bridged(env: &Env, asset: &Address, amount: i128) {
+fn increment_total_bridged(env: &Env, asset: &Address, amount: i128) -> Result<(), BridgeError> {
     let mut c = read_asset_counters(env, asset);
-    c.total_bridged += amount;
+    c.total_bridged = safe_math::safe_add(c.total_bridged, amount)?;
     save_asset_counters(env, asset, &c);
+    Ok(())
 }
 
 fn read_total_fees_collected(env: &Env, asset: &Address) -> i128 {
     read_asset_counters(env, asset).total_fees_collected
 }
 
-fn increment_total_fees_collected(env: &Env, asset: &Address, amount: i128) {
+fn increment_total_fees_collected(env: &Env, asset: &Address, amount: i128) -> Result<(), BridgeError> {
     let mut c = read_asset_counters(env, asset);
-    c.total_fees_collected += amount;
+    c.total_fees_collected = safe_math::safe_add(c.total_fees_collected, amount)?;
     save_asset_counters(env, asset, &c);
+    Ok(())
 }
 
 /// Atomically update all three counters in a single storage read+write
-fn update_asset_counters(env: &Env, asset: &Address, fees: i128, bridged: i128) {
+fn update_asset_counters(env: &Env, asset: &Address, fees: i128, bridged: i128) -> Result<(), BridgeError> {
     let mut c = read_asset_counters(env, asset);
-    c.accrued_fees += fees;
-    c.total_bridged += bridged;
-    c.total_fees_collected += fees;
+    c.accrued_fees = safe_math::safe_add(c.accrued_fees, fees)?;
+    c.total_bridged = safe_math::safe_add(c.total_bridged, bridged)?;
+    c.total_fees_collected = safe_math::safe_add(c.total_fees_collected, fees)?;
     save_asset_counters(env, asset, &c);
+    Ok(())
 }
 
 fn read_nonce(env: &Env, caller: &Address) -> u64 {
@@ -1001,10 +1007,11 @@ fn check_daily_limit(env: &Env, source: &Address, asset: &Address, amount: i128)
     let day = current_day(env);
     let key = DataKey::DailyUsage(source.clone(), asset.clone(), day);
     let used: i128 = env.storage().persistent().get(&key).unwrap_or(0);
-    if used + amount > limit {
+    let updated = safe_math::safe_add(used, amount)?;
+    if updated > limit {
         return Err(BridgeError::DailyLimitExceeded);
     }
-    env.storage().persistent().set(&key, &(used + amount));
+    env.storage().persistent().set(&key, &updated);
     Ok(())
 }
 
@@ -1049,11 +1056,13 @@ fn read_source_bridged_volume(env: &Env, source: &Address) -> i128 {
         .unwrap_or(0)
 }
 
-fn increment_source_bridged_volume(env: &Env, source: &Address, amount: i128) {
+fn increment_source_bridged_volume(env: &Env, source: &Address, amount: i128) -> Result<(), BridgeError> {
     let current = read_source_bridged_volume(env, source);
+    let updated = safe_math::safe_add(current, amount)?;
     env.storage()
         .persistent()
-        .set(&DataKey::SourceBridgedVolume(source.clone()), &(current + amount));
+        .set(&DataKey::SourceBridgedVolume(source.clone()), &updated);
+    Ok(())
 }
 
 fn get_tiered_fee_bps(env: &Env, source: &Address, fallback_bps: u32) -> u32 {
@@ -1390,11 +1399,11 @@ impl OnboardingBridge {
             token_client.transfer(&contract_addr, &target, &net_amount);
         }
 
-        increment_user_deposit(&env, &source, &asset, amount);
-        increment_accrued_fees(&env, &asset, fee);
-        increment_total_bridged(&env, &asset, net_amount);
-        increment_total_fees_collected(&env, &asset, fee);
-        increment_source_bridged_volume(&env, &source, amount);
+        increment_user_deposit(&env, &source, &asset, amount)?;
+        increment_accrued_fees(&env, &asset, fee)?;
+        increment_total_bridged(&env, &asset, net_amount)?;
+        increment_total_fees_collected(&env, &asset, fee)?;
+        increment_source_bridged_volume(&env, &source, amount)?;
 
         mint_loyalty_tokens(&env, &source);
 
@@ -1525,7 +1534,7 @@ impl OnboardingBridge {
 
             if check_access(&env, &target).is_err() {
                 num_failures += 1;
-                refund_amount += amount;
+                refund_amount = safe_math::safe_add(refund_amount, amount)?;
                 env.events().publish(
                     ("BatchTransferFailed", source.clone(), target.clone()),
                     (amount, "access_denied"),
@@ -1534,8 +1543,8 @@ impl OnboardingBridge {
             }
 
             num_success += 1;
-            total_fees += fee;
-            total_bridged += net_amount;
+            total_fees = safe_math::safe_add(total_fees, fee)?;
+            total_bridged = safe_math::safe_add(total_bridged, net_amount)?;
 
             if net_amount > 0 {
                 let existing = aggregated.get(target.clone()).unwrap_or(0);
@@ -1558,7 +1567,7 @@ impl OnboardingBridge {
 
         // Batch-update all counters in a single storage read+write
         if total_fees > 0 || total_bridged > 0 {
-            update_asset_counters(&env, &asset, total_fees, total_bridged);
+            update_asset_counters(&env, &asset, total_fees, total_bridged)?;
         }
 
         if refund_amount > 0 {
@@ -2175,9 +2184,9 @@ impl OnboardingBridge {
         };
 
         let protocol_fee = fee - referral_fee;
-        increment_accrued_fees(&env, &asset, protocol_fee);
-        increment_total_bridged(&env, &asset, net_amount);
-        increment_total_fees_collected(&env, &asset, fee);
+        increment_accrued_fees(&env, &asset, protocol_fee)?;
+        increment_total_bridged(&env, &asset, net_amount)?;
+        increment_total_fees_collected(&env, &asset, fee)?;
 
         mint_loyalty_tokens(&env, &source);
 
@@ -3547,7 +3556,7 @@ impl OnboardingBridge {
         if net_amount > 0 {
             token_client.transfer(&env.current_contract_address(), &target, &net_amount);
         }
-        update_asset_counters(&env, &asset, fee, net_amount);
+        update_asset_counters(&env, &asset, fee, net_amount)?;
 
         // No on-chain `source` exists for cross-chain deposits (the funds
         // originate on another chain), so `target` is the only address party
@@ -3845,7 +3854,7 @@ impl OnboardingBridge {
         if net_amount > 0 {
             token_client.transfer(&env.current_contract_address(), &entry.target, &net_amount);
         }
-        update_asset_counters(&env, &entry.asset, fee, net_amount);
+        update_asset_counters(&env, &entry.asset, fee, net_amount)?;
 
         env.events().publish(
             ("TimelockClaimed", entry.target),
@@ -4357,10 +4366,10 @@ impl OnboardingBridge {
             token_client.transfer(&contract_addr, &target, &net_amount);
         }
 
-        increment_accrued_fees(&env, &asset, fee);
-        increment_total_bridged(&env, &asset, net_amount);
-        increment_total_fees_collected(&env, &asset, fee);
-        increment_source_bridged_volume(&env, &source, amount);
+        increment_accrued_fees(&env, &asset, fee)?;
+        increment_total_bridged(&env, &asset, net_amount)?;
+        increment_total_fees_collected(&env, &asset, fee)?;
+        increment_source_bridged_volume(&env, &source, amount)?;
         extend_instance_ttl(&env);
 
         mint_loyalty_tokens(&env, &source);
@@ -4525,10 +4534,10 @@ impl OnboardingBridge {
             target_token.transfer(&contract_addr, &target, &net_amount);
         }
 
-        increment_accrued_fees(&env, &target_asset, fee);
-        increment_total_bridged(&env, &target_asset, net_amount);
-        increment_total_fees_collected(&env, &target_asset, fee);
-        increment_source_bridged_volume(&env, &source, source_amount);
+        increment_accrued_fees(&env, &target_asset, fee)?;
+        increment_total_bridged(&env, &target_asset, net_amount)?;
+        increment_total_fees_collected(&env, &target_asset, fee)?;
+        increment_source_bridged_volume(&env, &source, source_amount)?;
 
         mint_loyalty_tokens(&env, &source);
 
@@ -4697,11 +4706,11 @@ impl OnboardingBridge {
             token_client.transfer(&contract_addr, &params.target, &net_amount);
         }
 
-        increment_user_deposit(&env, &params.source, &params.asset, params.amount);
-        increment_accrued_fees(&env, &params.asset, fee);
-        increment_total_bridged(&env, &params.asset, net_amount);
-        increment_total_fees_collected(&env, &params.asset, fee);
-        increment_source_bridged_volume(&env, &params.source, params.amount);
+        increment_user_deposit(&env, &params.source, &params.asset, params.amount)?;
+        increment_accrued_fees(&env, &params.asset, fee)?;
+        increment_total_bridged(&env, &params.asset, net_amount)?;
+        increment_total_fees_collected(&env, &params.asset, fee)?;
+        increment_source_bridged_volume(&env, &params.source, params.amount)?;
 
         extend_instance_ttl(&env);
 
@@ -4758,6 +4767,9 @@ pub struct MetaFundParams {
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod overflow_accumulator_tests;
 
 #[cfg(test)]
 mod fee_fuzz_tests;

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2135,6 +2135,10 @@ impl OnboardingBridge {
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
         }
+        let minimum_amount = read_minimum_amount(&env);
+        if amount < minimum_amount {
+            return Err(BridgeError::InvalidAmount);
+        }
         check_access(&env, &target)?;
         check_asset_whitelisted(&env, &asset)?;
         check_daily_limit(&env, &source, &asset, amount)?;
@@ -4324,6 +4328,10 @@ impl OnboardingBridge {
         }
 
         if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        let minimum_amount = read_minimum_amount(&env);
+        if amount < minimum_amount {
             return Err(BridgeError::InvalidAmount);
         }
 

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1103,6 +1103,19 @@ fn read_loyalty_amount_per_fund(env: &Env) -> i128 {
         .unwrap_or(0)
 }
 
+// Loyalty minting policy: every funding path that pulls tokens from a
+// caller-controlled `source` and delivers them to a `target` mints loyalty
+// tokens to the funder (`source`), matching the advertised "general funding
+// incentive". This covers: `fund_c_address`, `batch_fund_c_address` (once per
+// call, not per recipient), `fund_c_address_with_referral`,
+// `fund_c_address_with_swap`, `reveal_fund`, and `execute_meta_fund`.
+// `fund_c_address_timelocked` mints at deposit time (when `source` is known
+// and authorises the call) rather than at `claim_timelocked` time, since the
+// claim is authorised by `target`, not `source`, and minting once at deposit
+// avoids ambiguity about which ledger a delayed claim should credit.
+// `fund_c_address_crosschain` has no on-chain `source` (funds originate on a
+// different chain and are attested by relayers), so the reward is minted to
+// `target`, the only address party to that call.
 fn mint_loyalty_tokens(env: &Env, recipient: &Address) {
     if let Some(loyalty_token) = read_loyalty_token(env) {
         let amount = read_loyalty_amount_per_fund(env);
@@ -1548,6 +1561,12 @@ impl OnboardingBridge {
 
         if refund_amount > 0 {
             token_client.transfer(&contract_addr, &source, &refund_amount);
+        }
+
+        // Reward the funder once per batch call (not per recipient), consistent
+        // with the single-transfer semantics of the rest of this function.
+        if num_success > 0 {
+            mint_loyalty_tokens(&env, &source);
         }
 
         env.events().publish(
@@ -2153,6 +2172,8 @@ impl OnboardingBridge {
         increment_accrued_fees(&env, &asset, protocol_fee);
         increment_total_bridged(&env, &asset, net_amount);
         increment_total_fees_collected(&env, &asset, fee);
+
+        mint_loyalty_tokens(&env, &source);
 
         env.events().publish(
             ("CAddressFunded", asset, source, target),
@@ -3522,6 +3543,11 @@ impl OnboardingBridge {
         }
         update_asset_counters(&env, &asset, fee, net_amount);
 
+        // No on-chain `source` exists for cross-chain deposits (the funds
+        // originate on another chain), so `target` is the only address party
+        // to this call and receives the loyalty reward.
+        mint_loyalty_tokens(&env, &target);
+
         env.events().publish(
             ("CrossChainFunded", target),
             (chain_id, tx_hash, amount, fee, asset),
@@ -3735,6 +3761,11 @@ impl OnboardingBridge {
         );
         // Ring-fence this deposit so reclaim_tokens cannot drain it before claim.
         increment_locked_timelock(&env, &asset, amount);
+
+        // Minted at deposit time, not at claim_timelocked, since `source`
+        // (the funder) authorises this call, while claim_timelocked is
+        // authorised by `target`. See policy note on `mint_loyalty_tokens`.
+        mint_loyalty_tokens(&env, &source);
 
         env.events().publish(
             ("TimelockCreated", source, target),
@@ -4322,6 +4353,8 @@ impl OnboardingBridge {
         increment_source_bridged_volume(&env, &source, amount);
         extend_instance_ttl(&env);
 
+        mint_loyalty_tokens(&env, &source);
+
         env.events().publish(
             ("CommitRevealFunded", asset, source, target),
             (commitment_id, amount, fee),
@@ -4661,6 +4694,10 @@ impl OnboardingBridge {
         increment_source_bridged_volume(&env, &params.source, params.amount);
 
         extend_instance_ttl(&env);
+
+        // execute_meta_fund replays the same transfer flow as fund_c_address on
+        // the user's behalf, so it earns the same loyalty reward.
+        mint_loyalty_tokens(&env, &params.source);
 
         env.events().publish(
             ("MetaFundExecuted", params.asset, params.source, params.target),

--- a/contracts/onboarding-bridge/src/overflow_accumulator_tests.rs
+++ b/contracts/onboarding-bridge/src/overflow_accumulator_tests.rs
@@ -1,0 +1,138 @@
+//! Property and edge-case coverage for the storage accumulators that were
+//! switched from raw `+=` to `safe_math::safe_add` (see lib.rs `increment_*`
+//! / `update_asset_counters` / `check_daily_limit`). Each of these functions
+//! must return `BridgeError::Overflow` instead of panicking/wrapping when the
+//! running total would exceed `i128::MAX`.
+
+#![cfg(test)]
+
+use crate::{
+    check_daily_limit, increment_accrued_fees, increment_source_bridged_volume,
+    increment_total_bridged, increment_total_fees_collected, increment_user_deposit,
+    save_source_daily_limit, update_asset_counters, BridgeError, OnboardingBridge,
+};
+use proptest::prelude::*;
+use soroban_sdk::{testutils::Address as _, Address, Env};
+
+fn setup() -> (Env, Address, Address, Address) {
+    let env = Env::default();
+    let bridge_id = env.register(OnboardingBridge, ());
+    let asset = Address::generate(&env);
+    let source = Address::generate(&env);
+    (env, bridge_id, asset, source)
+}
+
+#[test]
+fn accrued_fees_overflow_returns_error_not_panic() {
+    let (env, bridge_id, asset, _source) = setup();
+    env.as_contract(&bridge_id, || {
+        increment_accrued_fees(&env, &asset, i128::MAX).unwrap();
+        assert_eq!(
+            increment_accrued_fees(&env, &asset, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+#[test]
+fn total_bridged_overflow_returns_error_not_panic() {
+    let (env, bridge_id, asset, _source) = setup();
+    env.as_contract(&bridge_id, || {
+        increment_total_bridged(&env, &asset, i128::MAX).unwrap();
+        assert_eq!(
+            increment_total_bridged(&env, &asset, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+#[test]
+fn total_fees_collected_overflow_returns_error_not_panic() {
+    let (env, bridge_id, asset, _source) = setup();
+    env.as_contract(&bridge_id, || {
+        increment_total_fees_collected(&env, &asset, i128::MAX).unwrap();
+        assert_eq!(
+            increment_total_fees_collected(&env, &asset, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+#[test]
+fn update_asset_counters_overflow_returns_error_not_panic() {
+    let (env, bridge_id, asset, _source) = setup();
+    env.as_contract(&bridge_id, || {
+        update_asset_counters(&env, &asset, i128::MAX, i128::MAX).unwrap();
+        assert_eq!(
+            update_asset_counters(&env, &asset, 1, 0),
+            Err(BridgeError::Overflow)
+        );
+        assert_eq!(
+            update_asset_counters(&env, &asset, 0, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+#[test]
+fn source_bridged_volume_overflow_returns_error_not_panic() {
+    let (env, bridge_id, _asset, source) = setup();
+    env.as_contract(&bridge_id, || {
+        increment_source_bridged_volume(&env, &source, i128::MAX).unwrap();
+        assert_eq!(
+            increment_source_bridged_volume(&env, &source, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+#[test]
+fn user_deposit_overflow_returns_error_not_panic() {
+    let (env, bridge_id, asset, source) = setup();
+    env.as_contract(&bridge_id, || {
+        increment_user_deposit(&env, &source, &asset, i128::MAX).unwrap();
+        assert_eq!(
+            increment_user_deposit(&env, &source, &asset, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+#[test]
+fn daily_limit_usage_overflow_returns_error_not_panic() {
+    let (env, bridge_id, asset, source) = setup();
+    env.as_contract(&bridge_id, || {
+        // A high limit so the overflow check (not the limit check) is what fires.
+        save_source_daily_limit(&env, &source, &asset, i128::MAX);
+        check_daily_limit(&env, &source, &asset, i128::MAX).unwrap();
+        assert_eq!(
+            check_daily_limit(&env, &source, &asset, 1),
+            Err(BridgeError::Overflow)
+        );
+    });
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig { cases: 256, .. ProptestConfig::default() })]
+
+    /// Every `increment_*` accumulator must agree with `checked_add` on
+    /// whether a given (base, delta) pair overflows i128, regardless of how
+    /// close `base` sits to `i128::MAX`.
+    #[test]
+    fn accrued_fees_matches_checked_add_near_i128_max(
+        base in (i128::MAX - 1_000_000)..=i128::MAX,
+        delta in 0i128..=2_000_000i128,
+    ) {
+        let (env, bridge_id, asset, _source) = setup();
+        env.as_contract(&bridge_id, || {
+            increment_accrued_fees(&env, &asset, base).unwrap();
+            let result = increment_accrued_fees(&env, &asset, delta);
+            let expected_overflow = base.checked_add(delta).is_none();
+            prop_assert_eq!(result.is_err(), expected_overflow);
+            if let Err(e) = result {
+                prop_assert_eq!(e, BridgeError::Overflow);
+            }
+            Ok(())
+        })?;
+    }
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -867,6 +867,28 @@ fn test_reveal_fund_mints_loyalty() {
     assert_eq!(check_balance(&env, &loyalty_token_id, &user), 8i128);
 }
 
+#[test]
+fn test_reveal_fund_rejects_below_minimum() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (bridge, user, token_id, _admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    bridge.set_minimum_amount(&100i128, &None);
+
+    let amount: i128 = 50; // below the configured minimum of 100
+    let nonce: u64 = 1;
+    let amount_hash = commit_reveal_amount_hash(&env, amount, nonce);
+
+    let id = bridge.commit_fund(&user, &target, &token_id, &amount_hash, &10_000u64);
+    env.ledger().set_sequence_number(10);
+
+    assert_eq!(
+        bridge.try_reveal_fund(&id, &user, &target, &token_id, &amount, &nonce),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
+}
+
 /********** Asset whitelist tests **********/
 
 #[test]
@@ -2766,6 +2788,26 @@ fn test_referral_fund_mints_loyalty() {
     bridge.fund_c_address_with_referral(&user, &target, &token_id, &1000i128, &None);
 
     assert_eq!(check_balance(&env, &loyalty_token_id, &user), 6i128);
+}
+
+#[test]
+fn test_referral_fund_rejects_below_minimum() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_minimum_amount(&100i128, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target = Address::generate(&env);
+    assert_eq!(
+        bridge.try_fund_c_address_with_referral(&user, &target, &token_id, &50i128, &None),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
 }
 
 /********** Zero-amount behavior tests **********/

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -834,6 +834,39 @@ fn test_reclaim_cannot_drain_active_commitments() {
     assert_eq!(check_balance(&env, &token_id, &destination), 300i128);
 }
 
+/********** Commit-reveal (reveal_fund) tests **********/
+
+fn commit_reveal_amount_hash(env: &Env, amount: i128, nonce: u64) -> BytesN<32> {
+    let mut preimage = Bytes::new(env);
+    preimage.extend_from_array(&amount.to_be_bytes());
+    preimage.extend_from_array(&nonce.to_be_bytes());
+    env.crypto().sha256(&preimage).into()
+}
+
+#[test]
+fn test_reveal_fund_mints_loyalty() {
+    let env = Env::default();
+    env.ledger().set_timestamp(1_000);
+    let (bridge, user, token_id, admin) = setup_bridge(&env);
+    let target = Address::generate(&env);
+
+    let loyalty_token_id = env.register(TestToken, ());
+    init_token(&env, &loyalty_token_id, &admin);
+    bridge.set_loyalty_token(&loyalty_token_id, &8i128);
+    mint_tokens(&env, &loyalty_token_id, &bridge.address, 1_000i128);
+
+    let amount: i128 = 500;
+    let nonce: u64 = 1;
+    let amount_hash = commit_reveal_amount_hash(&env, amount, nonce);
+
+    let id = bridge.commit_fund(&user, &target, &token_id, &amount_hash, &10_000u64);
+    env.ledger().set_sequence_number(10);
+
+    bridge.reveal_fund(&id, &user, &target, &token_id, &amount, &nonce);
+
+    assert_eq!(check_balance(&env, &loyalty_token_id, &user), 8i128);
+}
+
 /********** Asset whitelist tests **********/
 
 #[test]
@@ -2202,6 +2235,33 @@ mod timelocked_tests {
             Err(Ok(BridgeError::TimelockNotFound))
         );
     }
+
+    #[test]
+    fn test_timelocked_fund_mints_loyalty_at_deposit() {
+        let env = Env::default();
+        env.ledger().set_timestamp(6_000);
+        let (bridge, user, token_id, _fee_collector, admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+        let release_time = 6_100u64;
+
+        // Minted at deposit time (when `source`/`user` is known), not at
+        // claim_timelocked time (which is authorised by `target`).
+        let loyalty_token_id = env.register(TestToken, ());
+        init_token(&env, &loyalty_token_id, &admin);
+        bridge.set_loyalty_token(&loyalty_token_id, &4i128);
+        mint_tokens(&env, &loyalty_token_id, &bridge.address, 1_000i128);
+
+        bridge.fund_c_address_timelocked(
+            &user,
+            &target,
+            &token_id,
+            &500i128,
+            &release_time,
+            &0u64,
+        );
+
+        assert_eq!(check_balance(&env, &loyalty_token_id, &user), 4i128);
+    }
 }
 
 /********** Cross-chain Onboarding Tests **********/
@@ -2480,6 +2540,91 @@ mod crosschain_tests {
             Err(Ok(BridgeError::DuplicateRelayerSignature))
         );
     }
+
+    #[test]
+    fn test_crosschain_mints_loyalty_to_target() {
+        let env = Env::default();
+        let (bridge_id, token_id, admin, bridge) = setup(&env);
+
+        // Cross-chain deposits have no on-chain `source`; the reward is
+        // credited to `target`, the only address party to this call.
+        let loyalty_token_id = env.register(TestToken, ());
+        init_token(&env, &loyalty_token_id, &admin);
+        bridge.set_loyalty_token(&loyalty_token_id, &3i128);
+        mint_tokens(&env, &loyalty_token_id, &bridge_id, 1_000i128);
+
+        let sk = make_signing_key([9u8; 32]);
+        let pubkey = BytesN::from_array(&env, sk.verifying_key().as_bytes());
+        bridge.add_relayer(&pubkey);
+        bridge.set_relayer_threshold(&1u32);
+
+        let target = soroban_sdk::Address::generate(&env);
+        let tx_hash = BytesN::from_array(&env, &[0x77; 32]);
+        let chain_id: u32 = 1;
+        let amount: i128 = 1000;
+
+        let payload_hash = build_payload_hash(&env, chain_id, &tx_hash, &target, &token_id, amount);
+        let sig = make_relayer_sig(&env, &sk, &payload_hash);
+        let sigs = Vec::from_array(&env, [sig]);
+
+        bridge.fund_c_address_crosschain(&chain_id, &tx_hash, &target, &token_id, &amount, &sigs);
+
+        assert_eq!(check_balance(&env, &loyalty_token_id, &target), 3i128);
+    }
+}
+
+#[test]
+fn test_batch_fund_mints_loyalty_once() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    let loyalty_token_id = env.register(TestToken, ());
+    init_token(&env, &loyalty_token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_loyalty_token(&loyalty_token_id, &10i128);
+    mint_tokens(&env, &loyalty_token_id, &bridge_id, 1_000i128);
+    mint_tokens(&env, &token_id, &user, 2_000i128);
+
+    let t1 = Address::generate(&env);
+    let t2 = Address::generate(&env);
+    let targets = Vec::from_array(&env, [t1, t2]);
+    let amounts = Vec::from_array(&env, [500i128, 500i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
+
+    // Rewarded once per batch call, not once per recipient.
+    assert_eq!(check_balance(&env, &loyalty_token_id, &user), 10i128);
+}
+
+#[test]
+fn test_batch_fund_all_blocked_mints_no_loyalty() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    let loyalty_token_id = env.register(TestToken, ());
+    init_token(&env, &loyalty_token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_loyalty_token(&loyalty_token_id, &10i128);
+    mint_tokens(&env, &loyalty_token_id, &bridge_id, 1_000i128);
+    mint_tokens(&env, &token_id, &user, 1_000i128);
+
+    let t1 = Address::generate(&env);
+    bridge.add_to_blocklist(&t1, &None);
+    let targets = Vec::from_array(&env, [t1]);
+    let amounts = Vec::from_array(&env, [500i128]);
+    bridge.batch_fund_c_address(&user, &targets, &amounts, &token_id, &None, &None);
+
+    // Nothing succeeded, so no loyalty reward is minted.
+    assert_eq!(check_balance(&env, &loyalty_token_id, &user), 0i128);
 }
 
 /********** Referral system tests **********/
@@ -2598,6 +2743,29 @@ fn test_fund_with_referral_zero_referral_rate() {
     // referral_rate = 0, so referrer gets nothing, full fee in contract
     assert_eq!(check_balance(&env, &token_id, &referrer), 0i128);
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 10i128);
+}
+
+#[test]
+fn test_referral_fund_mints_loyalty() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    let loyalty_token_id = env.register(TestToken, ());
+    init_token(&env, &loyalty_token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_loyalty_token(&loyalty_token_id, &6i128);
+    mint_tokens(&env, &loyalty_token_id, &bridge_id, 1_000i128);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target = Address::generate(&env);
+    bridge.fund_c_address_with_referral(&user, &target, &token_id, &1000i128, &None);
+
+    assert_eq!(check_balance(&env, &loyalty_token_id, &user), 6i128);
 }
 
 /********** Zero-amount behavior tests **********/

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3385,6 +3385,30 @@ mod concurrent_sequential_tests {
     }
 
     // -----------------------------------------------------------------------
+    // Reentrancy guard now returns BridgeError::Reentrant instead of
+    // panicking. This directly exercises ReentrancyGuard::enter re-entering
+    // while a guard is already held for the current contract, which is what
+    // a malicious token callback into a bridge function would trigger.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_reentrant_call_returns_error() {
+        let s = ConcurrentSetup::new();
+
+        s.env.as_contract(&s.bridge_id, || {
+            let _outer_guard = crate::ReentrancyGuard::enter(&s.env).unwrap();
+            let inner = crate::ReentrancyGuard::enter(&s.env);
+            assert!(matches!(inner, Err(BridgeError::Reentrant)));
+        });
+
+        // Once the outer guard drops, entry succeeds again (sequential calls
+        // are unaffected — only true reentrancy is rejected).
+        s.env.as_contract(&s.bridge_id, || {
+            assert!(crate::ReentrancyGuard::enter(&s.env).is_ok());
+        });
+    }
+
+    // -----------------------------------------------------------------------
     // Scenario 6: Fee counter consistency across mixed batch + single calls
     //
     // Mixing batch_fund_c_address and fund_c_address in sequence must keep


### PR DESCRIPTION
closes #238 
closes #239 
closes #240 
closes #241 


1. Loyalty minting across all funding paths — mint_loyalty_tokens is now called from batch_fund_c_address, fund_c_address_with_referral, fund_c_address_timelocked, fund_c_address_crosschain, reveal_fund, and execute_meta_fund (previously only fund_c_address/fund_c_address_with_swap), with the reward policy documented and tested per path.
2. Minimum-amount enforcement — added to fund_c_address_with_referral and reveal_fund, closing the bypass.
3. Reentrancy guard — ReentrancyGuard::enter now returns Result<_, BridgeError::Reentrant> instead of panicking, propagated via ? at all 51 call sites.
4. Safe arithmetic — all the flagged raw += accumulators now go through safe_math::safe_add, returning Overflow instead of wrapping/panicking, with new edge-case + property tests near i128::MAX.
1. Loyalty minting across all funding paths — mint_loyalty_tokens is now called from batch_fund_c_address, fund_c_address_with_referral, fund_c_address_timelocked, fund_c_address_crosschain, reveal_fund, and execute_meta_fund (previously only fund_c_address/fund_c_address_with_swap), with the reward policy documented and tested per path.
2. Minimum-amount enforcement — added to fund_c_address_with_referral and reveal_fund, closing the bypass.
3. Reentrancy guard — ReentrancyGuard::enter now returns Result<_, BridgeError::Reentrant> instead of panicking, propagated via ? at all 51 call sites.
4. Safe arithmetic — all the flagged raw += accumulators now go through safe_math::safe_add, returning Overflow instead of wrapping/panicking, with new edge-case + property tests near i128::MAX.