### PR TITLE
gasbehmanmessage

### DIFF
--- a/bench_baseline.txt
+++ b/bench_baseline.txt
@@ -39,3 +39,15 @@ remove_from_allowlist	135717	24022
 set_allowlist_mode	152203	23703
 pause	167410	25728
 unpause	171778	26868
+# ── Second-sprint features (placeholder entries — run benchmarks to capture real values) ──
+fund_c_address_timelocked	0	0
+claim_timelocked	0	0
+fund_c_address_crosschain	0	0
+commit_fund	0	0
+reveal_fund	0	0
+fund_c_address_with_swap	0	0
+execute_meta_fund	0	0
+fund_c_address/tiered_fee	0	0
+set_max_withdraw_per_tx	0	0
+set_source_daily_limit	0	0
+set_asset_fee_cap	0	0

--- a/contracts/onboarding-bridge/benches/gas_benchmark.rs
+++ b/contracts/onboarding-bridge/benches/gas_benchmark.rs
@@ -3,7 +3,7 @@
 use soroban_sdk::{
     contract, contractimpl, contracttype,
     testutils::Address as _,
-    Address, Env, IntoVal, Vec,
+    Address, Bytes, BytesN, Env, IntoVal, Vec,
 };
 
 use onboarding_bridge::OnboardingBridge;
@@ -308,6 +308,152 @@ fn bench_query_total_bridged() -> BenchResult {
     }
 }
 
