### PR TITLE
Fix/sdk issues amount validation observability error event

### DIFF
--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -1168,3 +1168,56 @@ describe('Type validation at runtime', () => {
     expect(options.sigs).toBeDefined();
   });
 });
+
+describe('Observability hooks - onRpcCall coverage', () => {
+  let onRpcCall: jest.Mock;
+  let sdk: OnboardingBridgeSDK;
+  let mockProvider: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    onRpcCall = jest.fn();
+
+    mockProvider = {
+      getAccount: jest.fn().mockResolvedValue({}),
+      prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
+      sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
+      simulateTransaction: jest.fn().mockResolvedValue({ results: [{ retval: {} }] }),
+    };
+
+    (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);
+    (scValToNative as jest.Mock).mockReturnValue({ toString: () => '100' });
+
+    sdk = new OnboardingBridgeSDK({
+      ...CONFIG,
+      hooks: { onRpcCall },
+    });
+  });
+
+  const methodsToTest = [
+    { name: 'getFeeBalance', call: (s: OnboardingBridgeSDK) => s.getFeeBalance(MOCK_ASSET) },
+    { name: 'getAllBalances', call: (s: OnboardingBridgeSDK) => s.getAllBalances([MOCK_ASSET]) },
+    { name: 'isInitialized', call: (s: OnboardingBridgeSDK) => s.isInitialized() },
+    { name: 'queryRelayerThreshold', call: (s: OnboardingBridgeSDK) => s.queryRelayerThreshold() },
+    { name: 'queryIsRelayer', call: (s: OnboardingBridgeSDK) => s.queryIsRelayer('aa'.repeat(32)) },
+    { name: 'getWhitelistedAssets', call: (s: OnboardingBridgeSDK) => s.getWhitelistedAssets() },
+    { name: 'getFeeExemptAddresses', call: (s: OnboardingBridgeSDK) => s.getFeeExemptAddresses() },
+    { name: 'getBlocklistedAddresses', call: (s: OnboardingBridgeSDK) => s.getBlocklistedAddresses() },
+    { name: 'getAllowlistedAddresses', call: (s: OnboardingBridgeSDK) => s.getAllowlistedAddresses() },
+    { name: 'estimateCost', call: (s: OnboardingBridgeSDK) => s.estimateCost({ source: MOCK_ADDRESS, target: MOCK_ASSET, asset: MOCK_ASSET, amount: '100' }) },
+  ];
+
+  methodsToTest.forEach(({ name, call }) => {
+    it(`fires onRpcCall for ${name}`, async () => {
+      // Catch post-simulation errors (e.g. map failures on mock data);
+      // onRpcCall fires in a finally block regardless.
+      await call(sdk).catch(() => {});
+
+      expect(onRpcCall).toHaveBeenCalledWith(
+        'simulateTransaction',
+        expect.any(Object),
+        expect.any(Number),
+      );
+    });
+  });
+});

