### PR TITLE
feat(sdk): add timelocked wrappers and update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Cross-chain funding with relayer signature verification, replay protection, and relayer threshold management.
+- Referral fee splitting and fee-tier/loyalty-token support.
+- Timelocked C-address funding with delayed claim and query support.
+- Commit-reveal funding flow for privacy-preserving deposits.
+- Meta-transaction support with signer registration and nonce tracking.
+- Admin controls for pausing, asset allowlisting, blocklist/allowlist access control, daily limits, fee caps, and emergency token reclaim.
+- Timelocked contract upgrade scheduling, execution, cancellation, and pending-upgrade query support.
+- Two-step admin and fee-collector handoff using propose/accept flows.
+- SDK wrappers for timelocked funding, claiming, and querying.
+
 ## [0.1.0] - 2024-01-01
 
 ### Added

--- a/adr/ADR-003-role-separation.md
+++ b/adr/ADR-003-role-separation.md
@@ -13,11 +13,21 @@ Split privileges into **two distinct roles**:
 
 | Role | Key stored | Can do |
 |---|---|---|
-| `admin` | `DataKey::Admin` | `set_fee_bps`, `set_fee_collector`, `set_admin`, `upgrade`, `pause`, `unpause`, `add_asset`, `remove_asset`, `add_to_blocklist`, `set_daily_limit`, etc. |
+| `admin` | `DataKey::Admin` | `set_fee_bps`, `set_fee_collector`, `propose_new_fee_collector`, `set_admin`, `propose_new_admin`, `upgrade`, `pause`, `unpause`, `add_asset`, `remove_asset`, `add_to_blocklist`, `set_daily_limit`, etc. |
 | `fee_collector` | `DataKey::FeeCollector` | `withdraw_fees` only |
 
 - Both roles are set at `initialize` time and can be rotated by their respective current holder (`set_admin` requires admin auth; `set_fee_collector` requires admin auth too, to prevent a compromised fee collector from locking the admin out).
 - Neither role can act as the other: `withdraw_fees` checks `fee_collector.require_auth()` and rejects the admin; all config functions check `admin.require_auth()`.
+
+### Superseding role rotation pattern
+
+The contract now supports a safer two-step handoff for both privileged roles:
+
+- Admin rotation: `propose_new_admin(new_admin, nonce)` stores `DataKey::PendingAdmin`, and `accept_admin()` must be authorized by the pending admin before the stored admin is changed.
+- Fee-collector rotation: `propose_new_fee_collector(new_collector, nonce)` stores `DataKey::PendingFeeCollector`, and `accept_fee_collector()` must be authorized by the pending collector before the stored fee collector is changed.
+- `query_pending_admin()` and `query_pending_fee_collector()` expose pending handoffs for operators and monitoring.
+
+This propose/accept pattern supersedes the original single-call `set_admin` and `set_fee_collector` rotation path for normal operations. It proves the recipient controls the destination key before the role is moved, reduces the chance of transferring control to an unusable address, and creates an observable pending state before the final handoff. The single-call setters remain available for backwards compatibility and emergency operational recovery, but production runbooks should prefer propose/accept.
 
 ## Consequences
 