+// ── Second-sprint feature benchmarks ──────────────────────────────────────────
+
+fn bench_fund_c_address_timelocked() -> BenchResult {
+    let (env, bridge_id, token_id, admin, fee_collector) = setup_env();
+    let bridge = onboarding_bridge::OnboardingBridgeClient::new(&env, &bridge_id);
+    let token = BenchTokenClient::new(&env, &token_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    let user = Address::generate(&env);
+    token.mint(&user, &20_000i128);
+    let target = Address::generate(&env);
+    let release_time = env.ledger().timestamp() + 365 * 86_400u64;
+
+    env.budget().reset_default();
+    env.budget().reset_tracker();
+
+    bridge.fund_c_address_timelocked(&user, &target, &token_id, &10_000i128, &release_time, &0u64, &None, &None);
+
+    let cpu = env.budget().cpu_instruction_cost();
+    let mem = env.budget().memory_bytes_cost();
+
+    BenchResult { function_name: "fund_c_address_timelocked", variant: "default", cpu_insns: cpu, mem_bytes: mem }
+}
+
+fn bench_claim_timelocked() -> BenchResult {
+    let (env, bridge_id, token_id, admin, fee_collector) = setup_env();
+    let bridge = onboarding_bridge::OnboardingBridgeClient::new(&env, &bridge_id);
+    let token = BenchTokenClient::new(&env, &token_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    let user = Address::generate(&env);
+    token.mint(&user, &20_000i128);
+    let target = Address::generate(&env);
+    let release_time = env.ledger().timestamp() + 86_400u64;
+    let id = bridge.fund_c_address_timelocked(&user, &target, &token_id, &10_000i128, &release_time, &0u64, &None, &None);
+    env.ledger().set_timestamp(release_time + 1);
+
+    env.budget().reset_default();
+    env.budget().reset_tracker();
+
+    bridge.claim_timelocked(&id);
+
+    let cpu = env.budget().cpu_instruction_cost();
+    let mem = env.budget().memory_bytes_cost();
+
+    BenchResult { function_name: "claim_timelocked", variant: "default", cpu_insns: cpu, mem_bytes: mem }
+}
+
+fn bench_commit_fund() -> BenchResult {
+    let (env, bridge_id, token_id, admin, fee_collector) = setup_env();
+    let bridge = onboarding_bridge::OnboardingBridgeClient::new(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+    let mut preimage = soroban_sdk::Bytes::new(&env);
+    preimage.extend_from_array(&10_000i128.to_be_bytes());
+    preimage.extend_from_array(&1u64.to_be_bytes());
+    let amount_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    env.budget().reset_default();
+    env.budget().reset_tracker();
+
+    bridge.commit_fund(&user, &target, &token_id, &amount_hash, &deadline);
+
+    let cpu = env.budget().cpu_instruction_cost();
+    let mem = env.budget().memory_bytes_cost();
+
+    BenchResult { function_name: "commit_fund", variant: "default", cpu_insns: cpu, mem_bytes: mem }
+}
+
+fn bench_reveal_fund() -> BenchResult {
+    let (env, bridge_id, token_id, admin, fee_collector) = setup_env();
+    let bridge = onboarding_bridge::OnboardingBridgeClient::new(&env, &bridge_id);
+    let token = BenchTokenClient::new(&env, &token_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+    let amount: i128 = 10_000;
+    let nonce: u64 = 1;
+    token.mint(&user, &(amount * 2));
+
+    let mut preimage = soroban_sdk::Bytes::new(&env);
+    preimage.extend_from_array(&amount.to_be_bytes());
+    preimage.extend_from_array(&nonce.to_be_bytes());
+    let amount_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+    let deadline = env.ledger().timestamp() + 86_400;
+    let id = bridge.commit_fund(&user, &target, &token_id, &amount_hash, &deadline);
+    env.ledger().set_sequence_number(env.ledger().sequence() + 6);
+
+    env.budget().reset_default();
+    env.budget().reset_tracker();
+
+    bridge.reveal_fund(&id, &user, &target, &token_id, &amount, &nonce);
+
+    let cpu = env.budget().cpu_instruction_cost();
+    let mem = env.budget().memory_bytes_cost();
+
+    BenchResult { function_name: "reveal_fund", variant: "default", cpu_insns: cpu, mem_bytes: mem }
+}
+
+fn bench_tiered_fee_lookup() -> BenchResult {
+    let (env, bridge_id, token_id, admin, fee_collector) = setup_env();
+    let bridge = onboarding_bridge::OnboardingBridgeClient::new(&env, &bridge_id);
+    let token = BenchTokenClient::new(&env, &token_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    let user = Address::generate(&env);
+    token.mint(&user, &2_000_000i128);
+
+    let tiers = Vec::from_array(
+        &env,
+        [
+            onboarding_bridge::FeeTier { min_volume: 0, max_volume: 1_000i128, fee_bps: 10u32 },
+            onboarding_bridge::FeeTier { min_volume: 1_001i128, max_volume: 10_000i128, fee_bps: 25u32 },
+            onboarding_bridge::FeeTier { min_volume: 10_001i128, max_volume: 1_000_000i128, fee_bps: 50u32 },
+        ],
+    );
+    bridge.set_fee_tiers(&tiers);
+
+    // Fund once to build volume so tiered lookup is exercised.
+    bridge.fund_c_address(&user, &Address::generate(&env), &token_id, &10_000i128, &None, &None);
+
+    env.budget().reset_default();
+    env.budget().reset_tracker();
+
+    bridge.fund_c_address(&user, &Address::generate(&env), &token_id, &10_000i128, &None, &None);
+
+    let cpu = env.budget().cpu_instruction_cost();
+    let mem = env.budget().memory_bytes_cost();
+
+    BenchResult { function_name: "fund_c_address/tiered_fee", variant: "default", cpu_insns: cpu, mem_bytes: mem }
+}
+
 fn main() {
     let results = vec![
         bench_initialize(),
@@ -323,6 +469,12 @@ fn main() {
         bench_query_fee_bps(),
         bench_query_balance(),
         bench_query_total_bridged(),
+        // Second-sprint features
+        bench_fund_c_address_timelocked(),
+        bench_claim_timelocked(),
+        bench_commit_fund(),
+        bench_reveal_fund(),
+        bench_tiered_fee_lookup(),
     ];
 
     println!("{{");
@@ -358,6 +510,12 @@ mod bench_tests {
             bench_query_fee_bps(),
             bench_query_balance(),
             bench_query_total_bridged(),
+            // Second-sprint features
+            bench_fund_c_address_timelocked(),
+            bench_claim_timelocked(),
+            bench_commit_fund(),
+            bench_reveal_fund(),
+            bench_tiered_fee_lookup(),
         ];
 
         for r in &results {

--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -18,7 +18,7 @@ use crate::OnboardingBridge;
 use soroban_sdk::{
     contract, contractimpl, contracttype,
     testutils::Address as _,
-    Address, Env, Vec,
+    Address, Bytes, BytesN, Env, Vec,
 };
 
 // ── Inline minimal token (mirrors the one in tests.rs) ────────────────────────
@@ -259,4 +259,337 @@ fn bench_admin_setters() {
     measure(&env, "set_allowlist_mode", &|| { bridge.set_allowlist_mode(&true, &None); });
     measure(&env, "pause",              &|| { bridge.pause(&None); });
     measure(&env, "unpause",            &|| { bridge.unpause(&None); });
+    measure(&env, "set_max_withdraw_per_tx", &|| { bridge.set_max_withdraw_per_tx(&500i128, &None); });
+    measure(&env, "set_source_daily_limit", &|| { bridge.set_source_daily_limit(&new_addr, &token_id, &10_000i128, &None); });
+    measure(&env, "set_asset_fee_cap",  &|| { bridge.set_asset_fee_cap(&token_id, &50u32, &None); });
+}
+
+// ── fund_c_address_timelocked / claim_timelocked ──────────────────────────────
+
+#[test]
+fn bench_fund_c_address_timelocked() {
+    let (env, bridge_id, token_id, _admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+    let amount = 10_000i128;
+    mint(&env, &token_id, &user, amount * 2);
+    let release_time = env.ledger().timestamp() + 365 * 86_400u64; // 1 year from now
+
+    measure(&env, "fund_c_address_timelocked", || {
+        bridge.fund_c_address_timelocked(
+            &user, &target, &token_id, &amount, &release_time, &0u64, &None, &None,
+        );
+    });
+}
+
+#[test]
+fn bench_claim_timelocked() {
+    let (env, bridge_id, token_id, _admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+    let amount = 10_000i128;
+    mint(&env, &token_id, &user, amount * 2);
+    let release_time = env.ledger().timestamp() + 86_400u64;
+    let id = bridge.fund_c_address_timelocked(
+        &user, &target, &token_id, &amount, &release_time, &0u64, &None, &None,
+    );
+
+    // Advance past release_time so the claim succeeds.
+    env.ledger().set_timestamp(release_time + 1);
+
+    measure(&env, "claim_timelocked", || {
+        bridge.claim_timelocked(&id);
+    });
+}
+
+// ═══ fund_c_address_crosschain ═════════════════════════════════════════════
+
+#[test]
+fn bench_fund_c_address_crosschain() {
+    let (env, bridge_id, token_id, admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+
+    // Register a single relayer and set threshold to 1.
+    let relayer_secret: [u8; 32] = [1u8; 32];
+    let relayer_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    bridge.add_relayer(&relayer_pubkey);
+    bridge.set_relayer_threshold(&1u32);
+
+    // Fund the bridge so it can transfer to target.
+    mint(&env, &token_id, &bridge_id, 10_000i128);
+
+    let target = Address::generate(&env);
+    let chain_id = 1u32;
+    let tx_hash = BytesN::from_array(&env, &[2u8; 32]);
+
+    // Build the canonical payload matching the contract's fund_c_address_crosschain.
+    // payload = sha256(
+    //   chain_id_be4 || tx_hash || sha256(target_strkey) || sha256(asset_strkey)
+    //   || amount_be16 || sha256(chain_id_be4 || tx_hash)
+    // )
+    let mut nonce_pre = Bytes::new(&env);
+    nonce_pre.extend_from_array(&chain_id.to_be_bytes());
+    let tx_hash_bytes: Bytes = tx_hash.clone().into();
+    nonce_pre.append(&tx_hash_bytes);
+    let nonce_hash: BytesN<32> = env.crypto().sha256(&nonce_pre).into();
+
+    let mut addr_buf = [0u8; 64];
+    let tstr = target.to_string();
+    let tlen = tstr.len();
+    tstr.copy_into_slice(&mut addr_buf[..tlen]);
+    let target_hash: BytesN<32> =
+        env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..tlen])).into();
+
+    let astr = token_id.to_string();
+    let alen = astr.len();
+    astr.copy_into_slice(&mut addr_buf[..alen]);
+    let asset_hash: BytesN<32> =
+        env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..alen])).into();
+
+    let mut payload = Bytes::new(&env);
+    payload.extend_from_array(&chain_id.to_be_bytes());
+    payload.append(&tx_hash_bytes);
+    payload.append(&Bytes::from(target_hash));
+    payload.append(&Bytes::from(asset_hash));
+    payload.extend_from_array(&10_000i128.to_be_bytes());
+    payload.append(&Bytes::from(nonce_hash));
+    let payload_hash: BytesN<32> = env.crypto().sha256(&payload).into();
+
+    // Create a relayer signature using the env's Ed25519.
+    let sig = env.crypto().ed25519_sign(&relayer_secret, &payload_hash);
+
+    let sigs = Vec::from_array(
+        &env,
+        [crate::RelayerSig {
+            pubkey: relayer_pubkey,
+            signature: sig,
+        }],
+    );
+
+    measure(&env, "fund_c_address_crosschain", || {
+        bridge.fund_c_address_crosschain(&chain_id, &tx_hash, &target, &token_id, &10_000i128, &sigs);
+    });
+
+    let _ = admin;
+}
+
+// ── commit_fund / reveal_fund ─────────────────────────────────────────────────
+
+#[test]
+fn bench_commit_fund() {
+    let (env, bridge_id, token_id, _admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    use soroban_sdk::Bytes;
+    let mut preimage = Bytes::new(&env);
+    preimage.extend_from_array(&10_000i128.to_be_bytes());
+    preimage.extend_from_array(&1u64.to_be_bytes());
+    let amount_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    measure(&env, "commit_fund", || {
+        bridge.commit_fund(&user, &target, &token_id, &amount_hash, &deadline);
+    });
+}
+
+#[test]
+fn bench_reveal_fund() {
+    let (env, bridge_id, token_id, _admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+    let amount = 10_000i128;
+    let nonce = 1u64;
+
+    mint(&env, &token_id, &user, amount * 2);
+
+    use soroban_sdk::Bytes;
+    let mut preimage = Bytes::new(&env);
+    preimage.extend_from_array(&amount.to_be_bytes());
+    preimage.extend_from_array(&nonce.to_be_bytes());
+    let amount_hash: BytesN<32> = env.crypto().sha256(&preimage).into();
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    let id = bridge.commit_fund(&user, &target, &token_id, &amount_hash, &deadline);
+
+    // Advance past the minimum delay.
+    env.ledger().set_sequence_number(env.ledger().sequence() + crate::COMMIT_REVEAL_MIN_DELAY_LEDGERS + 1);
+
+    measure(&env, "reveal_fund", || {
+        bridge.reveal_fund(&id, &user, &target, &token_id, &amount, &nonce);
+    });
+}
+
+// ── fund_c_address_with_swap ──────────────────────────────────────────────────
+
+#[test]
+fn bench_fund_c_address_with_swap() {
+    let (env, bridge_id, _token_id, admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+    let user = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    // Deploy two tokens: source and target.
+    let src_token_id = env.register(BenchToken, ());
+    let dst_token_id = env.register(BenchToken, ());
+    BenchTokenClient::new(&env, &src_token_id).initialize(&admin);
+    BenchTokenClient::new(&env, &dst_token_id).initialize(&admin);
+    mint(&env, &src_token_id, &user, 10_000i128);
+    bridge.add_asset(&dst_token_id, &None);
+
+    // Deploy a minimal swap pool.
+    let pool_id = env.register(SwapPool, ());
+    crate::benchmarks::SwapPoolClient::new(&env, &pool_id)
+        .initialize(&src_token_id, &dst_token_id, &1i128);
+
+    // Fund the swap pool with destination tokens.
+    mint(&env, &dst_token_id, &pool_id, 10_000i128);
+
+    bridge.add_swap_pool(&pool_id, &None);
+
+    let swap_route = Vec::from_array(&env, [pool_id]);
+
+    measure(&env, "fund_c_address_with_swap", || {
+        bridge.fund_c_address_with_swap(
+            &user, &target, &src_token_id, &dst_token_id, &10_000i128, &1i128, &swap_route, &None, &None,
+        );
+    });
+}
+
+// ── execute_meta_fund ─────────────────────────────────────────────────────────
+
+#[test]
+fn bench_execute_meta_fund() {
+    let (env, bridge_id, token_id, _admin, _fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+
+    let source = Address::generate(&env);
+    let target = Address::generate(&env);
+    let amount = 10_000i128;
+
+    // Fund the bridge so it can transfer to target.
+    mint(&env, &token_id, &bridge_id, amount);
+
+    // Generate a keypair and register it as the meta signer for source.
+    let secret: [u8; 32] = [7u8; 32];
+    let pubkey = BytesN::from_array(&env, &[7u8; 32]);
+    bridge.register_meta_signer(&source, &pubkey);
+
+    // Build the canonical meta-fund payload and sign it.
+    use soroban_sdk::Bytes;
+    let domain = Bytes::from_slice(&env, b"meta_fund");
+    let mut addr_buf = [0u8; 64];
+
+    let src_str = source.to_string();
+    let slen = src_str.len();
+    src_str.copy_into_slice(&mut addr_buf[..slen]);
+    let src_hash: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..slen])).into();
+
+    let tgt_str = target.to_string();
+    let tlen = tgt_str.len();
+    tgt_str.copy_into_slice(&mut addr_buf[..tlen]);
+    let tgt_hash: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..tlen])).into();
+
+    let ast_str = token_id.to_string();
+    let alen = ast_str.len();
+    ast_str.copy_into_slice(&mut addr_buf[..alen]);
+    let ast_hash: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..alen])).into();
+
+    let nonce = 1u64;
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    let mut payload = Bytes::new(&env);
+    payload.append(&domain);
+    payload.append(&src_hash.into());
+    payload.append(&tgt_hash.into());
+    payload.append(&ast_hash.into());
+    payload.extend_from_array(&amount.to_be_bytes());
+    payload.extend_from_array(&nonce.to_be_bytes());
+    payload.extend_from_array(&deadline.to_be_bytes());
+    let payload_hash: BytesN<32> = env.crypto().sha256(&payload).into();
+
+    let signature = env.crypto().ed25519_sign(&secret, &payload_hash);
+
+    let params = crate::MetaFundParams {
+        source: source.clone(),
+        target: target.clone(),
+        asset: token_id.clone(),
+        amount,
+        nonce,
+        deadline,
+    };
+
+    measure(&env, "execute_meta_fund", || {
+        bridge.execute_meta_fund(&params, &pubkey, &signature);
+    });
+}
+
+// ── Tiered fee lookups ────────────────────────────────────────────────────────
+
+#[test]
+fn bench_tiered_fee_lookup() {
+    let (env, bridge_id, token_id, admin, fee_collector) = initialized_setup();
+    let bridge = crate::OnboardingBridgeClient::new(&env, &bridge_id);
+    let user = Address::generate(&env);
+
+    // Configure fee tiers.
+    let tiers = Vec::from_array(
+        &env,
+        [
+            crate::FeeTier { min_volume: 0, max_volume: 1_000i128, fee_bps: 10u32 },
+            crate::FeeTier { min_volume: 1_001i128, max_volume: 10_000i128, fee_bps: 25u32 },
+            crate::FeeTier { min_volume: 10_001i128, max_volume: 1_000_000i128, fee_bps: 50u32 },
+        ],
+    );
+    bridge.set_fee_tiers(&tiers);
+    mint(&env, &token_id, &user, 1_000_000i128 * 2);
+
+    // Fund once to build volume so the tiered lookup activates.
+    bridge.fund_c_address(&user, &Address::generate(&env), &token_id, &10_000i128, &None, &None);
+
+    measure(&env, "fund_c_address/tiered_fee", || {
+        bridge.fund_c_address(&user, &Address::generate(&env), &token_id, &10_000i128, &None, &None);
+    });
+
+    let _ = (admin, fee_collector);
+}
+
+// ═══ Minimal swap pool for bench_fund_c_address_with_swap ═════════════════════
+
+#[contracttype]
+pub enum SwapPoolKey {
+    InputToken,
+    OutputToken,
+    Rate,
+}
+
+#[contract]
+pub struct SwapPool;
+
+#[contractimpl]
+impl SwapPool {
+    pub fn initialize(e: Env, input_token: Address, output_token: Address, rate: i128) {
+        e.storage().instance().set(&SwapPoolKey::InputToken, &input_token);
+        e.storage().instance().set(&SwapPoolKey::OutputToken, &output_token);
+        e.storage().instance().set(&SwapPoolKey::Rate, &rate);
+    }
+
+    pub fn swap(e: Env, min_amount_out: i128, to: Address) -> i128 {
+        let rate: i128 = e.storage().instance().get(&SwapPoolKey::Rate).unwrap();
+        let input_token: Address = e.storage().instance().get(&SwapPoolKey::InputToken).unwrap();
+        let input_client = soroban_sdk::token::Client::new(&e, &input_token);
+        let amount_in = input_client.balance(&e.current_contract_address());
+        let amount_out = amount_in.checked_mul(rate).unwrap_or(0);
+        if amount_out < min_amount_out {
+            return amount_out;
+        }
+        let output_token: Address = e.storage().instance().get(&SwapPoolKey::OutputToken).unwrap();
+        let output_client = soroban_sdk::token::Client::new(&e, &output_token);
+        output_client.transfer(&e.current_contract_address(), &to, &amount_out);
+        amount_out
+    }
 }

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -4332,3 +4332,180 @@ fn test_referral_fund_applies_tiered_fee() {
     assert_eq!(check_balance(&env, &token_id, &target), 999i128);
     assert_eq!(check_balance(&env, &token_id, &bridge_id), 1i128);
 }
