### PR TITLE
createdcaddrese

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -439,6 +439,22 @@ describe('OnboardingBridgeSDK', () => {
       expect(result.hash).toBe('mock_tx_hash');
       expect(mockProvider.getAccount).toHaveBeenCalledWith(MOCK_ADDRESS);
     });
+
+    it('passes nonce argument when provided', async () => {
+      const result = await sdk.withdrawFees(
+        { asset: MOCK_ASSET, amount: '100', nonce: 42 },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'withdraw_fees',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
   });
 
   describe('setFee', () => {
@@ -514,6 +530,75 @@ describe('OnboardingBridgeSDK', () => {
       const result = await sdk.setAdmin(MOCK_ADDRESS, mockKeypair);
 
       expect(result.status).toBe('pending');
+    });
+  });
+
+  describe('upgrade', () => {
+    it('submits upgrade with wasm hash and optional nonce', async () => {
+      const result = await sdk.upgrade(
+        { newWasmHash: 'a'.repeat(64) },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'upgrade',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('passes nonce argument when provided', async () => {
+      const result = await sdk.upgrade(
+        { newWasmHash: 'a'.repeat(64), nonce: 99 },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'upgrade',
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+
+  describe('reclaimTokens', () => {
+    it('returns pending status on success', async () => {
+      const result = await sdk.reclaimTokens(
+        { asset: MOCK_ASSET, amount: '100', to: MOCK_ADDRESS },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(result.hash).toBe('mock_tx_hash');
+      expect(contract.call).toHaveBeenCalledWith(
+        'reclaim_tokens',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it('passes nonce argument when provided', async () => {
+      const result = await sdk.reclaimTokens(
+        { asset: MOCK_ASSET, amount: '100', to: MOCK_ADDRESS, nonce: 7 },
+        mockKeypair,
+      );
+
+      const contract = (Contract as jest.Mock).mock.results[0].value;
+      expect(result.status).toBe('pending');
+      expect(contract.call).toHaveBeenCalledWith(
+        'reclaim_tokens',
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+        expect.anything(),
+      );
     });
   });
 

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -25,8 +25,6 @@ import {
   TransactionResult,
   CrossChainFundOptions,
   RelayerManagementOptions,
-  CreateCOptions,
-  CreateCAddressResult,
   FundCAddressWithSwapOptions,
   PaginatedResult,
   PaginationOptions,
@@ -952,6 +950,7 @@ export class OnboardingBridgeSDK {
               this.contract.call(
                 'withdraw_fees',
                 ...this.toScVals([options.asset, options.amount]),
+                options.nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(options.nonce), { type: 'u64' }),
               ),
             )
             .setTimeout(30)
@@ -1035,6 +1034,7 @@ export class OnboardingBridgeSDK {
               this.contract.call(
                 'reclaim_tokens',
                 ...this.toScVals([options.asset, options.amount, options.to]),
+                options.nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(options.nonce), { type: 'u64' }),
               ),
             )
             .setTimeout(30)
@@ -1844,13 +1844,16 @@ export class OnboardingBridgeSDK {
 
           const wasmHashBytes = Buffer.from(options.newWasmHash, 'hex');
           const wasmHashScVal = xdr.ScVal.scvBytes(wasmHashBytes);
+          const nonceScVal = options.nonce === undefined
+            ? xdr.ScVal.scvVoid()
+            : nativeToScVal(BigInt(options.nonce), { type: 'u64' });
 
           const tx = new TransactionBuilder(adminAccount, {
             fee: BASE_FEE,
             networkPassphrase: this.networkPassphrase,
           })
             .addOperation(
-              this.contract.call('upgrade', wasmHashScVal),
+              this.contract.call('upgrade', wasmHashScVal, nonceScVal),
             )
             .setTimeout(30)
             .build();
@@ -2139,163 +2142,6 @@ export class OnboardingBridgeSDK {
     }
     const scVal = (result as any).results?.[0]?.retval;
     return scVal ? Number(scValToNative(scVal)) : 0;
-  }
-
-  /**
-   * Create a new Soroban smart-contract account (C-address).
-   *
-   * Calls the bridge contract's `create_contract` helper which deploys a new
-   * account contract and derives its C-address from the deployer's address and
-   * an optional salt.  If `options.initialFunds` is provided, a `fund_c_address`
-   * call is made immediately after creation so the new account has a starting
-   * balance.
-   *
-   * @param options - Deployer keypair, optional deterministic salt, and optional
-   *                  initial funding parameters.
-   *
-   * @returns A {@link CreateCAddressResult} with the new C-address and creation tx hash.
-   *
-   * @throws {Error} If contract creation or the subsequent fund call fails.
-   *
-   * @example
-   * ```ts
-   * const { cAddress, txHash } = await sdk.createCAddress({
-   *   deployerKeypair: keypair,
-   *   initialFunds: { asset: 'CD...usdc', amount: '10000000' },
-   * });
-   * console.log('New C-address:', cAddress);
-   * ```
-   */
-  async createCAddress(
-    options: CreateCOptions,
-  ): Promise<CreateCAddressResult> {
-    return withTransactionHooks(
-      this.hooks,
-      'createCAddress',
-      { salt: options.salt, hasInitialFunds: !!options.initialFunds },
-      async () => {
-        const deployerKeypair = options.deployerKeypair;
-        const deployerAccount = await withRpcHook(
-          this.hooks,
-          'getAccount',
-          { address: deployerKeypair.publicKey() },
-          () => this.provider.getAccount(deployerKeypair.publicKey()),
-        );
-
-        const saltBytes = options.salt
-          ? Buffer.from(options.salt, 'hex')
-          : Buffer.from(
-              Array.from({ length: 32 }, () =>
-                Math.floor(Math.random() * 256),
-              ),
-            );
-        const saltScVal = xdr.ScVal.scvBytes(saltBytes);
-
-        const deployerAddress = new Address(deployerKeypair.publicKey());
-
-        const txBuilder = new TransactionBuilder(deployerAccount, {
-          fee: BASE_FEE,
-          networkPassphrase: this.networkPassphrase,
-        });
-
-        txBuilder.addOperation(
-          this.contract.call(
-            'create_contract',
-            deployerAddress.toScVal(),
-            saltScVal,
-          ),
-        );
-
-        const deployTx = txBuilder.setTimeout(30).build();
-        const preparedDeployTx = await withRpcHook(
-          this.hooks,
-          'prepareTransaction',
-          { contractMethod: 'create_contract' },
-          () => this.provider.prepareTransaction(deployTx),
-        );
-        preparedDeployTx.sign(deployerKeypair);
-
-        const deployResponse = await withRpcHook(
-          this.hooks,
-          'sendTransaction',
-          { contractMethod: 'create_contract' },
-          () => this.provider.sendTransaction(preparedDeployTx),
-        );
-        if (deployResponse.status === 'ERROR') {
-          throw new Error(`Failed to create C-address: ${deployResponse.status}`);
-        }
-
-        let txResult = await withRpcHook(
-          this.hooks,
-          'getTransaction',
-          { hash: deployResponse.hash },
-          () => this.provider.getTransaction(deployResponse.hash),
-        );
-        while (txResult.status === 'NOT_FOUND') {
-          await new Promise((resolve) => setTimeout(resolve, 1000));
-          txResult = await withRpcHook(
-            this.hooks,
-            'getTransaction',
-            { hash: deployResponse.hash },
-            () => this.provider.getTransaction(deployResponse.hash),
-          );
-        }
-
-        if (txResult.status !== 'SUCCESS') {
-          throw new Error(`C-address creation failed: ${txResult.status}`);
-        }
-
-        const returnVal = (txResult as any).returnValue;
-        const cAddress: string = returnVal
-          ? scValToNative(returnVal).toString()
-          : '';
-
-        if (options.initialFunds && cAddress) {
-          const fundAccount = await withRpcHook(
-            this.hooks,
-            'getAccount',
-            { address: deployerKeypair.publicKey() },
-            () => this.provider.getAccount(deployerKeypair.publicKey()),
-          );
-          const fundTx = new TransactionBuilder(fundAccount, {
-            fee: BASE_FEE,
-            networkPassphrase: this.networkPassphrase,
-          })
-            .addOperation(
-              this.contract.call(
-                'fund_c_address',
-                ...this.toScVals([
-                  deployerKeypair.publicKey(),
-                  cAddress,
-                  options.initialFunds.asset,
-                  options.initialFunds.amount,
-                ]),
-              ),
-            )
-            .setTimeout(30)
-            .build();
-
-          const preparedFundTx = await withRpcHook(
-            this.hooks,
-            'prepareTransaction',
-            { contractMethod: 'fund_c_address' },
-            () => this.provider.prepareTransaction(fundTx),
-          );
-          preparedFundTx.sign(deployerKeypair);
-          await withRpcHook(
-            this.hooks,
-            'sendTransaction',
-            { contractMethod: 'fund_c_address' },
-            () => this.provider.sendTransaction(preparedFundTx),
-          );
-        }
-
-        return {
-          cAddress,
-          txHash: deployResponse.hash,
-        };
-      },
-    );
   }
 
   /**

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -318,7 +318,8 @@ class ContractClient {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(
-        this.contract.call('withdraw_fees', ...this.toScVals([options.asset, options.amount])),
+        this.contract.call('withdraw_fees', ...this.toScVals([options.asset, options.amount]),
+          options.nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(options.nonce), { type: 'u64' })),
       );
 
     return this.submitMutation('withdrawFees', tx, sourceKeypair);
@@ -369,12 +370,15 @@ class ContractClient {
     const adminAccount = await this.provider.getAccount(adminKeypair.publicKey());
     const wasmHashBytes = Buffer.from(options.newWasmHash, 'hex');
     const wasmHashScVal = xdr.ScVal.scvBytes(wasmHashBytes);
+    const nonceScVal = options.nonce === undefined
+      ? xdr.ScVal.scvVoid()
+      : nativeToScVal(BigInt(options.nonce), { type: 'u64' });
 
     const tx = new TransactionBuilder(adminAccount, {
       fee: BASE_FEE,
       networkPassphrase: this.networkPassphrase,
     })
-      .addOperation(this.contract.call('upgrade', wasmHashScVal));
+      .addOperation(this.contract.call('upgrade', wasmHashScVal, nonceScVal));
 
     return this.submitMutation('upgrade', tx, adminKeypair);
   }

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -331,6 +331,13 @@ export interface WithdrawFeesOptions {
 
   /** Amount to withdraw, in the token's smallest unit. Must not exceed accrued fees. */
   amount: string;
+
+  /**
+   * Optional nonce for replay protection.
+   * When provided, the contract verifies that this call has not been made
+   * before with the same nonce.
+   */
+  nonce?: string | number | bigint;
 }
 
 /**
@@ -352,6 +359,13 @@ export interface UpgradeOptions {
    * Obtained from `stellar contract install --network <net> ...`.
    */
   newWasmHash: string;
+
+  /**
+   * Optional nonce for replay protection.
+   * When provided, the contract verifies that this call has not been made
+   * before with the same nonce.
+   */
+  nonce?: string | number | bigint;
 }
 
 /**
@@ -378,6 +392,13 @@ export interface ReclaimTokensOptions {
 
   /** Destination G-address that will receive the reclaimed tokens. */
   to: string;
+
+  /**
+   * Optional nonce for replay protection.
+   * When provided, the contract verifies that this call has not been made
+   * before with the same nonce.
+   */
+  nonce?: string | number | bigint;
 }
 
 // ---------------------------------------------------------------------------
@@ -719,58 +740,7 @@ export interface RelayerManagementOptions {
 // C-address creation
 // ---------------------------------------------------------------------------
 
-/**
- * Options for {@link OnboardingBridgeSDK.createCAddress}.
- *
- * Creates a new Soroban smart-contract account (C-address) and optionally
- * funds it immediately in the same flow.
- *
- * @example
- * ```ts
- * const { cAddress } = await sdk.createCAddress({
- *   deployerKeypair: keypair,
- *   initialFunds: { asset: 'CD...usdc', amount: '10000000' },
- * });
- * console.log('New C-address:', cAddress);
- * ```
- */
-export interface CreateCOptions {
-  /**
-   * Keypair used to sign the contract-creation transaction.
-   * This account pays the deployment fees.
-   */
-  deployerKeypair: any;
 
-  /**
-   * Optional 32-byte salt for deterministic address derivation, as a hex string.
-   * If omitted, a random salt is generated so the address is non-deterministic.
-   */
-  salt?: string;
-
-  /**
-   * Optional initial funds to transfer to the newly created C-address immediately
-   * after its creation, using the bridge contract's `fund_c_address` function.
-   */
-  initialFunds?: {
-    /** Token contract address of the asset to send. */
-    asset: string;
-    /** Amount to send, in the token's smallest unit. */
-    amount: string;
-  };
-}
-
-/**
- * Result returned by {@link OnboardingBridgeSDK.createCAddress}.
- */
-export interface CreateCAddressResult {
-  /**
-   * The newly created C-address (Soroban contract address starting with `C`).
-   */
-  cAddress: string;
-
-  /** Transaction hash of the contract-creation transaction. */
-  txHash: string;
-}
 
 // ---------------------------------------------------------------------------
 // Swap-and-bridge


### PR DESCRIPTION
Closes #262
Closes #263
Closes #264
Closes #265

Either implement the corresponding create_contract/factory entrypoint in the Rust contract, or remove createCAddress from the SDK until the contract supports it
 If keeping it, add a test that would have caught this signature mismatch (e.g. one that asserts against a real/simulated contract interface, not just a mock)
  Add an optional nonce field and pass it through in reclaimTokens
 Add a happy-path test for reclaimTokens (currently only has validation-rejection tests)