### PR TITLE
Fix/onboarding bridge admin issues

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1732,6 +1732,7 @@ impl OnboardingBridge {
     ) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
         consume_nonce(&env, &admin, nonce)?;
@@ -1798,6 +1799,7 @@ impl OnboardingBridge {
     ) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         if max_fee_bps > MAX_FEE_BPS {
             return Err(BridgeError::FeeTooHigh);
         }
@@ -2115,6 +2117,7 @@ impl OnboardingBridge {
     pub fn set_referral_rate(env: Env, bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         if bps > 10_000 {
             return Err(BridgeError::FeeTooHigh);
         }
@@ -3338,6 +3341,7 @@ impl OnboardingBridge {
     ) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
         if amount_per_fund < 0 {
@@ -3408,6 +3412,7 @@ impl OnboardingBridge {
     pub fn set_fee_tiers(env: Env, tiers: Vec<FeeTier>) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
         for i in 0..tiers.len() {
@@ -3675,6 +3680,7 @@ impl OnboardingBridge {
     pub fn add_relayer(env: Env, pubkey: BytesN<32>) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         read_admin(&env).require_auth();
         extend_instance_ttl(&env);
         add_relayer(&env, &pubkey);
@@ -3703,6 +3709,7 @@ impl OnboardingBridge {
     pub fn remove_relayer(env: Env, pubkey: BytesN<32>) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         read_admin(&env).require_auth();
         // Prevent removing below threshold
         let new_count = relayer_count(&env).saturating_sub(1);
@@ -3733,6 +3740,7 @@ impl OnboardingBridge {
     pub fn set_relayer_threshold(env: Env, threshold: u32) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
+        check_not_paused(&env)?;
         read_admin(&env).require_auth();
         if threshold > relayer_count(&env) {
             return Err(BridgeError::ThresholdExceedsRelayers);

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -161,6 +161,8 @@ pub enum BridgeError {
     PoolNotWhitelisted = 42,
     /// `swap_route` contained more than one hop; multi-hop swaps are not supported.
     MultiHopNotSupported = 43,
+    /// `set_fee_tiers` was called with more tiers than `MAX_FEE_TIERS` (50).
+    TooManyFeeTiers = 44,
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +239,10 @@ pub enum DataKey {
 const MAX_FEE_BPS: u32 = 1_000;
 const FEE_DENOMINATOR: i128 = 10_000;
 const MAX_BATCH_SIZE: u32 = 100;
+/// Maximum number of tiers accepted by `set_fee_tiers`. `get_tiered_fee_bps`
+/// / `find_current_tier` scan the full tier list linearly on every funding
+/// call, so this bounds the per-call cost of that scan.
+const MAX_FEE_TIERS: u32 = 50;
 const MAX_ALLOWED_TTL: u32 = 3_110_400; // ~1 year in ledgers (5s/ledger)
 /// Minimum configurable value for `MaxInstanceTtl` / `MaxPersistentTtl`.
 ///
@@ -3394,8 +3400,8 @@ impl OnboardingBridge {
     ///
     /// # Arguments
     ///
-    /// * `tiers` (`Vec<FeeTier>`) — Ordered list of fee tiers. Each tier's
-    ///   `fee_bps` must be ≤ 1 000.
+    /// * `tiers` (`Vec<FeeTier>`) — Ordered list of fee tiers. Must contain at
+    ///   most `MAX_FEE_TIERS` (50) entries. Each tier's `fee_bps` must be ≤ 1 000.
     ///
     /// # Authorization
     ///
@@ -3404,6 +3410,8 @@ impl OnboardingBridge {
     /// # Errors
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
+    /// * [`BridgeError::ContractPaused`] — Contract is paused.
+    /// * [`BridgeError::TooManyFeeTiers`] — `tiers.len()` exceeds `MAX_FEE_TIERS` (50).
     /// * [`BridgeError::FeeTooHigh`] — Any tier's `fee_bps` exceeds 1 000.
     ///
     /// # Events
@@ -3415,6 +3423,9 @@ impl OnboardingBridge {
         check_not_paused(&env)?;
         let admin = read_admin(&env);
         admin.require_auth();
+        if tiers.len() > MAX_FEE_TIERS {
+            return Err(BridgeError::TooManyFeeTiers);
+        }
         for i in 0..tiers.len() {
             let tier = tiers.get(i).unwrap();
             if tier.fee_bps > MAX_FEE_BPS {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2318,11 +2318,16 @@ impl OnboardingBridge {
     /// # Arguments
     ///
     /// * `assets` (`Vec<Address>`) — List of token contract addresses to query.
+    ///   Must contain at most `MAX_BATCH_SIZE` (100) entries.
     ///
     /// # Returns
     ///
     /// A `Map<Address, i128>` mapping each asset address to the contract's balance.
     /// Assets with a zero balance are included.
+    ///
+    /// # Errors
+    ///
+    /// * [`BridgeError::BatchTooLarge`] — `assets.len()` exceeds `MAX_BATCH_SIZE` (100).
     ///
     /// # Examples
     ///
@@ -2330,7 +2335,13 @@ impl OnboardingBridge {
     /// // let assets = Vec::from_array(&env, [usdc, xlm]);
     /// // let balances = bridge.query_all_balances(&assets);
     /// ```
-    pub fn query_all_balances(env: Env, assets: Vec<Address>) -> Map<Address, i128> {
+    pub fn query_all_balances(
+        env: Env,
+        assets: Vec<Address>,
+    ) -> Result<Map<Address, i128>, BridgeError> {
+        if assets.len() > MAX_BATCH_SIZE {
+            return Err(BridgeError::BatchTooLarge);
+        }
         let contract = env.current_contract_address();
         let mut result: Map<Address, i128> = Map::new(&env);
         for i in 0..assets.len() {
@@ -2338,7 +2349,7 @@ impl OnboardingBridge {
             let balance = token::Client::new(&env, &asset).balance(&contract);
             result.set(asset, balance);
         }
-        result
+        Ok(result)
     }
 
     /// Returns the contract's total token balance for `asset`.
@@ -3225,14 +3236,40 @@ impl OnboardingBridge {
         Ok(read_whitelist(&env).get(asset).unwrap_or(false))
     }
 
-    /// Returns the list of all currently whitelisted asset addresses.
+    /// Returns a page of currently whitelisted asset addresses.
+    ///
+    /// The whitelist can grow without bound over the contract's lifetime, so
+    /// results are paginated rather than returned in a single unbounded call.
+    ///
+    /// # Arguments
+    ///
+    /// * `offset` (`u32`) — Number of whitelist entries to skip.
+    /// * `limit` (`u32`) — Maximum number of entries to return. Capped at
+    ///   `MAX_BATCH_SIZE` (100); values above that are silently clamped.
     ///
     /// # Errors
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
-    pub fn query_whitelisted_assets(env: Env) -> Result<Vec<Address>, BridgeError> {
+    pub fn query_whitelisted_assets(
+        env: Env,
+        offset: u32,
+        limit: u32,
+    ) -> Result<Vec<Address>, BridgeError> {
         check_initialized(&env)?;
-        Ok(read_whitelist(&env).keys())
+        let all = read_whitelist(&env).keys();
+        let page_size = if limit > MAX_BATCH_SIZE {
+            MAX_BATCH_SIZE
+        } else {
+            limit
+        };
+        let mut page: Vec<Address> = Vec::new(&env);
+        let total = all.len();
+        let mut i = offset;
+        while i < total && (i - offset) < page_size {
+            page.push_back(all.get(i).unwrap());
+            i += 1;
+        }
+        Ok(page)
     }
 
     // -----------------------------------------------------------------------

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3796,6 +3796,9 @@ impl OnboardingBridge {
     /// * `cliff_time` (`u64`) — Optional cliff timestamp. If > 0 it must be
     ///   ≤ `release_time`. Currently informational only; not enforced by
     ///   `claim_timelocked`.
+    /// * `nonce` (`Option<u64>`) — Optional sequential nonce for `source`.
+    /// * `deadline` (`Option<u64>`) — Optional Unix timestamp (seconds) after
+    ///   which the call is rejected. Pass `None` for no expiry.
     ///
     /// # Authorization
     ///
@@ -3810,6 +3813,7 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::ContractPaused`] — Contract is paused.
+    /// * [`BridgeError::TransactionExpired`] — `deadline` is in the past.
     /// * [`BridgeError::InvalidAmount`] — `amount` ≤ 0.
     /// * [`BridgeError::InvalidReleaseTime`] — `release_time` ≤ current timestamp,
     ///   or `cliff_time > release_time`.
@@ -3817,6 +3821,7 @@ impl OnboardingBridge {
     /// * [`BridgeError::AddressNotAllowlisted`] — Allowlist mode on and `target`
     ///   is not allowlisted.
     /// * [`BridgeError::AssetNotWhitelisted`] — `asset` has not been added.
+    /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     ///
     /// # Events
     ///
@@ -3836,10 +3841,17 @@ impl OnboardingBridge {
         amount: i128,
         release_time: u64,
         cliff_time: u64,
+        nonce: Option<u64>,
+        deadline: Option<u64>,
     ) -> Result<u64, BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
+        if let Some(d) = deadline {
+            if env.ledger().timestamp() > d {
+                return Err(BridgeError::TransactionExpired);
+            }
+        }
         if amount <= 0 {
             return Err(BridgeError::InvalidAmount);
         }
@@ -3853,6 +3865,7 @@ impl OnboardingBridge {
         check_access(&env, &target)?;
         check_asset_whitelisted(&env, &asset)?;
         source.require_auth();
+        consume_nonce(&env, &source, nonce)?;
         extend_instance_ttl(&env);
 
         token::Client::new(&env, &asset)
@@ -4769,10 +4782,17 @@ impl OnboardingBridge {
         source_amount: i128,
         min_target_amount: i128,
         swap_route: Vec<Address>,
+        nonce: Option<u64>,
+        deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
         check_not_paused(&env)?;
+        if let Some(d) = deadline {
+            if env.ledger().timestamp() > d {
+                return Err(BridgeError::TransactionExpired);
+            }
+        }
 
         if source_amount <= 0 || min_target_amount <= 0 {
             return Err(BridgeError::InvalidAmount);
@@ -4792,6 +4812,7 @@ impl OnboardingBridge {
         check_pool_whitelisted(&env, &pool)?;
 
         source.require_auth();
+        consume_nonce(&env, &source, nonce)?;
         extend_instance_ttl(&env);
 
         let contract_addr = env.current_contract_address();

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1025,7 +1025,7 @@ fn test_query_whitelisted_assets() {
     bridge.add_asset(&asset1, &None);
     bridge.add_asset(&asset2, &None);
 
-    let assets = bridge.query_whitelisted_assets();
+    let assets = bridge.query_whitelisted_assets(&0u32, &100u32);
     assert_eq!(assets.len(), 2);
 
     let mut found1 = false;
@@ -1052,7 +1052,7 @@ fn test_add_asset_is_idempotent() {
     bridge.add_asset(&token_id, &None);
     bridge.add_asset(&token_id, &None);
 
-    assert_eq!(bridge.query_whitelisted_assets().len(), 1);
+    assert_eq!(bridge.query_whitelisted_assets(&0u32, &100u32).len(), 1);
 }
 
 #[test]
@@ -1165,6 +1165,56 @@ fn test_query_all_balances_empty_input() {
     let assets: Vec<Address> = Vec::new(&env);
     let balances = bridge.query_all_balances(&assets);
     assert_eq!(balances.len(), 0);
+}
+
+#[test]
+fn test_query_all_balances_rejects_oversized_input() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
+
+    // MAX_BATCH_SIZE is 100 — one more than that must be rejected.
+    let mut assets: Vec<Address> = Vec::new(&env);
+    for _ in 0..101 {
+        assets.push_back(Address::generate(&env));
+    }
+    assert_eq!(
+        bridge.try_query_all_balances(&assets),
+        Err(Ok(BridgeError::BatchTooLarge))
+    );
+
+    // Exactly MAX_BATCH_SIZE is accepted.
+    assets.pop_back();
+    assert_eq!(bridge.query_all_balances(&assets).len(), 100);
+}
+
+#[test]
+fn test_query_whitelisted_assets_pagination() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    for _ in 0..5 {
+        bridge.add_asset(&Address::generate(&env), &None);
+    }
+
+    let page1 = bridge.query_whitelisted_assets(&0u32, &2u32);
+    assert_eq!(page1.len(), 2);
+    let page2 = bridge.query_whitelisted_assets(&2u32, &2u32);
+    assert_eq!(page2.len(), 2);
+    let page3 = bridge.query_whitelisted_assets(&4u32, &2u32);
+    assert_eq!(page3.len(), 1);
+    // Offset past the end returns an empty page rather than erroring.
+    let page4 = bridge.query_whitelisted_assets(&5u32, &2u32);
+    assert_eq!(page4.len(), 0);
+
+    // A limit above MAX_BATCH_SIZE is silently clamped, not rejected.
+    let clamped = bridge.query_whitelisted_assets(&0u32, &1000u32);
+    assert_eq!(clamped.len(), 5);
 }
 
 #[test]

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -922,8 +922,16 @@ fn test_reclaim_cannot_drain_active_timelocks() {
 
     // 500 tokens locked in an unclaimed timelock; nothing else in the balance.
     let release_time = 1_100u64;
-    let id =
-        bridge.fund_c_address_timelocked(&user, &target, &token_id, &500i128, &release_time, &0u64);
+    let id = bridge.fund_c_address_timelocked(
+        &user,
+        &target,
+        &token_id,
+        &500i128,
+        &release_time,
+        &0u64,
+        &None,
+        &None,
+    );
     assert_eq!(check_balance(&env, &token_id, &bridge.address), 500i128);
 
     // Locked funds cannot be reclaimed at all before the timelock is claimed.
@@ -1433,6 +1441,8 @@ fn test_swap_rejects_non_whitelisted_pool() {
             &500i128,
             &400i128,
             &swap_route,
+            &None,
+            &None,
         ),
         Err(Ok(BridgeError::PoolNotWhitelisted))
     );
@@ -1464,6 +1474,8 @@ fn test_swap_multi_hop_route_rejected() {
             &500i128,
             &400i128,
             &swap_route,
+            &None,
+            &None,
         ),
         Err(Ok(BridgeError::MultiHopNotSupported))
     );
@@ -1490,8 +1502,114 @@ fn test_swap_happy_path_single_hop() {
         &500i128,
         &400i128,
         &swap_route,
+        &None,
+        &None,
     );
 
+    assert_eq!(check_balance(&env, &target_token_id, &target), 500i128);
+}
+
+#[test]
+fn test_swap_nonce_replay_rejected() {
+    let env = Env::default();
+    let (bridge, user, source_token_id, target_token_id) = setup_swap(&env);
+
+    let pool_id = env.register(SwapPool, ());
+    SwapPoolClient::new(&env, &pool_id).initialize(&source_token_id, &target_token_id, &1i128);
+    mint_tokens(&env, &target_token_id, &pool_id, 10_000i128);
+    bridge.add_swap_pool(&pool_id, &None);
+
+    let target = Address::generate(&env);
+    let swap_route = Vec::from_array(&env, [pool_id]);
+
+    bridge.fund_c_address_with_swap(
+        &user,
+        &target,
+        &source_token_id,
+        &target_token_id,
+        &500i128,
+        &400i128,
+        &swap_route,
+        &Some(0u64),
+        &None,
+    );
+    assert_eq!(bridge.query_nonce(&user), 1u64);
+
+    // Reusing nonce=0 is rejected.
+    let target2 = Address::generate(&env);
+    assert_eq!(
+        bridge.try_fund_c_address_with_swap(
+            &user,
+            &target2,
+            &source_token_id,
+            &target_token_id,
+            &500i128,
+            &400i128,
+            &swap_route,
+            &Some(0u64),
+            &None,
+        ),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
+#[test]
+fn test_swap_deadline_expired_reverts() {
+    let env = Env::default();
+    env.ledger().set_timestamp(2_000);
+    let (bridge, user, source_token_id, target_token_id) = setup_swap(&env);
+
+    let pool_id = env.register(SwapPool, ());
+    SwapPoolClient::new(&env, &pool_id).initialize(&source_token_id, &target_token_id, &1i128);
+    mint_tokens(&env, &target_token_id, &pool_id, 10_000i128);
+    bridge.add_swap_pool(&pool_id, &None);
+
+    let target = Address::generate(&env);
+    let swap_route = Vec::from_array(&env, [pool_id]);
+
+    assert_eq!(
+        bridge.try_fund_c_address_with_swap(
+            &user,
+            &target,
+            &source_token_id,
+            &target_token_id,
+            &500i128,
+            &400i128,
+            &swap_route,
+            &None,
+            &Some(1_999u64),
+        ),
+        Err(Ok(BridgeError::TransactionExpired))
+    );
+    // Nothing was pulled from the user since the deadline check runs first.
+    assert_eq!(check_balance(&env, &source_token_id, &user), 1_000i128);
+}
+
+#[test]
+fn test_swap_deadline_in_future_passes() {
+    let env = Env::default();
+    env.ledger().set_timestamp(2_000);
+    let (bridge, user, source_token_id, target_token_id) = setup_swap(&env);
+
+    let pool_id = env.register(SwapPool, ());
+    SwapPoolClient::new(&env, &pool_id).initialize(&source_token_id, &target_token_id, &1i128);
+    mint_tokens(&env, &target_token_id, &pool_id, 10_000i128);
+    bridge.add_swap_pool(&pool_id, &None);
+
+    let target = Address::generate(&env);
+    let swap_route = Vec::from_array(&env, [pool_id]);
+
+    bridge.fund_c_address_with_swap(
+        &user,
+        &target,
+        &source_token_id,
+        &target_token_id,
+        &500i128,
+        &400i128,
+        &swap_route,
+        &None,
+        &Some(3_000u64),
+    );
     assert_eq!(check_balance(&env, &target_token_id, &target), 500i128);
 }
 
@@ -2233,6 +2351,8 @@ mod timelocked_tests {
             &500i128,
             &release_time,
             &0u64,
+            &None,
+            &None,
         );
 
         env.ledger().set_timestamp(release_time + 1);
@@ -2256,6 +2376,8 @@ mod timelocked_tests {
             &500i128,
             &(2_100u64),
             &0u64,
+            &None,
+            &None,
         );
 
         assert_eq!(
@@ -2279,6 +2401,8 @@ mod timelocked_tests {
                 &500i128,
                 &3_100u64,
                 &3_101u64,
+                &None,
+                &None,
             ),
             Err(Ok(BridgeError::InvalidReleaseTime))
         );
@@ -2299,6 +2423,8 @@ mod timelocked_tests {
                 &500i128,
                 &4_000u64,
                 &0u64,
+                &None,
+                &None,
             ),
             Err(Ok(BridgeError::InvalidReleaseTime))
         );
@@ -2319,6 +2445,8 @@ mod timelocked_tests {
             &500i128,
             &release_time,
             &0u64,
+            &None,
+            &None,
         );
 
         env.ledger().set_timestamp(release_time + 1);
@@ -2339,6 +2467,86 @@ mod timelocked_tests {
             bridge.try_query_timelocked(&999_999u64),
             Err(Ok(BridgeError::TimelockNotFound))
         );
+    }
+
+    #[test]
+    fn test_timelocked_nonce_replay_rejected() {
+        let env = Env::default();
+        env.ledger().set_timestamp(6_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+        let release_time = 6_100u64;
+
+        bridge.fund_c_address_timelocked(
+            &user,
+            &target,
+            &token_id,
+            &500i128,
+            &release_time,
+            &0u64,
+            &Some(0u64),
+            &None,
+        );
+        assert_eq!(bridge.query_nonce(&user), 1u64);
+
+        // Reusing nonce=0 is rejected.
+        let target2 = Address::generate(&env);
+        assert_eq!(
+            bridge.try_fund_c_address_timelocked(
+                &user,
+                &target2,
+                &token_id,
+                &500i128,
+                &release_time,
+                &0u64,
+                &Some(0u64),
+                &None,
+            ),
+            Err(Ok(BridgeError::DuplicateNonce))
+        );
+    }
+
+    #[test]
+    fn test_timelocked_deadline_expired_reverts() {
+        let env = Env::default();
+        env.ledger().set_timestamp(7_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+
+        assert_eq!(
+            bridge.try_fund_c_address_timelocked(
+                &user,
+                &target,
+                &token_id,
+                &500i128,
+                &7_100u64,
+                &0u64,
+                &None,
+                &Some(6_999u64),
+            ),
+            Err(Ok(BridgeError::TransactionExpired))
+        );
+    }
+
+    #[test]
+    fn test_timelocked_deadline_in_future_passes() {
+        let env = Env::default();
+        env.ledger().set_timestamp(8_000);
+        let (bridge, user, token_id, _fee_collector, _admin) = setup_timelocked(&env);
+        let target = Address::generate(&env);
+
+        let id = bridge.fund_c_address_timelocked(
+            &user,
+            &target,
+            &token_id,
+            &500i128,
+            &8_100u64,
+            &0u64,
+            &None,
+            &Some(9_000u64),
+        );
+        assert_eq!(check_balance(&env, &token_id, &bridge.address), 500i128);
+        let _ = id;
     }
 }
 

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -442,6 +442,144 @@ fn test_set_admin_paused() {
     );
 }
 
+/********** Issue: check_not_paused consistency across admin setters **********/
+
+#[test]
+fn test_set_referral_rate_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    assert_eq!(
+        bridge.try_set_referral_rate(&1000u32, &None),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_set_asset_fee_cap_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    assert_eq!(
+        bridge.try_set_asset_fee_cap(&token_id, &50u32, &None),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_set_source_daily_limit_paused() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    assert_eq!(
+        bridge.try_set_source_daily_limit(&user, &token_id, &10_000i128, &None),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_set_loyalty_token_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    assert_eq!(
+        bridge.try_set_loyalty_token(&token_id, &10i128),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_set_fee_tiers_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    let tiers = Vec::from_array(
+        &env,
+        [FeeTier {
+            min_volume: 0,
+            max_volume: 1000i128,
+            fee_bps: 50u32,
+        }],
+    );
+    assert_eq!(
+        bridge.try_set_fee_tiers(&tiers),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_add_relayer_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    let pubkey = BytesN::from_array(&env, &[7u8; 32]);
+    assert_eq!(
+        bridge.try_add_relayer(&pubkey),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_remove_relayer_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pubkey = BytesN::from_array(&env, &[7u8; 32]);
+    bridge.add_relayer(&pubkey);
+    bridge.pause(&None);
+    assert_eq!(
+        bridge.try_remove_relayer(&pubkey),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_set_relayer_threshold_paused() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pubkey = BytesN::from_array(&env, &[7u8; 32]);
+    bridge.add_relayer(&pubkey);
+    bridge.pause(&None);
+    assert_eq!(
+        bridge.try_set_relayer_threshold(&1u32),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
 #[test]
 fn test_view_functions_work_when_paused() {
     let env = Env::default();

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -3997,6 +3997,42 @@ fn test_batch_fund_applies_tiered_fee() {
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 1i128);
 }
 
+#[test]
+fn test_set_fee_tiers_rejects_excessive_tier_count() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+
+    // MAX_FEE_TIERS is 50 — one more than that must be rejected.
+    let mut too_many: Vec<FeeTier> = Vec::new(&env);
+    for i in 0..51u32 {
+        too_many.push_back(FeeTier {
+            min_volume: (i as i128) * 1000,
+            max_volume: (i as i128) * 1000 + 999,
+            fee_bps: 10u32,
+        });
+    }
+    assert_eq!(
+        bridge.try_set_fee_tiers(&too_many),
+        Err(Ok(BridgeError::TooManyFeeTiers))
+    );
+
+    // Exactly MAX_FEE_TIERS is accepted.
+    let mut exactly_max: Vec<FeeTier> = Vec::new(&env);
+    for i in 0..50u32 {
+        exactly_max.push_back(FeeTier {
+            min_volume: (i as i128) * 1000,
+            max_volume: (i as i128) * 1000 + 999,
+            fee_bps: 10u32,
+        });
+    }
+    bridge.set_fee_tiers(&exactly_max);
+    assert_eq!(bridge.query_fee_tiers().len(), 50);
+}
+
 // fund_c_address_with_referral computed its fee straight from the global rate via
 // get_effective_fee_bps, never consulting the caller's volume tier.
 #[test]


### PR DESCRIPTION
 closes #242 
closes #243 
closes #244 
closes #245



1. a5f70e5 — check_not_paused added consistently to set_referral_rate, set_asset_fee_cap, set_source_daily_limit, set_loyalty_token, set_fee_tiers, add_relayer, remove_relayer, set_relayer_threshold + 8 paused-state tests.
2. 73771a2 — nonce/deadline params added to fund_c_address_with_swap and fund_c_address_timelocked, mirroring fund_c_address's validation, plus replay/expiry tests for both.
3. 75b1156 — MAX_FEE_TIERS (50) constant added; set_fee_tiers now rejects oversized tier lists with new BridgeError::TooManyFeeTiers, plus a boundary test.
4. 43a3cf4 — query_all_balances capped at MAX_BATCH_SIZE (100); query_whitelisted_assets now paginated via offset/limit, plus boundary tests.