+
+/********** Daily limit unit tests **********/
+
+// check_daily_limit has never been exercised to confirm it actually rejects
+// an over-limit transfer via fund_c_address.
+#[test]
+fn test_daily_limit_blocks_excess_funding() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_source_daily_limit(&user, &token_id, &500i128, &None);
+
+    mint_tokens(&env, &token_id, &user, 2000i128);
+
+    let target = Address::generate(&env);
+    // 501 exceeds the configured daily limit of 500.
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &501i128, &None, &None),
+        Err(Ok(BridgeError::DailyLimitExceeded))
+    );
+
+    // Source balance is untouched because the transfer never executed.
+    assert_eq!(check_balance(&env, &token_id, &user), 2000i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 0i128);
+}
+
+// Verify that the daily limit counter resets on the next UTC day,
+// allowing transfers that would have been blocked the previous day.
+#[test]
+fn test_daily_limit_resets_next_day() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_source_daily_limit(&user, &token_id, &500i128, &None);
+
+    mint_tokens(&env, &token_id, &user, 2000i128);
+
+    // Day 1: consume the full limit.
+    let target1 = Address::generate(&env);
+    bridge.fund_c_address(&user, &target1, &token_id, &500i128, &None, &None);
+
+    // Still on day 1: a further transfer is rejected.
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &Address::generate(&env), &token_id, &1i128, &None, &None),
+        Err(Ok(BridgeError::DailyLimitExceeded))
+    );
+
+    // Advance to the next UTC day (86 400 seconds later).
+    env.ledger().set_timestamp(env.ledger().timestamp() + 86_400);
+
+    // After the day rolls over the limit should reset, allowing a fresh transfer.
+    let target2 = Address::generate(&env);
+    bridge.fund_c_address(&user, &target2, &token_id, &500i128, &None, &None);
+    assert_eq!(check_balance(&env, &token_id, &target2), 495i128);
+}
+
+/********** Asset fee cap unit tests **********/
+
+// When a per-asset fee cap is set lower than the global rate, the effective
+// fee must use the cap rather than the global rate.
+#[test]
+fn test_asset_fee_cap_overrides_global_rate() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    // Global fee is 100 bps (1%), but the asset cap is 50 bps (0.5%).
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_asset_fee_cap(&token_id, &50u32, &None);
+
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target = Address::generate(&env);
+    bridge.fund_c_address(&user, &target, &token_id, &1000i128, &None, &None);
+
+    // Effective fee: min(100, 50) = 50 bps -> fee = floor(1000 * 50 / 10000) = 5.
+    assert_eq!(check_balance(&env, &token_id, &target), 995i128);
+    assert_eq!(check_balance(&env, &token_id, &bridge_id), 5i128);
+    assert_eq!(bridge.query_accrued_fees(&token_id), 5i128);
+}
+
+#[test]
+fn test_query_asset_fee_cap_returns_configured_value() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    // Default: no cap set yet, should return MAX_FEE_BPS (1000).
+    assert_eq!(bridge.query_asset_fee_cap(&token_id), 1000u32);
+
+    // Set a specific cap.
+    bridge.set_asset_fee_cap(&token_id, &75u32, &None);
+    assert_eq!(bridge.query_asset_fee_cap(&token_id), 75u32);
+
+    // Zero also queries correctly.
+    bridge.set_asset_fee_cap(&token_id, &0u32, &None);
+    assert_eq!(bridge.query_asset_fee_cap(&token_id), 0u32);
+}
+
+/********** Withdraw max-per-tx unit tests **********/
+
+// The per-transaction withdrawal cap must reject a withdraw_fees call that
+// exceeds the configured limit.
+#[test]
+fn test_withdraw_fees_rejects_amount_over_max_per_tx() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+
+    // Accrue enough fees to exceed the cap.
+    mint_tokens(&env, &token_id, &user, 10_000i128);
+    bridge.fund_c_address(&user, &Address::generate(&env), &token_id, &10_000i128, &None, &None);
+    // Fee = 10_000 * 100 / 10_000 = 100 accrued.
+    assert_eq!(bridge.query_accrued_fees(&token_id), 100i128);
+
+    // Cap withdrawals at 50 per transaction.
+    bridge.set_max_withdraw_per_tx(&50i128, &None);
+
+    // Trying to withdraw 51 exceeds the per-tx cap.
+    assert_eq!(
+        bridge.try_withdraw_fees(&token_id, &51i128, &None),
+        Err(Ok(BridgeError::WithdrawExceedsLimit))
+    );
+
+    // Withdrawing within the cap succeeds.
+    bridge.withdraw_fees(&token_id, &50i128, &None);
+    assert_eq!(check_balance(&env, &token_id, &fee_collector), 50i128);
+    assert_eq!(bridge.query_accrued_fees(&token_id), 50i128);
+}
+
+#[test]
+fn test_set_max_withdraw_per_tx_updates_limit() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    // Default: no cap set.
+    assert_eq!(bridge.query_max_withdraw_per_tx(), 0i128);
+
+    // Set a cap.
+    bridge.set_max_withdraw_per_tx(&500i128, &None);
+    assert_eq!(bridge.query_max_withdraw_per_tx(), 500i128);
+
+    // Update the cap.
+    bridge.set_max_withdraw_per_tx(&1000i128, &None);
+    assert_eq!(bridge.query_max_withdraw_per_tx(), 1000i128);
+
+    // Zero disables the cap.
+    bridge.set_max_withdraw_per_tx(&0i128, &None);
+    assert_eq!(bridge.query_max_withdraw_per_tx(), 0i128);
+}


### PR DESCRIPTION
Closes #254
Closes #255
Closes #256
Closes #257

 Add benchmark functions for the listed second-sprint features, following the existing bench_* naming convention
 Add corresponding baseline entries to bench_baseline.txt once real values are captured (see the related bench_baseline.txt issue) Add test_withdraw_fees_rejects_amount_over_max_per_tx
 Add test_set_max_withdraw_per_tx_updates_limit
  Add test_asset_fee_cap_overrides_global_rate
 Add test_query_asset_fee_cap_returns_configured_value