### PR TITLE
fix(sdk): type safety, validation, and dead-code cleanup

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -795,6 +795,58 @@ describe('OnboardingBridgeSDK', () => {
     });
   });
 
+  describe('addRelayer / removeRelayer pubkey validation', () => {
+    it('addRelayer rejects pubkey shorter than 32 bytes', async () => {
+      const result = await sdk.addRelayer({ pubkey: 'a'.repeat(32) }, mockKeypair);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/expected a 64-character lowercase hex string/);
+    });
+
+    it('addRelayer rejects pubkey longer than 32 bytes', async () => {
+      const result = await sdk.addRelayer({ pubkey: 'a'.repeat(66) }, mockKeypair);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/expected a 64-character lowercase hex string/);
+    });
+
+    it('addRelayer rejects non-hex characters in pubkey', async () => {
+      const result = await sdk.addRelayer({ pubkey: 'z'.repeat(64) }, mockKeypair);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/expected a 64-character lowercase hex string/);
+    });
+
+    it('addRelayer rejects uppercase hex pubkey', async () => {
+      const result = await sdk.addRelayer({ pubkey: 'A'.repeat(64) }, mockKeypair);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/expected a 64-character lowercase hex string/);
+    });
+
+    it('addRelayer rejects empty pubkey', async () => {
+      const result = await sdk.addRelayer({ pubkey: '' }, mockKeypair);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/expected a 64-character lowercase hex string/);
+    });
+
+    it('removeRelayer rejects malformed pubkey', async () => {
+      const result = await sdk.removeRelayer({ pubkey: 'deadbeef' }, mockKeypair);
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toMatch(/expected a 64-character lowercase hex string/);
+    });
+
+    it('addRelayer accepts valid 64-char lowercase hex pubkey', async () => {
+      const result = await sdk.addRelayer({ pubkey: 'a'.repeat(64) }, mockKeypair);
+
+      // Should not fail on validation; proceeds to RPC
+      expect(result.status).toBe('pending');
+      expect(mockProvider.getAccount).toHaveBeenCalled();
+    });
+  });
+
   describe('setRelayerThreshold', () => {
     it('returns pending status on success', async () => {
       const result = await sdk.setRelayerThreshold(2, mockKeypair);

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -32,6 +32,7 @@ import {
   PaginationOptions,
   CostEstimate,
   TimelockEntry,
+  FundCTimelockedOptions,
 } from './types';
 import {
   type ObservabilityHooks,
@@ -50,7 +51,7 @@ import {
  * size and submits one transaction per chunk.
  */
 export const BATCH_TX_LIMIT = 100;
-import { assertAccountAddress, assertContractAddress } from './validate';
+import { assertAccountAddress, assertContractAddress, assertRelayerPubkey } from './validate';
 import { withRpcRetry } from './retry';
 import {
   SorobanRpc,
@@ -1983,6 +1984,7 @@ export class OnboardingBridgeSDK {
       { pubkey: options.pubkey },
       async () => {
         try {
+          assertRelayerPubkey(options.pubkey, 'pubkey');
           const adminAccount = await withRpcHook(
             this.hooks,
             'getAccount',
@@ -2035,6 +2037,7 @@ export class OnboardingBridgeSDK {
       { pubkey: options.pubkey },
       async () => {
         try {
+          assertRelayerPubkey(options.pubkey, 'pubkey');
           const adminAccount = await withRpcHook(
             this.hooks,
             'getAccount',

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -669,7 +669,7 @@ export class OnboardingBridgeSDK {
    */
   async fundCAddressWithSwap(
     options: FundCAddressWithSwapOptions,
-    sourceKeypair: any,
+    sourceKeypair: Keypair,
   ): Promise<TransactionResult> {
     return withTransactionHooks(
       this.hooks,

--- a/sdk/src/observability.ts
+++ b/sdk/src/observability.ts
@@ -380,7 +380,7 @@ export interface OpenTelemetryHooksOptions {
  * Each mutating SDK method becomes a span with:
  * - `bridge.method` — the SDK method name.
  * - `bridge.tx.hash` — the transaction hash on success.
- * - `bridge.tx.status` — `'pending'`, `'success'`, or `'failed'`.
+ * - `bridge.tx.status` — `'pending'` or `'failed'`.
  * - `bridge.duration_ms` — wall-clock duration.
  *
  * RPC calls (when `traceRpcCalls` is true, the default) produce spans with:

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -10,6 +10,7 @@
 
 import type { RpcRetryOptions } from './retry';
 import type { ObservabilityHooks } from './observability';
+import type { Keypair } from '@stellar/stellar-sdk';
 
 // ---------------------------------------------------------------------------
 // SDK configuration
@@ -739,7 +740,7 @@ export interface CreateCOptions {
    * Keypair used to sign the contract-creation transaction.
    * This account pays the deployment fees.
    */
-  deployerKeypair: any;
+  deployerKeypair: Keypair;
 
   /**
    * Optional 32-byte salt for deterministic address derivation, as a hex string.

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -609,10 +609,9 @@ export interface TransactionResult {
   /**
    * Current status of the transaction:
    * - `'pending'`  — submitted and waiting for ledger inclusion.
-   * - `'success'`  — included and successful (rare, usually stays `'pending'`).
    * - `'failed'`   — rejected before submission or returned an error.
    */
-  status: 'success' | 'pending' | 'failed';
+  status: 'pending' | 'failed';
 
   /**
    * Human-readable error description when `status === 'failed'`.

--- a/sdk/src/validate.ts
+++ b/sdk/src/validate.ts
@@ -63,3 +63,31 @@ export function assertContractAddress(address: string, field: string): void {
     );
   }
 }
+
+/**
+ * Assert that `pubkeyHex` is a valid 32-byte Ed25519 public key as a lowercase
+ * hex string (64 hex characters).
+ *
+ * Throws an {@link Error} with a descriptive message including `field` if
+ * validation fails.
+ *
+ * @param pubkeyHex - The hex-encoded public key to validate.
+ * @param field     - A human-readable field name used in the error message
+ *                    (e.g. `'pubkey'`).
+ *
+ * @throws {Error} When `pubkeyHex` is not a 64-character lowercase hex string.
+ *
+ * @example
+ * ```ts
+ * assertRelayerPubkey('00'.repeat(32), 'pubkey');   // passes silently
+ * assertRelayerPubkey('short', 'pubkey');            // throws
+ * assertRelayerPubkey('GG...invalid...', 'pubkey');  // throws
+ * ```
+ */
+export function assertRelayerPubkey(pubkeyHex: string, field: string): void {
+  if (typeof pubkeyHex !== 'string' || !/^[0-9a-f]{64}$/.test(pubkeyHex)) {
+    throw new Error(
+      `Invalid relayer pubkey for "${field}": expected a 64-character lowercase hex string (32 bytes), got "${pubkeyHex}"`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #271
Closes #272
Closes #273
Closes #274 

## Summary

Four targeted SDK fixes addressing type-safety gaps, unreachable code, and input validation:

### 1. `fundCAddressWithSwap` sourceKeypair typed as `Keypair`
The `sourceKeypair` parameter was typed as `any`, a regression of the SDK keypair-typing fix already applied to every other mutating method (`fundCAddress`, `withdrawFees`, `setAdmin`, etc.).
Changed `sourceKeypair: any` to `sourceKeypair: Keypair`.

### 2. `CreateCOptions.deployerKeypair` typed as `Keypair`
Same type-safety gap in the type layer — the `deployerKeypair` field in `CreateCOptions` was `any`. Changed to `Keypair` with the necessary type import.

### 3. Remove unreachable `'success'` from `TransactionResult.status`
The status union documented `'success'` as a possible value, but no code path ever produces it — every mutating method only sets `'pending'` or `'failed'`. Removed from the union type, JSDoc, and observability docs.

### 4. Hex-format pubkey validation for `addRelayer`/`removeRelayer`
`Buffer.from(options.pubkey, 'hex')` silently truncates at invalid hex pairs without validating length. Added `assertRelayerPubkey()` helper in `validate.ts` (64-char lowercase hex), called before encoding. Added 7 tests covering invalid inputs. Also fixed a pre-existing missing `FundCTimelockedOptions` import.

## Files Changed
- `sdk/src/bridge.ts` — type fix, validation calls, missing import
- `sdk/src/types.ts` — type fix, status union cleanup
- `sdk/src/validate.ts` — new `assertRelayerPubkey` helper
- `sdk/src/observability.ts` — doc fix
- `sdk/src/__tests__/bridge.test.ts` — 7 new hex validation tests

## Verification
- `tsc --noEmit` passes cleanly
- All 185 tests pass (6 suites)
