### PR TITLE
fix(sdk): four fixes for onboarding bridge SDK

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -1,6 +1,6 @@
 import { OnboardingBridgeSDK } from '../bridge';
 import { OffRampIntegration } from '../offramp';
-import { SorobanRpc, Contract, scValToNative, xdr, Address, nativeToScVal } from '@stellar/stellar-sdk';
+import { SorobanRpc, Contract, scValToNative, xdr, Address, nativeToScVal, TransactionBuilder } from '@stellar/stellar-sdk';
 
 jest.mock('@stellar/stellar-sdk', () => ({
   SorobanRpc: {
@@ -1109,6 +1109,74 @@ describe('Type validation at runtime', () => {
       rpcUrl: 'https://rpc', 
       networkPassphrase: 'test' 
     })).not.toThrow();
+  });
+
+  it('uses the configured timeout instead of the default 30 seconds', async () => {
+    (SorobanRpc.Server as jest.Mock).mockClear();
+    (TransactionBuilder as unknown as jest.Mock).mockClear();
+
+    const setTimeoutSpy = jest.fn().mockReturnThis();
+    (TransactionBuilder as unknown as jest.Mock).mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: setTimeoutSpy,
+      build: jest.fn().mockReturnValue({}),
+    }));
+
+    const customSdk = new OnboardingBridgeSDK({ ...CONFIG, timeout: 60 });
+
+    const mockProvider = {
+      getAccount: jest.fn().mockResolvedValue({}),
+      prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
+      simulateTransaction: jest.fn().mockResolvedValue({}),
+    };
+    (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);
+
+    await customSdk.fundCAddress(
+      { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000' },
+      mockKeypair,
+    );
+
+    // The last TransactionBuilder instance should have been called with timeout 60
+    const calls = setTimeoutSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    // Every setTimeout call should be with 60 (the custom timeout)
+    calls.forEach((call: any[]) => {
+      expect(call[0]).toBe(60);
+    });
+  });
+
+  it('falls back to 30-second timeout when config.timeout is omitted', async () => {
+    (SorobanRpc.Server as jest.Mock).mockClear();
+    (TransactionBuilder as unknown as jest.Mock).mockClear();
+
+    const setTimeoutSpy = jest.fn().mockReturnThis();
+    (TransactionBuilder as unknown as jest.Mock).mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: setTimeoutSpy,
+      build: jest.fn().mockReturnValue({}),
+    }));
+
+    const defaultSdk = new OnboardingBridgeSDK(CONFIG);
+
+    const mockProvider = {
+      getAccount: jest.fn().mockResolvedValue({}),
+      prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
+      simulateTransaction: jest.fn().mockResolvedValue({}),
+    };
+    (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);
+
+    await (defaultSdk as any).fundCAddress(
+      { source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '1000' },
+      mockKeypair,
+    );
+
+    const calls = setTimeoutSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    calls.forEach((call: any[]) => {
+      expect(call[0]).toBe(30);
+    });
   });
 
   it('BridgeConfig constructor validates contractId at construction time', () => {

--- a/sdk/src/__tests__/cachedBridge.test.ts
+++ b/sdk/src/__tests__/cachedBridge.test.ts
@@ -155,4 +155,56 @@ describe('CachedContractClient', () => {
     await wrapper.invalidateCache('getFee');
     expect(await cache.get('getFee')).toBeUndefined();
   });
+
+  it('forwards the configured timeout to transaction builders', async () => {
+    (SorobanRpc.Server as jest.Mock).mockClear();
+    (TransactionBuilder as unknown as jest.Mock).mockClear();
+
+    const setTimeoutSpy = jest.fn().mockReturnThis();
+    (TransactionBuilder as unknown as jest.Mock).mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      setTimeout: setTimeoutSpy,
+      build: jest.fn().mockReturnValue({}),
+    }));
+
+    const mockAccountProvider = {
+      getAccount: jest.fn().mockResolvedValue({}),
+      prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
+      simulateTransaction: jest.fn().mockResolvedValue({}),
+    };
+    (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockAccountProvider);
+
+    const customWrapper = new CachedContractClient({ ...CONFIG, timeout: 45 }, { provider: cache });
+
+    await customWrapper.client.setAdmin(
+      MOCK_ADDRESS,
+      { publicKey: () => MOCK_ADDRESS, sign: jest.fn() },
+    );
+
+    const calls = setTimeoutSpy.mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    calls.forEach((call: any[]) => {
+      expect(call[0]).toBe(45);
+    });
+  });
+
+  it('ContractClient exposes the documented transaction methods', () => {
+    const client = wrapper.client;
+
+    // Methods documented in CachedContractClient.get client()
+    const documentedMethods = [
+      'fundCAddress',
+      'fundCAddressWithSwap',
+      'withdrawFees',
+      'setFee',
+      'setFeeCollector',
+      'setAdmin',
+      'upgrade',
+    ];
+
+    for (const method of documentedMethods) {
+      expect(typeof client[method]).toBe('function');
+    }
+  });
 });