@@ -26,7 +36,8 @@ Split privileges into **two distinct roles**:
 - Compromising the admin key cannot directly drain fees (it can rotate the fee collector, but that's a detectable on-chain action).
 - Auditors can clearly distinguish operational access from financial access.
 - Principle of least privilege: hot wallets used for fee collection don't need admin powers.
+- Two-step handoff verifies the recipient can authorize before role control moves.
 
 **Negative:**
 - Two keypairs to manage instead of one.
-- `set_fee_collector` requires admin auth, so rotating the fee collector after an admin key rotation must be done atomically to avoid a gap.
+- Two-step handoff requires coordination from both the current admin and the proposed recipient.

--- a/adr/ADR-006-upgrade-strategy.md
+++ b/adr/ADR-006-upgrade-strategy.md
@@ -15,7 +15,7 @@ Three upgrade strategies were considered:
 
 ## Decision
 
-Use a **timelock upgrade** pattern:
+Use a **timelock upgrade** pattern for production deployments:
 
 - `schedule_upgrade(new_wasm_hash, delay_seconds)` (admin only): stores the pending hash and `release_time = now + delay` under `DataKey::PendingUpgrade`.
 - `execute_upgrade(expected_hash)` (admin only): callable only after `release_time`; verifies the hash matches to prevent bait-and-switch; calls `update_current_contract_wasm`.
@@ -24,7 +24,9 @@ Use a **timelock upgrade** pattern:
 - The `expected_hash` parameter in `execute_upgrade` is a safety check: if the admin's key was compromised and the attacker scheduled a different WASM, the legitimate admin (who stored the expected hash off-chain at schedule time) can detect the mismatch.
 
 Deploy-new-instance was rejected because it changes the contract ID, breaking all integrations.
-Immediate upgrade was rejected because it gives no window for users to exit if the new code is malicious.
+Immediate upgrade was rejected as the default production governance path because it gives no window for users to exit if the new code is malicious.
+
+The contract still retains `upgrade(new_wasm_hash, nonce)` as an explicit **untimelocked** admin-only path for development, testnet deployments, emergency recovery drills, and controlled environments where waiting 24 hours is counterproductive. Production runbooks should treat this as a break-glass or non-mainnet convenience path and prefer `schedule_upgrade` plus `execute_upgrade` for user-facing deployments.
 
 ## Consequences
 
@@ -33,8 +35,10 @@ Immediate upgrade was rejected because it gives no window for users to exit if t
 - Hash verification prevents bait-and-switch attacks.
 - Instance storage (admin config, fees, accrued balances) is fully preserved across upgrades.
 - No change to the contract address — integrations continue working.
+- Testnet and development deployments can still use the immediate path when a timelock would slow iteration without improving user safety.
 
 **Negative:**
 - Security patches cannot be applied instantly; a 24-hour window must elapse. For critical bugs, the admin should pause the contract immediately while the upgrade is pending.
 - Adds operational complexity: two transactions (schedule + execute) instead of one.
 - If the admin key is lost after scheduling an upgrade, there is no way to execute it. Mitigated by maintaining a secure backup of the admin key.
+- Retaining an immediate path means operational policy and monitoring must distinguish production timelocked upgrades from non-production or break-glass immediate upgrades.

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1873,6 +1873,11 @@ impl OnboardingBridge {
         Ok(())
     }
 
+    /// Proposes a fee-collector handoff that must be accepted by `new_collector`.
+    ///
+    /// This two-step path is preferred over `set_fee_collector` for normal
+    /// operations because it proves the proposed collector controls the key
+    /// before the role is moved.
     pub fn propose_new_fee_collector(env: Env, new_collector: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
@@ -1887,6 +1892,7 @@ impl OnboardingBridge {
         Ok(())
     }
 
+    /// Accepts a pending fee-collector handoff.
     pub fn accept_fee_collector(env: Env) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
@@ -1926,6 +1932,10 @@ impl OnboardingBridge {
         Ok(())
     }
 
+    /// Proposes an admin handoff that must be accepted by `new_admin`.
+    ///
+    /// This two-step path is preferred over `set_admin` for normal operations
+    /// because it prevents accidentally transferring control to an unusable key.
     pub fn propose_new_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
@@ -1940,6 +1950,7 @@ impl OnboardingBridge {
         Ok(())
     }
 
+    /// Accepts a pending admin handoff.
     pub fn accept_admin(env: Env) -> Result<(), BridgeError> {
         let _guard = ReentrancyGuard::enter(&env);
         check_initialized(&env)?;
@@ -2512,9 +2523,10 @@ impl OnboardingBridge {
 
     /// Immediately upgrades the contract WASM to `new_wasm_hash`.
     ///
-    /// This is the **untimelocked** upgrade path. For production deployments,
-    /// prefer `schedule_upgrade` + `execute_upgrade` which enforces a ~24-hour
-    /// delay, giving users time to react.
+    /// This is the **untimelocked** upgrade path retained for development,
+    /// testnet, and controlled break-glass operations. For production
+    /// deployments, prefer `schedule_upgrade` + `execute_upgrade` which
+    /// enforces a ~24-hour delay, giving users time to react.
     ///
     /// # Arguments
     ///

--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -116,6 +116,63 @@ describe('OnboardingBridgeSDK', () => {
     });
   });
 
+  describe('timelocked funding', () => {
+    it('fundCAddressTimelocked returns pending status on success', async () => {
+      const result = await sdk.fundCAddressTimelocked(
+        {
+          source: MOCK_ADDRESS,
+          target: MOCK_ASSET,
+          asset: MOCK_ASSET,
+          amount: '1000',
+          releaseTime: 1893456000,
+          cliffTime: 1893455000,
+        },
+        mockKeypair,
+      );
+
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBe('mock_tx_hash');
+      expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
+      expect(mockProvider.prepareTransaction).toHaveBeenCalled();
+      expect(mockProvider.sendTransaction).toHaveBeenCalled();
+    });
+
+    it('claimTimelocked returns pending status on success', async () => {
+      const result = await sdk.claimTimelocked(1, mockKeypair);
+
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBe('mock_tx_hash');
+      expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
+      expect(mockProvider.prepareTransaction).toHaveBeenCalled();
+      expect(mockProvider.sendTransaction).toHaveBeenCalled();
+    });
+
+    it('queryTimelocked returns a timelock entry', async () => {
+      (scValToNative as jest.Mock).mockReturnValue({
+        source: MOCK_ADDRESS,
+        target: MOCK_ASSET,
+        asset: MOCK_ASSET,
+        amount: 1000n,
+        release_time: 1893456000n,
+        cliff_time: 1893455000n,
+        claimed: false,
+      });
+      mockProvider.simulateTransaction.mockResolvedValue({ results: [{ retval: {} }] });
+
+      const entry = await sdk.queryTimelocked(1);
+
+      expect(entry).toEqual({
+        source: MOCK_ADDRESS,
+        target: MOCK_ASSET,
+        asset: MOCK_ASSET,
+        amount: '1000',
+        releaseTime: 1893456000,
+        cliffTime: 1893455000,
+        claimed: false,
+      });
+    });
+  });
+
   describe('batchFundCAddresses', () => {
     it('returns array with one pending result on success', async () => {
       const results = await sdk.batchFundCAddresses(

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -11,6 +11,7 @@
 import {
   BridgeConfig,
   FundCOptions,
+  FundCTimelockedOptions,
   BatchFundCOptions,
   BatchProgressCallback,
   WithdrawFeesOptions,
@@ -25,6 +26,7 @@ import {
   PaginatedResult,
   PaginationOptions,
   CostEstimate,
+  TimelockEntry,
 } from './types';
 import {
   type ObservabilityHooks,
@@ -237,6 +239,193 @@ export class OnboardingBridgeSDK {
         }
       },
     );
+  }
+
+  /**
+   * Create a timelocked funding entry for a C-address.
+   *
+   * Transfers `options.amount` of `options.asset` from `source` into the bridge
+   * contract immediately. The `target` can later call {@link claimTimelocked}
+   * once `releaseTime` has passed.
+   */
+  async fundCAddressTimelocked(
+    options: FundCTimelockedOptions,
+    sourceKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'fundCAddressTimelocked',
+      {
+        source: options.source,
+        target: options.target,
+        asset: options.asset,
+        amount: options.amount,
+        releaseTime: options.releaseTime,
+        cliffTime: options.cliffTime ?? 0,
+      },
+      async () => {
+        try {
+          assertAccountAddress(options.source, 'source');
+          assertContractAddress(options.target, 'target');
+          assertContractAddress(options.asset, 'asset');
+
+          const sourceAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: options.source },
+            () => this.provider.getAccount(options.source),
+          );
+
+          const tx = new TransactionBuilder(sourceAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'fund_c_address_timelocked',
+                new Address(options.source).toScVal(),
+                new Address(options.target).toScVal(),
+                new Address(options.asset).toScVal(),
+                nativeToScVal(BigInt(options.amount), { type: 'i128' }),
+                nativeToScVal(BigInt(options.releaseTime), { type: 'u64' }),
+                nativeToScVal(BigInt(options.cliffTime ?? 0), { type: 'u64' }),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'fund_c_address_timelocked' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(sourceKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'fund_c_address_timelocked' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  /**
+   * Claim a matured timelocked funding entry.
+   */
+  async claimTimelocked(
+    id: number,
+    targetKeypair: Keypair,
+  ): Promise<TransactionResult> {
+    return withTransactionHooks(
+      this.hooks,
+      'claimTimelocked',
+      { id },
+      async () => {
+        try {
+          const targetAccount = await withRpcHook(
+            this.hooks,
+            'getAccount',
+            { address: targetKeypair.publicKey() },
+            () => this.provider.getAccount(targetKeypair.publicKey()),
+          );
+
+          const tx = new TransactionBuilder(targetAccount, {
+            fee: BASE_FEE,
+            networkPassphrase: this.networkPassphrase,
+          })
+            .addOperation(
+              this.contract.call(
+                'claim_timelocked',
+                nativeToScVal(BigInt(id), { type: 'u64' }),
+              ),
+            )
+            .setTimeout(30)
+            .build();
+
+          const preparedTx = await withRpcHook(
+            this.hooks,
+            'prepareTransaction',
+            { contractMethod: 'claim_timelocked' },
+            () => this.provider.prepareTransaction(tx),
+          );
+          preparedTx.sign(targetKeypair);
+
+          const response = await withRpcHook(
+            this.hooks,
+            'sendTransaction',
+            { contractMethod: 'claim_timelocked' },
+            () => this.provider.sendTransaction(preparedTx),
+          );
+
+          return {
+            hash: response.hash,
+            status: response.status === 'ERROR' ? 'failed' : 'pending',
+          };
+        } catch (error: any) {
+          return {
+            hash: '',
+            status: 'failed',
+            error: error.message || 'Unknown error',
+          };
+        }
+      },
+    );
+  }
+
+  /**
+   * Query a timelocked funding entry by ID.
+   */
+  async queryTimelocked(id: number): Promise<TimelockEntry | null> {
+    const account = new Account('GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF', '0');
+    const tx = new TransactionBuilder(account, {
+      fee: '100',
+      networkPassphrase: this.networkPassphrase,
+    })
+      .addOperation(
+        this.contract.call(
+          'query_timelocked',
+          nativeToScVal(BigInt(id), { type: 'u64' }),
+        ),
+      )
+      .setTimeout(30)
+      .build();
+
+    const result = await this.provider.simulateTransaction(
+      tx,
+    );
+
+    if ('error' in result && result.error) {
+      throw new Error(`Failed to query timelocked entry: ${result.error}`);
+    }
+
+    const scVal = (result as any).results?.[0]?.retval;
+    if (!scVal) return null;
+
+    const native = scValToNative(scVal) as any;
+    return {
+      source: native.source?.toString?.() ?? String(native.source),
+      target: native.target?.toString?.() ?? String(native.target),
+      asset: native.asset?.toString?.() ?? String(native.asset),
+      amount: native.amount?.toString?.() ?? String(native.amount),
+      releaseTime: Number(native.release_time ?? native.releaseTime),
+      cliffTime: Number(native.cliff_time ?? native.cliffTime),
+      claimed: Boolean(native.claimed),
+    };
   }
 
   /**

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -166,6 +166,38 @@ export interface FundCOptions {
 }
 
 /**
+ * Options for creating a timelocked C-address funding entry via
+ * {@link OnboardingBridgeSDK.fundCAddressTimelocked}.
+ */
+export interface FundCTimelockedOptions extends FundCOptions {
+  /**
+   * Unix timestamp in seconds after which the target can claim the locked funds.
+   * Must be strictly in the future when submitted to the contract.
+   */
+  releaseTime: number;
+
+  /**
+   * Optional informational cliff timestamp in seconds. Use `0` when no cliff is
+   * needed. If set, it must be less than or equal to `releaseTime`.
+   */
+  cliffTime?: number;
+}
+
+/**
+ * Timelocked funding record returned by
+ * {@link OnboardingBridgeSDK.queryTimelocked}.
+ */
+export interface TimelockEntry {
+  source: string;
+  target: string;
+  asset: string;
+  amount: string;
+  releaseTime: number;
+  cliffTime: number;
+  claimed: boolean;
+}
+
+/**
  * Options for funding multiple C-addresses in one or more transactions via
  * {@link OnboardingBridgeSDK.batchFundCAddresses}.
  *


### PR DESCRIPTION
Summary:
- Add SDK wrappers and tests for timelocked funding, claiming, and querying.
- Backfill changelog entries for post-0.1.0 features.
- Update ADR-003 and ADR-006 for two-step role handoff and retained immediate upgrade behavior.

Closes: #342
Closes: #341
Closes: #340
Closes: #339

Validation:
- npm test -- --runTestsByPath src/__tests__/bridge.test.ts --runInBand
- npm run build
- git diff --check

Note:
- npm run lint is configured but currently fails because eslint is not installed/declared in the SDK package.