--- a/sdk/src/__tests__/events.test.ts
+++ b/sdk/src/__tests__/events.test.ts
@@ -2,7 +2,7 @@
  * Tests for the EventSubscriber polling event API (issue #57).
  */
 import { EventSubscriber } from '../events';
-import type { CAddressFundedEvent, BridgeEventPayload } from '../events';
+import type { CAddressFundedEvent, BridgeEventPayload, BridgeEventName } from '../events';
 
 const mockGetEvents = jest.fn();
 
@@ -157,6 +157,55 @@ describe('EventSubscriber', () => {
 
       await expect(subscriber.poll()).resolves.toBeUndefined();
       expect(healthy).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits error event when the underlying RPC call rejects', async () => {
+      // Use real timers so async/await works naturally with poll()
+      jest.useRealTimers();
+      try {
+        const rpcError = new Error('RPC endpoint down');
+        mockGetEvents.mockRejectedValueOnce(rpcError);
+
+        const errors: Error[] = [];
+        subscriber.on('error' as BridgeEventName, (err: Error) => errors.push(err));
+
+        // poll() dispatches errors and rethrows — catch the throw
+        await subscriber.poll().catch(() => {});
+
+        expect(errors).toHaveLength(1);
+        expect(errors[0]).toBe(rpcError);
+      } finally {
+        jest.useFakeTimers();
+      }
+    });
+
+    it('isolates a throwing error listener from other error listeners', async () => {
+      jest.useRealTimers();
+      try {
+        mockGetEvents.mockRejectedValueOnce(new Error('rpc down'));
+
+        const healthy = jest.fn();
+        subscriber.on('error' as BridgeEventName, () => {
+          throw new Error('handler bug');
+        });
+        subscriber.on('error' as BridgeEventName, healthy);
+
+        await subscriber.poll().catch(() => {});
+
+        expect(healthy).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useFakeTimers();
+      }
+    });
+
+    it('does not stop the polling loop when an error event fires', async () => {
+      mockGetEvents.mockRejectedValueOnce(new Error('rpc down'));
+      subscriber.on('error' as BridgeEventName, jest.fn());
+
+      jest.advanceTimersByTime(1_000);
+      // The existing test pattern: just verify the loop stays alive (call count)
+      jest.advanceTimersByTime(1_000);
+      expect(mockGetEvents).toHaveBeenCalledTimes(2);
     });
 
     it('dispatches unknown event names as generic events', async () => {

--- a/sdk/src/__tests__/offramp.test.ts
+++ b/sdk/src/__tests__/offramp.test.ts
@@ -367,6 +367,42 @@ describe('OffRampIntegration', () => {
       expect(comparison.banxa).toBeUndefined();
     });
 
+    it('throws for malformed amount (non-numeric)', () => {
+      const offramp = new OffRampIntegration({});
+
+      expect(() => offramp.compareProviders('abc', 'XLM', 'USD'))
+        .toThrow(/amount must be a well-formed positive numeric string/);
+    });
+
+    it('throws for empty amount string', () => {
+      const offramp = new OffRampIntegration({});
+
+      expect(() => offramp.compareProviders('', 'XLM', 'USD'))
+        .toThrow(/amount must be a well-formed positive numeric string/);
+    });
+
+    it('throws for negative amount', () => {
+      const offramp = new OffRampIntegration({});
+
+      expect(() => offramp.compareProviders('-100', 'XLM', 'USD'))
+        .toThrow(/amount must be a well-formed positive numeric string/);
+    });
+
+    it('throws for zero amount', () => {
+      const offramp = new OffRampIntegration({});
+
+      expect(() => offramp.compareProviders('0', 'XLM', 'USD'))
+        .toThrow(/amount must be a well-formed positive numeric string/);
+    });
+
+    it('does not throw for valid amount formats', () => {
+      const offramp = new OffRampIntegration({});
+
+      expect(() => offramp.compareProviders('100', 'XLM', 'USD')).not.toThrow();
+      expect(() => offramp.compareProviders('100.50', 'XLM', 'USD')).not.toThrow();
+      expect(() => offramp.compareProviders('0.01', 'XLM', 'USD')).not.toThrow();
+    });
+
     it('returns empty when no provider supports asset/fiat combo', () => {
       const offramp = new OffRampIntegration({});
       
@@ -488,12 +524,12 @@ describe('OffRampIntegration', () => {
     it('compareProviders handles edge cases', () => {
       const offramp = new OffRampIntegration({});
       
-      // Zero amount
-      let comparison = offramp.compareProviders('0', 'XLM', 'USD');
-      expect(comparison.moonpay?.feeAmount).toBe('0.00');
-      
+      // Zero amount now throws (validated as non-positive)
+      expect(() => offramp.compareProviders('0', 'XLM', 'USD'))
+        .toThrow(/amount must be a well-formed positive numeric string/);
+
       // Very large amount - floating point precision may vary
-      comparison = offramp.compareProviders('999999999', 'XLM', 'USD');
+      let comparison = offramp.compareProviders('999999999', 'XLM', 'USD');
       expect(parseFloat(comparison.moonpay?.feeAmount || '0')).toBeCloseTo(44999999.96, 1);
       
       // Decimal amount

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -32,6 +32,7 @@ import {
   PaginationOptions,
   CostEstimate,
   TimelockEntry,
+  FundCTimelockedOptions,
 } from './types';
 import {
   type ObservabilityHooks,
@@ -1309,10 +1310,14 @@ export class OnboardingBridgeSDK {
    */
   async getFeeBalance(asset: string): Promise<string> {
     assertContractAddress(asset, 'asset');
-    const result = await this.provider
-      .simulateTransaction(
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_fee_balance' },
+      () => this.provider.simulateTransaction(
         this.buildSimulationTx('query_fee_balance', [asset]),
-      );
+      ),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to get fee balance: ${result.error}`);
@@ -1343,10 +1348,14 @@ export class OnboardingBridgeSDK {
    */
   async getAllBalances(assets: string[]): Promise<Record<string, string>> {
     assets.forEach((a, i) => assertContractAddress(a, `assets[${i}]`));
-    const result = await this.provider
-      .simulateTransaction(
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_all_balances' },
+      () => this.provider.simulateTransaction(
         this.buildSimulationTx('query_all_balances', [assets]),
-      );
+      ),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to get all balances: ${result.error}`);
@@ -1381,10 +1390,14 @@ export class OnboardingBridgeSDK {
    * ```
    */
   async isInitialized(): Promise<boolean> {
-    const result = await this.provider
-      .simulateTransaction(
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_is_initialized' },
+      () => this.provider.simulateTransaction(
         this.buildSimulationTx('query_is_initialized', []),
-      );
+      ),
+    );
 
     if ('error' in result && result.error) {
       throw new Error(`Failed to check initialization: ${result.error}`);
@@ -2131,8 +2144,13 @@ export class OnboardingBridgeSDK {
    * @throws {Error} On RPC failure.
    */
   async queryRelayerThreshold(): Promise<number> {
-    const result = await this.provider.simulateTransaction(
-      this.buildSimulationTx('query_relayer_threshold', []),
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_relayer_threshold' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTx('query_relayer_threshold', []),
+      ),
     );
     if ('error' in result && result.error) {
       throw new Error(`Failed to query relayer threshold: ${result.error}`);
@@ -2308,8 +2326,13 @@ export class OnboardingBridgeSDK {
    * @throws {Error} On RPC failure.
    */
   async queryIsRelayer(pubkeyHex: string): Promise<boolean> {
-    const result = await this.provider.simulateTransaction(
-      this.buildSimulationTx('query_is_relayer', [Buffer.from(pubkeyHex, 'hex')]),
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_is_relayer' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTx('query_is_relayer', [Buffer.from(pubkeyHex, 'hex')]),
+      ),
     );
     if ('error' in result && result.error) {
       throw new Error(`Failed to query relayer: ${result.error}`);
@@ -2381,8 +2404,13 @@ export class OnboardingBridgeSDK {
     cursor?: string,
     limit = 20,
   ): Promise<PaginatedResult<string>> {
-    const result = await this.provider.simulateTransaction(
-      this.buildSimulationTx('query_whitelisted_assets', []),
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_whitelisted_assets' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTx('query_whitelisted_assets', []),
+      ),
     );
     if ('error' in result && result.error) {
       throw new Error(`Failed to query whitelisted assets: ${result.error}`);
@@ -2412,8 +2440,13 @@ export class OnboardingBridgeSDK {
     cursor?: string,
     limit = 20,
   ): Promise<PaginatedResult<string>> {
-    const result = await this.provider.simulateTransaction(
-      this.buildSimulationTx('query_fee_exempt_addresses', []),
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_fee_exempt_addresses' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTx('query_fee_exempt_addresses', []),
+      ),
     );
     if ('error' in result && result.error) {
       throw new Error(`Failed to query fee-exempt addresses: ${result.error}`);
@@ -2442,8 +2475,13 @@ export class OnboardingBridgeSDK {
     cursor?: string,
     limit = 20,
   ): Promise<PaginatedResult<string>> {
-    const result = await this.provider.simulateTransaction(
-      this.buildSimulationTx('query_blocklist', []),
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_blocklist' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTx('query_blocklist', []),
+      ),
     );
     if ('error' in result && result.error) {
       throw new Error(`Failed to query blocklist: ${result.error}`);
@@ -2473,8 +2511,13 @@ export class OnboardingBridgeSDK {
     cursor?: string,
     limit = 20,
   ): Promise<PaginatedResult<string>> {
-    const result = await this.provider.simulateTransaction(
-      this.buildSimulationTx('query_allowlist', []),
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'query_allowlist' },
+      () => this.provider.simulateTransaction(
+        this.buildSimulationTx('query_allowlist', []),
+      ),
     );
     if ('error' in result && result.error) {
       throw new Error(`Failed to query allowlist: ${result.error}`);
@@ -2544,7 +2587,12 @@ export class OnboardingBridgeSDK {
       .setTimeout(30)
       .build();
 
-    const result = await this.provider.simulateTransaction(tx);
+    const result = await withRpcHook(
+      this.hooks,
+      'simulateTransaction',
+      { contractMethod: 'estimate_cost' },
+      () => this.provider.simulateTransaction(tx),
+    );
     const executionTimeMs = Date.now() - start;
 
     if ('error' in result && result.error) {

--- a/sdk/src/events.ts
+++ b/sdk/src/events.ts
@@ -113,6 +113,12 @@ export interface BridgeEventMap {
   FeesWithdrawn: FeesWithdrawnEvent;
   AdminChanged: AdminChangedEvent;
   MetaFundExecuted: MetaFundExecutedEvent;
+  /**
+   * Emitted when the polling loop encounters an RPC error.
+   * Subscribe via `sub.on('error', (err) => { ... })` to detect
+   * persistently-down endpoints.
+   */
+  'error': Error;
   /** Wildcard — receives every event regardless of name */
   '*': BridgeEventPayload;
 }
@@ -248,7 +254,9 @@ export class EventSubscriber {
           this.listeners.delete(eventName);
         }
       }
-      // Stop polling when no listeners remain
+      // Stop polling when no listeners remain (preserve 'error' listeners for
+      // the polling loop — only stop when ALL listeners are gone, including
+      // error listeners).
       if (this.listenerCount() === 0) {
         this.stopPolling();
       }
@@ -288,9 +296,17 @@ export class EventSubscriber {
 
   /**
    * Manually trigger a single poll. Useful in tests or for on-demand refresh.
+   *
+   * If the underlying RPC call rejects, the error is dispatched to registered
+   * 'error' listeners before the exception propagates to the caller.
    */
   async poll(): Promise<void> {
-    await this.fetchAndDispatch();
+    try {
+      await this.fetchAndDispatch();
+    } catch (err) {
+      this.dispatchError(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -300,9 +316,10 @@ export class EventSubscriber {
   private startPolling(): void {
     if (this.intervalHandle !== null) return;
     this.intervalHandle = setInterval(() => {
-      this.fetchAndDispatch().catch(() => {
-        // Swallow polling errors to keep the loop alive. Applications should
-        // add error handling via a dedicated error event if needed.
+      this.fetchAndDispatch().catch((err) => {
+        // Emit to error listeners so consumers can detect persistently-down
+        // RPC endpoints and react (e.g. circuit break, alert, reconnect).
+        this.dispatchError(err instanceof Error ? err : new Error(String(err)));
       });
     }, this.pollingIntervalMs);
   }
@@ -456,6 +473,22 @@ export class EventSubscriber {
     if (wildcard) {
       for (const cb of wildcard) {
         try { cb(payload); } catch { /* isolate handler errors */ }
+      }
+    }
+  }
+
+  /**
+   * Dispatch an error to any registered 'error' listeners.
+   *
+   * This is called on poll failures so consumers can detect persistently-down
+   * RPC endpoints.  Handler errors are isolated so one bad listener doesn't
+   * break others.
+   */
+  private dispatchError(err: Error): void {
+    const errorListeners = this.listeners.get('error');
+    if (errorListeners) {
+      for (const cb of errorListeners) {
+        try { cb(err); } catch { /* isolate handler errors */ }
       }
     }
   }

--- a/sdk/src/offramp.ts
+++ b/sdk/src/offramp.ts
@@ -252,6 +252,10 @@ export class OffRampIntegration {
     asset: string,
     fiatCurrency: string = 'USD',
   ): Partial<Record<OffRampProvider, ProviderComparison>> {
+    // Validate amount is a well-formed positive numeric string
+    if (typeof amount !== 'string' || !/^\d+(\.\d+)?$/.test(amount) || parseFloat(amount) <= 0) {
+      throw new Error('amount must be a well-formed positive numeric string, got: ' + JSON.stringify(amount));
+    }
     const amountNum = parseFloat(amount);
     const result: Partial<Record<OffRampProvider, ProviderComparison>> = {};
 


### PR DESCRIPTION
Closes #279
Closes #280
Closes #281
Closes #282

 Add an 'error' event that EventSubscriber emits on poll failure, so consumers can subscribe via the existing on/off API
 Add a test asserting the error event fires when the underlying RPC call rejects