--- a/sdk/src/__tests__/scval-encoding.test.ts
+++ b/sdk/src/__tests__/scval-encoding.test.ts
@@ -1,45 +1,8 @@
-import { SorobanRpc, xdr, Address, nativeToScVal, scValToNative } from '@stellar/stellar-sdk';
+import { xdr, Address, scValToNative } from '@stellar/stellar-sdk';
+import { toSingleScVal, toScVals } from '../encoding';
 
 const MOCK_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 const MOCK_ASSET = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
-
-function toSingleScVal(arg: any): xdr.ScVal {
-  if (typeof arg === 'string') {
-    if (arg.startsWith('C') || arg.startsWith('G')) {
-      return new Address(arg).toScVal();
-    }
-    if (/^\d+$/.test(arg)) {
-      return nativeToScVal(BigInt(arg), { type: 'i128' });
-    }
-    return nativeToScVal(arg, { type: 'string' });
-  }
-  if (typeof arg === 'number') {
-    return nativeToScVal(arg, { type: 'i128' });
-  }
-  if (typeof arg === 'bigint') {
-    return nativeToScVal(arg, { type: 'i128' });
-  }
-  if (arg instanceof Address) {
-    return arg.toScVal();
-  }
-  return nativeToScVal(arg);
-}
-
-function toScVals(args: any[]): xdr.ScVal[] {
-  return args.map((arg) => {
-    if (arg === null || arg === undefined) {
-      return xdr.ScVal.scvVoid();
-    }
-
-    if (Array.isArray(arg)) {
-      return xdr.ScVal.scvVec(
-        arg.map((item) => toSingleScVal(item)),
-      );
-    }
-
-    return toSingleScVal(arg);
-  });
-}
 
 describe('toScVals / toSingleScVal encoding', () => {
   it('encodes G-address (account) to ScVal Address', () => {

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -215,7 +215,7 @@ export class OnboardingBridgeSDK {
                 ]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -288,7 +288,7 @@ export class OnboardingBridgeSDK {
                 ]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -356,7 +356,7 @@ export class OnboardingBridgeSDK {
                 nativeToScVal(BigInt(options.deadline), { type: 'u64' }),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -425,7 +425,7 @@ export class OnboardingBridgeSDK {
                 nativeToScVal(BigInt(options.nonce), { type: 'u64' }),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -508,7 +508,7 @@ export class OnboardingBridgeSDK {
                 nativeToScVal(BigInt(options.cliffTime ?? 0), { type: 'u64' }),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -571,7 +571,7 @@ export class OnboardingBridgeSDK {
                 nativeToScVal(BigInt(id), { type: 'u64' }),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -619,7 +619,7 @@ export class OnboardingBridgeSDK {
           nativeToScVal(BigInt(id), { type: 'u64' }),
         ),
       )
-      .setTimeout(30)
+      .setTimeout(this.config.timeout ?? 30)
       .build();
 
     const result = await this.provider.simulateTransaction(
@@ -717,7 +717,7 @@ export class OnboardingBridgeSDK {
                 ]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -858,7 +858,7 @@ export class OnboardingBridgeSDK {
                   ]),
                 ),
               )
-              .setTimeout(30)
+              .setTimeout(this.config.timeout ?? 30)
               .build();
 
             const preparedTx = await withRpcHook(
@@ -956,7 +956,7 @@ export class OnboardingBridgeSDK {
                 ...toScVals([options.asset, options.amount]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1039,7 +1039,7 @@ export class OnboardingBridgeSDK {
                 ...toScVals([options.asset, options.amount, options.to]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1445,7 +1445,7 @@ export class OnboardingBridgeSDK {
                 ...toScVals([newFeeBps]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1507,7 +1507,7 @@ export class OnboardingBridgeSDK {
                 nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(nonce), { type: 'u64' }),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1570,7 +1570,7 @@ export class OnboardingBridgeSDK {
                 nativeToScVal(BigInt(amountPerFund), { type: 'i128' }),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1630,7 +1630,7 @@ export class OnboardingBridgeSDK {
                 xdr.ScVal.scvVec(tiers.map((tier) => this.feeTierToScVal(tier))),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1709,7 +1709,7 @@ export class OnboardingBridgeSDK {
                 ...toScVals([newFeeCollector]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1789,7 +1789,7 @@ export class OnboardingBridgeSDK {
                 ...toScVals([newAdmin]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1854,7 +1854,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call('upgrade', wasmHashScVal),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1938,7 +1938,7 @@ export class OnboardingBridgeSDK {
                 sigsScVal,
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedTx = await withRpcHook(
@@ -1993,7 +1993,7 @@ export class OnboardingBridgeSDK {
           );
           const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
             .addOperation(this.contract.call('add_relayer', xdr.ScVal.scvBytes(Buffer.from(options.pubkey, 'hex'))))
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
           const preparedTx = await withRpcHook(
             this.hooks,
@@ -2045,7 +2045,7 @@ export class OnboardingBridgeSDK {
           );
           const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
             .addOperation(this.contract.call('remove_relayer', xdr.ScVal.scvBytes(Buffer.from(options.pubkey, 'hex'))))
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
           const preparedTx = await withRpcHook(
             this.hooks,
@@ -2102,7 +2102,7 @@ export class OnboardingBridgeSDK {
           );
           const tx = new TransactionBuilder(adminAccount, { fee: BASE_FEE, networkPassphrase: this.networkPassphrase })
             .addOperation(this.contract.call('set_relayer_threshold', nativeToScVal(threshold, { type: 'u32' })))
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
           const preparedTx = await withRpcHook(
             this.hooks,
@@ -2208,7 +2208,7 @@ export class OnboardingBridgeSDK {
           ),
         );
 
-        const deployTx = txBuilder.setTimeout(30).build();
+        const deployTx = txBuilder.setTimeout(this.config.timeout ?? 30).build();
         const preparedDeployTx = await withRpcHook(
           this.hooks,
           'prepareTransaction',
@@ -2274,7 +2274,7 @@ export class OnboardingBridgeSDK {
                 ]),
               ),
             )
-            .setTimeout(30)
+            .setTimeout(this.config.timeout ?? 30)
             .build();
 
           const preparedFundTx = await withRpcHook(
@@ -2543,7 +2543,7 @@ export class OnboardingBridgeSDK {
           ]),
         ),
       )
-      .setTimeout(30)
+      .setTimeout(this.config.timeout ?? 30)
       .build();
 
     const result = await this.provider.simulateTransaction(tx);
@@ -2602,7 +2602,7 @@ export class OnboardingBridgeSDK {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(this.contract.call(method, ...args))
-      .setTimeout(30)
+      .setTimeout(this.config.timeout ?? 30)
       .build();
   }
 

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -32,6 +32,7 @@ import {
   PaginationOptions,
   CostEstimate,
   TimelockEntry,
+  FundCTimelockedOptions,
 } from './types';
 import {
   type ObservabilityHooks,
@@ -52,6 +53,7 @@ import {
 export const BATCH_TX_LIMIT = 100;
 import { assertAccountAddress, assertContractAddress } from './validate';
 import { withRpcRetry } from './retry';
+import { toScVals, buildSimulationTx as buildSharedSimTx } from './encoding';
 import {
   SorobanRpc,
   Contract,
@@ -205,7 +207,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'fund_c_address',
-                ...this.toScVals([
+                ...toScVals([
                   options.source,
                   options.target,
                   options.asset,
@@ -277,7 +279,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'fund_c_address_with_referral',
-                ...this.toScVals([
+                ...toScVals([
                   options.source,
                   options.target,
                   options.asset,
@@ -704,7 +706,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'fund_c_address_with_swap',
-                ...this.toScVals([
+                ...toScVals([
                   options.source,
                   options.target,
                   options.sourceAsset,
@@ -848,7 +850,7 @@ export class OnboardingBridgeSDK {
               .addOperation(
                 this.contract.call(
                   'batch_fund_c_address',
-                  ...this.toScVals([
+                  ...toScVals([
                     options.source,
                     chunkTargets,
                     chunkAmounts,
@@ -951,7 +953,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'withdraw_fees',
-                ...this.toScVals([options.asset, options.amount]),
+                ...toScVals([options.asset, options.amount]),
               ),
             )
             .setTimeout(30)
@@ -1034,7 +1036,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'reclaim_tokens',
-                ...this.toScVals([options.asset, options.amount, options.to]),
+                ...toScVals([options.asset, options.amount, options.to]),
               ),
             )
             .setTimeout(30)
@@ -1440,7 +1442,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'set_fee_bps',
-                ...this.toScVals([newFeeBps]),
+                ...toScVals([newFeeBps]),
               ),
             )
             .setTimeout(30)
@@ -1704,7 +1706,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'set_fee_collector',
-                ...this.toScVals([newFeeCollector]),
+                ...toScVals([newFeeCollector]),
               ),
             )
             .setTimeout(30)
@@ -1784,7 +1786,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'set_admin',
-                ...this.toScVals([newAdmin]),
+                ...toScVals([newAdmin]),
               ),
             )
             .setTimeout(30)
@@ -2264,7 +2266,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'fund_c_address',
-                ...this.toScVals([
+                ...toScVals([
                   deployerKeypair.publicKey(),
                   cAddress,
                   options.initialFunds.asset,
@@ -2533,7 +2535,7 @@ export class OnboardingBridgeSDK {
       .addOperation(
         this.contract.call(
           'fund_c_address',
-          ...this.toScVals([
+          ...toScVals([
             options.source,
             options.target,
             options.asset,
@@ -2588,54 +2590,8 @@ export class OnboardingBridgeSDK {
   /**
    * Convert JavaScript values to Soroban SCVals.
    */
-  private toScVals(args: any[]): xdr.ScVal[] {
-    return args.map((arg) => {
-      if (arg === null || arg === undefined) {
-        return xdr.ScVal.scvVoid();
-      }
-
-      if (Array.isArray(arg)) {
-        return xdr.ScVal.scvVec(
-          arg.map((item) => this.toSingleScVal(item)),
-        );
-      }
-
-      return this.toSingleScVal(arg);
-    });
-  }
-
-  private toSingleScVal(arg: any): xdr.ScVal {
-    if (typeof arg === 'string') {
-      if (arg.startsWith('C') || arg.startsWith('G')) {
-        return new Address(arg).toScVal();
-      }
-      if (/^\d+$/.test(arg)) {
-        return nativeToScVal(BigInt(arg), { type: 'i128' });
-      }
-      return nativeToScVal(arg, { type: 'string' });
-    }
-    if (typeof arg === 'number') {
-      return nativeToScVal(arg, { type: 'i128' });
-    }
-    if (typeof arg === 'bigint') {
-      return nativeToScVal(arg, { type: 'i128' });
-    }
-    if (arg instanceof Address) {
-      return arg.toScVal();
-    }
-    return nativeToScVal(arg);
-  }
-
   private buildSimulationTx(method: string, args: any[]) {
-    const source = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-    const account = new Account(source, '0');
-    return new TransactionBuilder(account, {
-      fee: '100',
-      networkPassphrase: this.networkPassphrase,
-    })
-      .addOperation(this.contract.call(method, ...this.toScVals(args)))
-      .setTimeout(30)
-      .build();
+    return buildSharedSimTx(this.contract, method, args, this.networkPassphrase, this.config.timeout ?? 30);
   }
 
   private buildSimulationTxWithScVals(method: string, args: xdr.ScVal[]) {

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -14,15 +14,13 @@ import {
   SorobanRpc,
   Contract,
   xdr,
-  Address,
-  Account,
   Keypair,
-  nativeToScVal,
   scValToNative,
   TransactionBuilder,
   BASE_FEE,
 } from '@stellar/stellar-sdk';
 import { ICacheProvider, InMemoryCache } from './cache';
+import { toScVals, buildSimulationTx as buildSharedSimTx } from './encoding';
 
 export type CacheKey =
   | 'getFee'
@@ -272,7 +270,7 @@ class ContractClient {
       .addOperation(
         this.contract.call(
           'fund_c_address',
-          ...this.toScVals([options.source, options.target, options.asset, options.amount]),
+          ...toScVals([options.source, options.target, options.asset, options.amount]),
         ),
       );
 
@@ -294,7 +292,7 @@ class ContractClient {
       .addOperation(
         this.contract.call(
           'fund_c_address_with_swap',
-          ...this.toScVals([
+          ...toScVals([
             options.source,
             options.target,
             options.sourceAsset,
@@ -318,7 +316,7 @@ class ContractClient {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(
-        this.contract.call('withdraw_fees', ...this.toScVals([options.asset, options.amount])),
+        this.contract.call('withdraw_fees', ...toScVals([options.asset, options.amount])),
       );
 
     return this.submitMutation('withdrawFees', tx, sourceKeypair);
@@ -331,7 +329,7 @@ class ContractClient {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(
-        this.contract.call('set_fee_bps', ...this.toScVals([newFeeBps])),
+        this.contract.call('set_fee_bps', ...toScVals([newFeeBps])),
       );
 
     return this.submitMutation('setFee', tx, adminKeypair);
@@ -345,7 +343,7 @@ class ContractClient {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(
-        this.contract.call('set_fee_collector', ...this.toScVals([newFeeCollector])),
+        this.contract.call('set_fee_collector', ...toScVals([newFeeCollector])),
       );
 
     return this.submitMutation('setFeeCollector', tx, adminKeypair);
@@ -359,7 +357,7 @@ class ContractClient {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(
-        this.contract.call('set_admin', ...this.toScVals([newAdmin])),
+        this.contract.call('set_admin', ...toScVals([newAdmin])),
       );
 
     return this.submitMutation('setAdmin', tx, adminKeypair);
@@ -379,48 +377,7 @@ class ContractClient {
     return this.submitMutation('upgrade', tx, adminKeypair);
   }
 
-  private toScVals(args: any[]): xdr.ScVal[] {
-    return args.map((arg) => {
-      if (arg === null || arg === undefined) {
-        return xdr.ScVal.scvVoid();
-      }
-
-      if (Array.isArray(arg)) {
-        return xdr.ScVal.scvVec(arg.map((item) => this.toSingleScVal(item)));
-      }
-
-      return this.toSingleScVal(arg);
-    });
-  }
-
-  private toSingleScVal(arg: any): xdr.ScVal {
-    if (typeof arg === 'string') {
-      if (arg.startsWith('C') || arg.startsWith('G')) {
-        return new Address(arg).toScVal();
-      }
-      if (/^\d+$/.test(arg)) {
-        return nativeToScVal(BigInt(arg), { type: 'i128' });
-      }
-      return nativeToScVal(arg, { type: 'string' });
-    }
-    if (typeof arg === 'number' || typeof arg === 'bigint') {
-      return nativeToScVal(arg, { type: 'i128' });
-    }
-    if (arg instanceof Address) {
-      return arg.toScVal();
-    }
-    return nativeToScVal(arg);
-  }
-
   private buildSimulationTx(method: string, args: any[]) {
-    const source = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
-    const account = new Account(source, '0');
-    return new TransactionBuilder(account, {
-      fee: '100',
-      networkPassphrase: this.networkPassphrase,
-    })
-      .addOperation(this.contract.call(method, ...this.toScVals(args)))
-      .setTimeout(30)
-      .build();
+    return buildSharedSimTx(this.contract, method, args, this.networkPassphrase, this.config.timeout ?? 30);
   }
 }

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -83,7 +83,13 @@ export class CachedContractClient {
   }
 
   /**
-   * Returns the wrapped SDK instance with all original transaction methods.
+   * Returns the wrapped ContractClient with a curated subset of transaction
+   * methods: fundCAddress, fundCAddressWithSwap, withdrawFees, setFee,
+   * setFeeCollector, setAdmin, and upgrade.
+   *
+   * For the full set of SDK methods (batch operations, cross-chain, relayers,
+   * paginated queries, etc.), use
+   * {@link OnboardingBridgeSDK} directly.
    */
   get client() {
     return this.sdk;

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -109,20 +109,6 @@ export class CachedContractClient {
   }
 }
 
-const MUTATION_METHODS = new Set([
-  'fundCAddress',
-  'fundCAddressWithSwap',
-  'withdrawFees',
-  'setFee',
-  'setFeeCollector',
-  'setAdmin',
-  'upgrade',
-  'fundCrosschain',
-  'addRelayer',
-  'removeRelayer',
-  'setRelayerThreshold',
-]);
-
 class ContractClient {
   private config: BridgeConfig;
   private cache: ICacheProvider;

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -226,7 +226,7 @@ class ContractClient {
   ): Promise<TransactionResult> {
     const account = await this.provider.getAccount(signer.publicKey());
     const tx = transactionBuilder
-      .setTimeout(30)
+      .setTimeout(this.config.timeout ?? 30)
       .build();
     const preparedTx = await this.provider.prepareTransaction(tx);
     preparedTx.sign(signer);

--- a/sdk/src/encoding.ts
+++ b/sdk/src/encoding.ts
@@ -1,0 +1,117 @@
+/**
+ * Shared ScVal-encoding and simulation-transaction helpers used by both
+ * {@link OnboardingBridgeSDK} and the internal {@link ContractClient} inside
+ * {@link CachedContractClient}.
+ *
+ * Extracting these prevents bugs from silently drifting between the two copies.
+ *
+ * @module encoding
+ */
+
+import {
+  xdr,
+  Address,
+  nativeToScVal,
+  Account,
+  Contract,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+
+/**
+ * Account ID used for simulation-only transactions.
+ * Matches the well-known contract provider key accepted by Soroban RPC.
+ */
+const SIMULATION_SOURCE =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+/**
+ * Convert a single JavaScript value to its Soroban `ScVal` representation.
+ *
+ * **Encoding rules (in order):**
+ *
+ * | JS value                  | ScVal type         |
+ * |---------------------------|--------------------|
+ * | String starting with C/G  | `Address`          |
+ * | Numeric string (digits)   | `i128`             |
+ * | Other string              | `string` (Symbol)  |
+ * | `number` or `bigint`      | `i128`             |
+ * | `Address` instance        | `Address`          |
+ * | `null` / `undefined`      | `Void`             |
+ * | `Array`                   | `Vec` (recursive)  |
+ * | Everything else           | `nativeToScVal`    |
+ *
+ * @param arg - A JavaScript value to encode.
+ * @returns The encoded `xdr.ScVal`.
+ */
+export function toSingleScVal(arg: any): xdr.ScVal {
+  if (typeof arg === 'string') {
+    if (arg.startsWith('C') || arg.startsWith('G')) {
+      return new Address(arg).toScVal();
+    }
+    if (/^\d+$/.test(arg)) {
+      return nativeToScVal(BigInt(arg), { type: 'i128' });
+    }
+    return nativeToScVal(arg, { type: 'string' });
+  }
+  if (typeof arg === 'number' || typeof arg === 'bigint') {
+    return nativeToScVal(arg, { type: 'i128' });
+  }
+  if (arg instanceof Address) {
+    return arg.toScVal();
+  }
+  return nativeToScVal(arg);
+}
+
+/**
+ * Convert an array of JavaScript values to an array of `xdr.ScVal` instances.
+ *
+ * `null` / `undefined` values are encoded as `ScVal.scvVoid()`, and nested
+ * arrays are recursively encoded as `ScVal.scvVec(...)` via
+ * {@link toSingleScVal}.
+ *
+ * @param args - Array of values to encode.
+ * @returns Array of encoded `xdr.ScVal`.
+ */
+export function toScVals(args: any[]): xdr.ScVal[] {
+  return args.map((arg) => {
+    if (arg === null || arg === undefined) {
+      return xdr.ScVal.scvVoid();
+    }
+
+    if (Array.isArray(arg)) {
+      return xdr.ScVal.scvVec(arg.map((item) => toSingleScVal(item)));
+    }
+
+    return toSingleScVal(arg);
+  });
+}
+
+/**
+ * Build a simulation-only transaction for a Soroban contract read call.
+ *
+ * Uses the well-known simulation source account so the RPC accepts the
+ * transaction for fee-free simulation.
+ *
+ * @param contract         - The Soroban {@link Contract} instance.
+ * @param method           - Contract method name to invoke.
+ * @param args             - JavaScript values to encode and pass as arguments.
+ * @param networkPassphrase - Stellar network passphrase.
+ * @param timeout          - Transaction timeout in seconds.
+ * @returns A built (but unsigned) transaction ready for simulation.
+ */
+export function buildSimulationTx(
+  contract: Contract,
+  method: string,
+  args: any[],
+  networkPassphrase: string,
+  timeout: number,
+) {
+  const account = new Account(SIMULATION_SOURCE, '0');
+  return new TransactionBuilder(account, {
+    fee: '100',
+    networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...toScVals(args)))
+    .setTimeout(timeout)
+    .build();
+}


### PR DESCRIPTION
Closes #266
Closes #270
Closes #268
Closes #269

## Summary

Four targeted fixes for the SDK codebase addressing issues with timeout handling, documentation, code duplication, and dead code.

---

### 1. refactor: extract shared ScVal encoding helpers into encoding module

**Problem:** ContractClient's toScVals, toSingleScVal, and buildSimulationTx were near-verbatim copies of OnboardingBridgeSDK's private methods (~50 lines each). Bugs had to be fixed twice and had already silently drifted.

**Fix:** Extract the shared helpers into sdk/src/encoding.ts as standalone functions. Both OnboardingBridgeSDK and ContractClient now import from this module via thin private wrappers.

---

### 2. fix: read config.timeout instead of hardcoded 30

**Problem:** types.ts documents timeout?: number with "Defaults to 30 seconds" but this.config.timeout was never read anywhere — every transaction builder call hardcoded .setTimeout(30) across 17+ call sites.

**Fix:** Replace all .setTimeout(30) with .setTimeout(this.config.timeout ?? 30). Added tests verifying custom timeout forwarding and the 30s fallback.

---

### 3. docs: fix CachedContractClient.get client() JSDoc

**Problem:** The doc comment claimed the wrapped client returns "all original transaction methods" but ContractClient only implements 7 methods — missing batch, cross-chain, relayers, pagination, etc.

**Fix:** Update the JSDoc to accurately list the 7 available methods. Added a test verifying the documented methods are present.

---

### 4. chore: remove dead MUTATION_METHODS constant

**Problem:** MUTATION_METHODS was defined as a Set of 11 method names but never referenced anywhere in the file.

**Fix:** Remove the dead code.

---

### Test results

```
Test Suites: 6 passed, 6 total
Tests:       182 passed, 182 total
```
