### PR TITLE
fix(sdk,indexer): dedup events, cancel retries, real min balance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ bench_results.txt
 
 # Lock files for sub-packages (keep root Cargo.lock, ignore sdk sub-lock)
 sdk/package-lock.json
+indexer/Cargo.lock

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,3 +1,9 @@
+# The root Cargo workspace builds only the Soroban contract, so the indexer is
+# its own workspace root. Without this, `cargo build`/`cargo test` in this
+# directory fails with "current package believes it's in a workspace when it's
+# not".
+[workspace]
+
 [package]
 name = "bridge-indexer"
 version = "0.1.0"

--- a/indexer/src/db.rs
+++ b/indexer/src/db.rs
@@ -114,9 +114,14 @@ impl Database {
         Ok(())
     }
 
-    pub async fn insert_event(&self, event: &IndexedEvent) -> Result<(), sqlx::Error> {
+    /// Insert an event, ignoring it if its id was already indexed.
+    ///
+    /// Returns `true` when a new row was written and `false` when the event was
+    /// a duplicate. Callers use this to avoid re-queuing webhook deliveries for
+    /// an event that has already been delivered.
+    pub async fn insert_event(&self, event: &IndexedEvent) -> Result<bool, sqlx::Error> {
         let data_str = serde_json::to_string(&event.data).unwrap_or_default();
-        sqlx::query(
+        let result = sqlx::query(
             "INSERT OR IGNORE INTO events (id, event_type, ledger_sequence, contract_id, tx_hash, timestamp, data)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         )
@@ -129,7 +134,7 @@ impl Database {
         .bind(&data_str)
         .execute(&self.pool)
         .await?;
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn list_events(
@@ -452,5 +457,128 @@ fn row_to_event(
         tx_hash,
         timestamp,
         data: serde_json::from_str(&data).unwrap_or(serde_json::Value::Null),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A throwaway on-disk SQLite database. In-memory SQLite is per-connection,
+    /// so it cannot be shared across the pool's connections.
+    struct TempDb {
+        path: std::path::PathBuf,
+    }
+
+    impl TempDb {
+        fn new() -> Self {
+            let mut path = std::env::temp_dir();
+            path.push(format!("bridge-indexer-{}.db", uuid::Uuid::new_v4()));
+            Self { path }
+        }
+
+        fn url(&self) -> String {
+            format!("sqlite:{}?mode=rwc", self.path.display())
+        }
+    }
+
+    impl Drop for TempDb {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+
+    fn sample_event(id: &str) -> IndexedEvent {
+        IndexedEvent {
+            id: id.to_string(),
+            event_type: "CAddressFunded".to_string(),
+            ledger_sequence: 4242,
+            contract_id: "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4".to_string(),
+            tx_hash: "9f1c0e6a".to_string(),
+            timestamp: "2026-07-29T10:00:00Z".to_string(),
+            data: serde_json::json!({ "amount": "1000" }),
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_event_ignores_a_repeated_id() {
+        let temp = TempDb::new();
+        let db = Database::new(&temp.url()).await;
+        db.migrate().await;
+
+        let event = sample_event("4242-9f1c0e6a-0");
+        db.insert_event(&event).await.unwrap();
+        db.insert_event(&event).await.unwrap();
+
+        let stored = db.list_events(10, 0).await.unwrap();
+        assert_eq!(
+            stored.len(),
+            1,
+            "re-inserting the same id must not duplicate"
+        );
+    }
+
+    #[tokio::test]
+    async fn insert_event_stores_distinct_ids_separately() {
+        let temp = TempDb::new();
+        let db = Database::new(&temp.url()).await;
+        db.migrate().await;
+
+        db.insert_event(&sample_event("4242-9f1c0e6a-0"))
+            .await
+            .unwrap();
+        db.insert_event(&sample_event("4242-9f1c0e6a-1"))
+            .await
+            .unwrap();
+
+        let stored = db.list_events(10, 0).await.unwrap();
+        assert_eq!(stored.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn insert_event_reports_whether_the_row_was_new() {
+        let temp = TempDb::new();
+        let db = Database::new(&temp.url()).await;
+        db.migrate().await;
+
+        let event = sample_event("4242-9f1c0e6a-0");
+        assert!(
+            db.insert_event(&event).await.unwrap(),
+            "first insert is new"
+        );
+        assert!(
+            !db.insert_event(&event).await.unwrap(),
+            "second insert must be reported as a duplicate"
+        );
+    }
+
+    /// Mirrors the poller's flow: webhooks are only queued for events that were
+    /// actually newly inserted, so re-polling never re-delivers.
+    #[tokio::test]
+    async fn a_duplicate_event_does_not_queue_another_webhook_delivery() {
+        let temp = TempDb::new();
+        let db = Database::new(&temp.url()).await;
+        db.migrate().await;
+
+        db.create_subscription(CreateSubscription {
+            url: "https://example.test/hook".to_string(),
+            event_type: None,
+            asset_filter: None,
+            source_filter: None,
+            target_filter: None,
+        })
+        .await
+        .unwrap();
+
+        let event = sample_event("4242-9f1c0e6a-0");
+        for _ in 0..3 {
+            if db.insert_event(&event).await.unwrap() {
+                db.queue_webhook_deliveries(&event).await.unwrap();
+            }
+        }
+
+        let stats = db.get_stats().await.unwrap();
+        assert_eq!(stats["total_events"], 1);
+        assert_eq!(stats["pending_deliveries"], 1);
     }
 }

--- a/indexer/src/poller.rs
+++ b/indexer/src/poller.rs
@@ -1,5 +1,6 @@
 use crate::events::{BridgeEventType, IndexedEvent};
 use crate::AppState;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 const POLL_INTERVAL_MS: u64 = 5000;
@@ -61,6 +62,11 @@ async fn poll_once(state: &AppState) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let mut max_ledger = start_ledger;
+    // Position of each event within its transaction. Combined with the ledger
+    // and tx hash this yields a stable primary key, so re-polling a range
+    // already seen (after a restart, or a crash before `set_last_ledger`)
+    // regenerates the same ids and `insert_event` deduplicates them.
+    let mut events_seen_per_tx: HashMap<&str, usize> = HashMap::new();
 
     for raw_event in &events {
         let ledger = raw_event
@@ -71,14 +77,27 @@ async fn poll_once(state: &AppState) -> Result<(), Box<dyn std::error::Error>> {
             max_ledger = ledger;
         }
 
-        if let Some(indexed) = parse_contract_event(raw_event, &state.contract_id) {
-            state.db.insert_event(&indexed).await?;
-            state.db.queue_webhook_deliveries(&indexed).await?;
-            tracing::info!(
-                "Indexed event: {} at ledger {}",
-                indexed.event_type,
-                indexed.ledger_sequence
-            );
+        let tx_hash = raw_event
+            .get("txHash")
+            .and_then(|t| t.as_str())
+            .unwrap_or("");
+        let counter = events_seen_per_tx.entry(tx_hash).or_insert(0);
+        let event_index = *counter;
+        *counter += 1;
+
+        if let Some(indexed) = parse_contract_event(raw_event, &state.contract_id, event_index) {
+            // Only fan out webhooks for events we have not indexed before;
+            // otherwise a re-poll would re-deliver every event in the range.
+            if state.db.insert_event(&indexed).await? {
+                state.db.queue_webhook_deliveries(&indexed).await?;
+                tracing::info!(
+                    "Indexed event: {} at ledger {}",
+                    indexed.event_type,
+                    indexed.ledger_sequence
+                );
+            } else {
+                tracing::debug!("Skipping already-indexed event {}", indexed.id);
+            }
         }
     }
 
@@ -88,9 +107,15 @@ async fn poll_once(state: &AppState) -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+/// Build an [`IndexedEvent`] from a raw `getEvents` entry.
+///
+/// `event_index` is the position of this event within its transaction; it is
+/// part of the event id, so the same on-chain event always parses to the same
+/// id no matter how many times it is polled.
 fn parse_contract_event(
     raw: &serde_json::Value,
     contract_id: &str,
+    event_index: usize,
 ) -> Option<IndexedEvent> {
     let topics = raw.get("topic")?.as_array()?;
     if topics.is_empty() {
@@ -129,11 +154,18 @@ fn parse_contract_event(
         }
     }
 
+    // Deterministic primary key: the same (ledger, tx, position) triple always
+    // produces the same id, which is what makes `INSERT OR IGNORE` in
+    // `Database::insert_event` an effective dedup on re-processing.
     let id = format!(
         "{}-{}-{}",
         ledger,
-        tx_hash.get(..8).unwrap_or("unknown"),
-        uuid::Uuid::new_v4().to_string().get(..8).unwrap_or("rand")
+        if tx_hash.is_empty() {
+            "unknown"
+        } else {
+            tx_hash.as_str()
+        },
+        event_index
     );
 
     Some(IndexedEvent {
@@ -145,4 +177,57 @@ fn parse_contract_event(
         timestamp,
         data: serde_json::Value::Object(data),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4";
+
+    fn raw_event() -> serde_json::Value {
+        serde_json::json!({
+            "ledger": 4242,
+            "txHash": "9f1c0e6a4b2d8e7f00112233445566778899aabbccddeeff0011223344556677",
+            "createdAt": "2026-07-29T10:00:00Z",
+            "topic": ["CAddressFunded", "GSOURCE", "CTARGET"],
+            "value": { "amount": "1000" },
+        })
+    }
+
+    #[test]
+    fn parsing_the_same_event_twice_yields_the_same_id() {
+        let raw = raw_event();
+
+        let first = parse_contract_event(&raw, CONTRACT_ID, 0).expect("event should parse");
+        let second = parse_contract_event(&raw, CONTRACT_ID, 0).expect("event should parse");
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(
+            first.id,
+            "4242-9f1c0e6a4b2d8e7f00112233445566778899aabbccddeeff0011223344556677-0"
+        );
+    }
+
+    #[test]
+    fn events_at_different_positions_in_a_tx_get_distinct_ids() {
+        let raw = raw_event();
+
+        let first = parse_contract_event(&raw, CONTRACT_ID, 0).expect("event should parse");
+        let second = parse_contract_event(&raw, CONTRACT_ID, 1).expect("event should parse");
+
+        assert_ne!(first.id, second.id);
+    }
+
+    #[test]
+    fn a_missing_tx_hash_still_produces_a_deterministic_id() {
+        let mut raw = raw_event();
+        raw.as_object_mut().unwrap().remove("txHash");
+
+        let first = parse_contract_event(&raw, CONTRACT_ID, 0).expect("event should parse");
+        let second = parse_contract_event(&raw, CONTRACT_ID, 0).expect("event should parse");
+
+        assert_eq!(first.id, second.id);
+        assert_eq!(first.id, "4242-unknown-0");
+    }
 }

--- a/sdk/API_REFERENCE.md
+++ b/sdk/API_REFERENCE.md
@@ -8,7 +8,14 @@ This document provides a comprehensive API reference for all exported classes, i
 1. [Classes](#classes)
    - [OnboardingBridgeSDK](#onboardingbridgesdk)
    - [OffRampIntegration](#offrampintegration)
-2. [Interfaces](#interfaces)
+   - [CachedContractClient](#cachedcontractclient)
+   - [InMemoryCache](#inmemorycache)
+   - [EventSubscriber](#eventsubscriber)
+2. [Functions](#functions)
+   - [Retry Utilities](#retry-utilities)
+   - [Observability Helpers](#observability-helpers)
+3. [Constants](#constants)
+4. [Interfaces](#interfaces)
    - [BridgeConfig](#bridgeconfig)
    - [FundCOptions](#fundcoptions)
    - [BatchFundCOptions](#batchfundcoptions)
@@ -21,9 +28,21 @@ This document provides a comprehensive API reference for all exported classes, i
    - [CreateCAddressResult](#createcaddressresult)
    - [PaginatedResult](#paginatedresult)
    - [PaginationOptions](#paginationoptions)
-3. [Error Handling & Validation](#error-handling--validation)
+   - [CostEstimate](#costestimate)
+   - [CacheOptions](#cacheoptions)
+   - [ICacheProvider](#icacheprovider)
+   - [RetryOptions](#retryoptions)
+   - [RpcRetryOptions](#rpcretryoptions)
+   - [RetryAttempt](#retryattempt)
+   - [ObservabilityHooks](#observabilityhooks)
+   - [OpenTelemetryHooksOptions](#opentelemetryhooksoptions)
+   - [EventSubscriberConfig](#eventsubscriberconfig)
+   - [Bridge Event Payloads](#bridge-event-payloads)
+5. [Type Aliases](#type-aliases)
+6. [Error Handling & Validation](#error-handling--validation)
    - [Validation Methods](#validation-methods)
    - [RPC Retry & Transient Errors](#rpc-retry--transient-errors)
+   - [Cancelling Retries](#cancelling-retries)
    - [Common Error Scenarios & Solutions](#common-error-scenarios--solutions)
 
 ---
@@ -78,14 +97,24 @@ Funds a C-address by first swapping a source asset to a target asset via DEX poo
 ```ts
 async batchFundCAddresses(
   options: BatchFundCOptions,
-  sourceKeypair: Keypair
-): Promise<TransactionResult>
+  sourceKeypair: Keypair,
+  onProgress?: BatchProgressCallback
+): Promise<TransactionResult[]>
 ```
-Funds multiple C-addresses in a single Stellar transaction.
+Funds multiple C-addresses. Lists longer than [`BATCH_TX_LIMIT`](#constants) are split into chunks of that size and submitted as one transaction per chunk, so the result is an array with one entry per chunk.
 - **Parameters**:
   - `options`: [`BatchFundCOptions`](#batchfundcoptions)
   - `sourceKeypair`: `Keypair`
-- **Returns**: `Promise<TransactionResult>`
+  - `onProgress`: [`BatchProgressCallback`](#type-aliases) (optional) — invoked after each chunk.
+- **Returns**: `Promise<TransactionResult[]>`
+- **Example**:
+```ts
+const results = await sdk.batchFundCAddresses(
+  { source: keypair.publicKey(), targets, amounts, asset: 'CD...' },
+  keypair,
+  (completed, total, txHash) => console.log(`${completed}/${total}`, txHash),
+);
+```
 
 ##### `withdrawFees`
 ```ts
@@ -355,6 +384,26 @@ Queries the allowlist with client-side pagination.
   - `limit`: `number` (optional)
 - **Returns**: `Promise<PaginatedResult<string>>`
 
+##### `estimateCost`
+```ts
+async estimateCost(options: FundCOptions): Promise<CostEstimate>
+```
+Simulates a `fundCAddress` call without submitting it, returning the inclusion fee, the Soroban resource fee, and the minimum balance the source account must hold. The minimum balance is derived from the account's on-chain subentry count as `(2 + numSubentries) * baseReserve`; see [`BASE_RESERVE_STROOPS`](#constants).
+- **Parameters**:
+  - `options`: [`FundCOptions`](#fundcoptions)
+- **Returns**: `Promise<CostEstimate>` — see [`CostEstimate`](#costestimate)
+- **Example**:
+```ts
+const estimate = await sdk.estimateCost({
+  source: keypair.publicKey(),
+  target: 'CC...',
+  asset: 'CD...',
+  amount: '10000000',
+});
+console.log('Total fee:  ', estimate.fee, 'stroops');
+console.log('Min balance:', estimate.minBalance, 'stroops');
+```
+
 ---
 
 ### `OffRampIntegration`
@@ -435,6 +484,339 @@ Decodes a CEX deposit memo to retrieve the destination C-address, returning `nul
 
 ---
 
+### `CachedContractClient`
+
+Wraps the SDK and caches the four cheap-but-frequently-read view methods, delegating every transaction method to the underlying client. Cached values are invalidated automatically when a state-changing transaction succeeds.
+
+Default TTLs are 5 minutes for `getFee` and `isInitialized`, and 24 hours for `getFeeCollector` and `getAdmin`.
+
+#### Constructor
+
+```ts
+constructor(config: BridgeConfig, options?: CacheOptions)
+```
+- **Parameters**:
+  - `config`: [`BridgeConfig`](#bridgeconfig)
+  - `options`: [`CacheOptions`](#cacheoptions) (optional) — defaults to an [`InMemoryCache`](#inmemorycache) with the default TTLs.
+
+---
+
+#### Methods
+
+##### `getFee`
+```ts
+async getFee(): Promise<number>
+```
+Returns the protocol fee in basis points, served from cache when a fresh value is present.
+- **Returns**: `Promise<number>`
+
+##### `getFeeCollector`
+```ts
+async getFeeCollector(): Promise<string>
+```
+Returns the fee collector's G-address, served from cache when fresh.
+- **Returns**: `Promise<string>`
+
+##### `getAdmin`
+```ts
+async getAdmin(): Promise<string>
+```
+Returns the contract admin's G-address, served from cache when fresh.
+- **Returns**: `Promise<string>`
+
+##### `isInitialized`
+```ts
+async isInitialized(): Promise<boolean>
+```
+Returns whether the contract is initialized, served from cache when fresh.
+- **Returns**: `Promise<boolean>`
+
+##### `client`
+```ts
+get client(): ContractClient
+```
+Accessor for the wrapped client, exposing the transaction methods `fundCAddress`, `fundCAddressWithSwap`, `withdrawFees`, `setFee`, `setFeeCollector`, `setAdmin`, and `upgrade`. Calling any of them invalidates the affected cache entries. For the full method set (batching, cross-chain, relayers, paginated queries) use [`OnboardingBridgeSDK`](#onboardingbridgesdk) directly.
+- **Returns**: The wrapped client instance.
+
+##### `invalidateCache`
+```ts
+async invalidateCache(keys?: CacheKey | CacheKey[]): Promise<void>
+```
+Drops one key, several keys, or — when `keys` is omitted — the entire cache.
+- **Parameters**:
+  - `keys`: [`CacheKey`](#type-aliases) `| CacheKey[]` (optional)
+- **Returns**: `Promise<void>`
+
+- **Example**:
+```ts
+import { CachedContractClient } from '@stellar/c-address-onboarding-bridge-sdk';
+
+const cached = new CachedContractClient(
+  { contractId: 'CA...', rpcUrl: 'https://soroban-testnet.stellar.org', networkPassphrase: Networks.TESTNET },
+  { ttlMs: { getFee: 60_000 } },
+);
+
+await cached.getFee();               // simulated against the network
+await cached.getFee();               // served from cache
+
+await cached.client.setFee(50, adminKeypair); // invalidates the cached fee
+await cached.invalidateCache('getAdmin');     // or drop a key by hand
+```
+
+---
+
+### `InMemoryCache`
+
+The default [`ICacheProvider`](#icacheprovider): a process-local `Map` with per-entry TTLs. Expired entries are evicted lazily on read. Implement `ICacheProvider` yourself to back the cache with Redis, `localStorage`, or anything else.
+
+```ts
+class InMemoryCache implements ICacheProvider {
+  async get<T>(key: string): Promise<T | undefined>
+  async set<T>(key: string, value: T, ttlMs?: number): Promise<void>
+  async delete(key: string): Promise<void>
+  async clear(): Promise<void>
+}
+```
+
+- **Example**:
+```ts
+import { InMemoryCache, CachedContractClient } from '@stellar/c-address-onboarding-bridge-sdk';
+
+const provider = new InMemoryCache();
+await provider.set('custom', { hello: 'world' }, 30_000); // expires in 30s
+
+const cached = new CachedContractClient(config, { provider });
+```
+
+---
+
+### `EventSubscriber`
+
+Polls Soroban RPC for contract events and dispatches them to typed listeners. Polling starts automatically when the first listener is registered and stops when the last one is removed.
+
+#### Constructor
+
+```ts
+constructor(config: EventSubscriberConfig)
+```
+- **Parameters**:
+  - `config`: [`EventSubscriberConfig`](#eventsubscriberconfig)
+
+---
+
+#### Methods
+
+##### `on`
+```ts
+on<K extends BridgeEventName>(
+  eventName: K,
+  callback: BridgeEventCallback<K>
+): Unsubscribe
+```
+Registers a listener for one event name, `'error'`, or `'*'` for every event. Starts the polling loop on the first call. Throws if the subscriber has been destroyed.
+- **Parameters**:
+  - `eventName`: [`BridgeEventName`](#type-aliases)
+  - `callback`: [`BridgeEventCallback<K>`](#type-aliases)
+- **Returns**: [`Unsubscribe`](#type-aliases) — call it to remove this listener.
+
+##### `off`
+```ts
+off(eventName: BridgeEventName): void
+```
+Removes every listener registered for one event name.
+- **Parameters**:
+  - `eventName`: [`BridgeEventName`](#type-aliases)
+- **Returns**: `void`
+
+##### `listenerCount`
+```ts
+listenerCount(): number
+```
+Total number of registered callbacks across all event names.
+- **Returns**: `number`
+
+##### `poll`
+```ts
+async poll(): Promise<void>
+```
+Runs a single poll immediately, for tests or on-demand refresh. RPC failures are dispatched to `'error'` listeners rather than thrown.
+- **Returns**: `Promise<void>`
+
+##### `destroy`
+```ts
+destroy(): void
+```
+Stops polling and removes all listeners. The instance cannot be reused afterwards.
+- **Returns**: `void`
+
+- **Example**:
+```ts
+import { EventSubscriber } from '@stellar/c-address-onboarding-bridge-sdk';
+
+const subscriber = new EventSubscriber({
+  contractId: 'CA...',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  pollingIntervalMs: 5000,
+  startLedger: 'now',
+});
+
+const unsubscribe = subscriber.on('CAddressFunded', (event) => {
+  console.log(`${event.amount} of ${event.asset} -> ${event.target} (fee ${event.fee})`);
+});
+
+subscriber.on('error', (err) => console.error('poll failed', err));
+
+// later
+unsubscribe();
+subscriber.destroy();
+```
+
+---
+
+## Functions
+
+### Retry Utilities
+
+Exported from the SDK root for use with any async operation, not just SDK calls.
+
+##### `withRetry`
+```ts
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  options?: RetryOptions
+): Promise<T>
+```
+Runs `fn`, retrying transient failures with exponential backoff plus full jitter. The initial call is attempt 0 and up to `maxRetries` further attempts follow. Errors classified as permanent are re-thrown immediately; the last error is re-thrown once retries are exhausted. Pass `options.signal` to cancel an in-flight loop — see [Cancelling Retries](#cancelling-retries).
+- **Parameters**:
+  - `fn`: `() => Promise<T>`
+  - `options`: [`RetryOptions`](#retryoptions) (optional)
+- **Returns**: `Promise<T>`
+
+##### `withRpcRetry`
+```ts
+function withRpcRetry<T extends object>(
+  provider: T,
+  options?: RpcRetryOptions
+): T
+```
+Wraps an RPC provider in a transparent proxy so each method is retried under the policy matching its nature: read methods use `VIEW_RETRY_POLICY`, `sendTransaction` uses `STATE_CHANGING_RETRY_POLICY`, and anything else passes through untouched. Method signatures and return values are unchanged, so the proxy can replace the provider in place. The SDK applies this to its own RPC server automatically.
+- **Parameters**:
+  - `provider`: `T` — typically a `SorobanRpc.Server`.
+  - `options`: [`RpcRetryOptions`](#rpcretryoptions) (optional)
+- **Returns**: `T`
+
+##### `isRetryableRpcError`
+```ts
+function isRetryableRpcError(error: unknown): boolean
+```
+Classifies an error as transient (worth retrying) or permanent. Matches transient network error codes, the retryable HTTP statuses, and a set of message patterns; returns `false` for validation errors and contract reverts. See [RPC Retry & Transient Errors](#rpc-retry--transient-errors) for the full lists.
+- **Parameters**:
+  - `error`: `unknown`
+- **Returns**: `boolean`
+
+##### `computeBackoffDelay`
+```ts
+function computeBackoffDelay(
+  attempt: number,
+  baseDelayMs?: number,
+  maxDelayMs?: number,
+  jitter?: boolean
+): number
+```
+Computes the delay before a given retry. Without jitter the sequence is `base, base*2, base*4, …` capped at `maxDelayMs`. With full jitter the result is uniform in `[0, cappedDelay]`.
+- **Parameters**:
+  - `attempt`: `number` — 0-based retry index.
+  - `baseDelayMs`: `number` (optional, default `1000`)
+  - `maxDelayMs`: `number` (optional, default `30000`)
+  - `jitter`: `boolean` (optional, default `true`)
+- **Returns**: `number` — delay in milliseconds.
+
+- **Example**:
+```ts
+import { withRetry, withRpcRetry, isRetryableRpcError } from '@stellar/c-address-onboarding-bridge-sdk';
+
+// Retry an arbitrary async operation.
+const data = await withRetry(() => fetch(url).then((r) => r.json()), {
+  maxRetries: 5,
+  baseDelayMs: 500,
+  onRetry: ({ attempt, delayMs }) => console.warn(`retry ${attempt} in ${delayMs}ms`),
+});
+
+// Or wrap a whole RPC provider.
+const server = withRpcRetry(new SorobanRpc.Server(rpcUrl), { maxRetries: 4 });
+
+if (!isRetryableRpcError(err)) throw err;
+```
+
+---
+
+### Observability Helpers
+
+##### `ConsoleLogger`
+```ts
+const ConsoleLogger: ObservabilityHooks
+```
+A ready-made [`ObservabilityHooks`](#observabilityhooks) implementation that writes one `[bridge-sdk]` line per transaction start, RPC call, and transaction result to the console. Intended for local debugging.
+
+##### `createOpenTelemetryHooks`
+```ts
+function createOpenTelemetryHooks(
+  tracer: Tracer,
+  options?: OpenTelemetryHooksOptions
+): ObservabilityHooks
+```
+Builds hooks backed by an OpenTelemetry `Tracer`. Each mutating SDK method becomes a span carrying `bridge.method`, `bridge.tx.hash`, `bridge.tx.status`, and `bridge.duration_ms`. When `traceRpcCalls` is enabled (the default) each RPC round-trip becomes a child span with `rpc.method` and `rpc.duration_ms`.
+- **Parameters**:
+  - `tracer`: `Tracer` — from `trace.getTracer(...)` in `@opentelemetry/api`.
+  - `options`: [`OpenTelemetryHooksOptions`](#opentelemetryhooksoptions) (optional)
+- **Returns**: [`ObservabilityHooks`](#observabilityhooks)
+
+##### `composeHooks`
+```ts
+function composeHooks(...hooks: ObservabilityHooks[]): ObservabilityHooks
+```
+Merges several hook objects into one that forwards every callback to each of them in order. Useful for combining `ConsoleLogger` with your own metrics hooks.
+- **Parameters**:
+  - `...hooks`: [`ObservabilityHooks[]`](#observabilityhooks)
+- **Returns**: [`ObservabilityHooks`](#observabilityhooks)
+
+- **Example**:
+```ts
+import { trace } from '@opentelemetry/api';
+import {
+  OnboardingBridgeSDK,
+  ConsoleLogger,
+  composeHooks,
+  createOpenTelemetryHooks,
+} from '@stellar/c-address-onboarding-bridge-sdk';
+
+const tracer = trace.getTracer('my-service', '1.0.0');
+
+const sdk = new OnboardingBridgeSDK({
+  contractId: 'CA...',
+  rpcUrl: 'https://soroban-testnet.stellar.org',
+  networkPassphrase: Networks.TESTNET,
+  hooks: composeHooks(
+    ConsoleLogger,
+    createOpenTelemetryHooks(tracer, { spanPrefix: 'my-service/bridge' }),
+    { onRpcCall: (method, _params, durationMs) => metrics.histogram('rpc', durationMs, { method }) },
+  ),
+});
+```
+
+---
+
+## Constants
+
+| Constant | Type | Value | Description |
+| :--- | :--- | :--- | :--- |
+| `BATCH_TX_LIMIT` | `number` | `100` | Maximum `(target, amount)` pairs per `batch_fund_c_address` call, matching the contract's on-chain `MAX_BATCH_SIZE`. `batchFundCAddresses` splits longer lists into chunks of this size. |
+| `BASE_RESERVE_STROOPS` | `number` | `5_000_000` | Stellar's default base reserve (0.5 XLM) used by [`estimateCost`](#estimatecost). Override per instance with `BridgeConfig.baseReserveStroops`. |
+| `VIEW_RETRY_POLICY` | `Required<Pick<RetryOptions, 'maxRetries' \| 'baseDelayMs' \| 'maxDelayMs' \| 'jitter'>>` | `{ maxRetries: 3, baseDelayMs: 1000, maxDelayMs: 30000, jitter: true }` | Retry policy for idempotent read-only RPC calls. |
+| `STATE_CHANGING_RETRY_POLICY` | same as above | `{ maxRetries: 1, baseDelayMs: 1000, maxDelayMs: 30000, jitter: true }` | Conservative policy for `sendTransaction`, limiting double-submission risk. |
+
+---
+
 ## Interfaces
 
 ### `BridgeConfig`
@@ -447,6 +829,8 @@ Defines configuration properties to connect the SDK to the network.
 | `networkPassphrase` | `string` | Network identifier (e.g. `Test SDF Network ; September 2015`). |
 | `timeout` | `number` | *Optional*. Timeout in seconds for Soroban operations. |
 | `retry` | `RpcRetryOptions` | *Optional*. Retries configuration for RPC requests. |
+| `hooks` | `ObservabilityHooks` | *Optional*. Instrumentation callbacks for SDK methods and RPC calls. |
+| `baseReserveStroops` | `number \| string` | *Optional*. Network base reserve in stroops used by [`estimateCost`](#estimatecost). Defaults to `BASE_RESERVE_STROOPS` (5,000,000). |
 
 ---
 
@@ -579,6 +963,183 @@ Parameters to page read queries.
 
 ---
 
+### `CostEstimate`
+Returned by [`estimateCost`](#estimatecost). All fee values are in stroops (1 XLM = 10,000,000 stroops).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `fee` | `string` | Total fee: inclusion fee plus resource fee. |
+| `minBalance` | `string` | Minimum balance the source account must hold, computed as `(2 + numSubentries) * baseReserve`. |
+| `resourceFee` | `string` | Soroban resource fee covering CPU, memory, storage, and I/O. |
+| `executionTimeMs` | `number` | Wall-clock duration of the simulation, useful as an RPC-load signal. |
+
+---
+
+### `CacheOptions`
+Second argument to the [`CachedContractClient`](#cachedcontractclient) constructor.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `provider` | `ICacheProvider` | *Optional*. Backing store. Defaults to a new [`InMemoryCache`](#inmemorycache). |
+| `ttlMs` | `Partial<Record<CacheKey, number>>` | *Optional*. Per-key TTL overrides in milliseconds. Unspecified keys keep their defaults. |
+
+---
+
+### `ICacheProvider`
+Storage abstraction behind [`CachedContractClient`](#cachedcontractclient). Every method is asynchronous so the same interface fits in-memory, Redis, and `localStorage` backends.
+
+| Method | Signature | Description |
+| :--- | :--- | :--- |
+| `get` | `get<T>(key: string): Promise<T \| undefined>` | Returns the cached value, or `undefined` if absent or expired. |
+| `set` | `set<T>(key: string, value: T, ttlMs?: number): Promise<void>` | Stores a value; omitting `ttlMs` stores it without expiry. |
+| `delete` | `delete(key: string): Promise<void>` | Removes one key. |
+| `clear` | `clear(): Promise<void>` | Removes every key. |
+
+---
+
+### `RetryOptions`
+Options for [`withRetry`](#retry-utilities).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `maxRetries` | `number` | *Optional*. Retries after the initial attempt (default: 3). |
+| `baseDelayMs` | `number` | *Optional*. Delay for the first backoff step (default: 1000). |
+| `maxDelayMs` | `number` | *Optional*. Upper bound for any single delay (default: 30000). |
+| `jitter` | `boolean` | *Optional*. Apply full jitter to each delay (default: `true`). |
+| `isRetryable` | `RetryableClassifier` | *Optional*. Error classifier (default: `isRetryableRpcError`). |
+| `onRetry` | `RetryLogger` | *Optional*. Called once per retry (default: no-op). |
+| `signal` | `AbortSignal` | *Optional*. Cancels the loop. Checked before each attempt and interrupts the pending backoff, so an abort takes effect immediately. |
+
+---
+
+### `RpcRetryOptions`
+Options for [`withRpcRetry`](#retry-utilities), also accepted as `BridgeConfig.retry`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `maxRetries` | `number` | *Optional*. Retries for view calls (default: 3). State-changing calls are capped at 1 regardless. |
+| `baseDelayMs` | `number` | *Optional*. Delay for the first backoff step (default: 1000). |
+| `maxDelayMs` | `number` | *Optional*. Upper bound for any single delay (default: 30000). |
+| `jitter` | `boolean` | *Optional*. Apply full jitter (default: `true`). |
+| `onRetry` | `RetryLogger` | *Optional*. Called once per retry (default: no-op). |
+
+---
+
+### `RetryAttempt`
+The record passed to a `RetryLogger`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `attempt` | `number` | 1-based index of the attempt that just failed. |
+| `maxRetries` | `number` | Total retries allowed after the initial attempt. |
+| `delayMs` | `number` | Delay before the next attempt. |
+| `error` | `unknown` | The error that triggered the retry. |
+
+---
+
+### `ObservabilityHooks`
+Instrumentation callbacks, passed as `BridgeConfig.hooks`. Supply any subset. Exceptions thrown inside a hook are caught and logged, so instrumentation never disrupts SDK behaviour.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `onTransactionStart` | `(method: string, params: unknown) => void` | *Optional*. Fires before a mutating method runs. `params` excludes keypairs. |
+| `onTransactionSuccess` | `(method: string, result: unknown, durationMs: number) => void` | *Optional*. Fires when a mutating method returns without throwing — including `status: 'failed'` results. |
+| `onTransactionError` | `(method: string, error: Error, durationMs: number) => void` | *Optional*. Fires only on an unhandled exception, not on a `'failed'` result. |
+| `onRpcCall` | `(method: string, params: unknown, durationMs: number) => void` | *Optional*. Fires after every internal RPC call, whether it succeeded or failed. |
+
+---
+
+### `OpenTelemetryHooksOptions`
+Second argument to [`createOpenTelemetryHooks`](#observability-helpers).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `traceRpcCalls` | `boolean` | *Optional*. Record RPC calls as child spans of the transaction span (default: `true`). |
+| `spanPrefix` | `string` | *Optional*. Prefix for all span names (default: `'bridge-sdk'`). |
+
+---
+
+### `EventSubscriberConfig`
+Constructor argument for [`EventSubscriber`](#eventsubscriber).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `contractId` | `string` | Deployed bridge contract ID (C-address). |
+| `rpcUrl` | `string` | Soroban RPC URL. |
+| `networkPassphrase` | `string` | *Optional*. Used only when constructing the RPC server. |
+| `pollingIntervalMs` | `number` | *Optional*. Poll interval in milliseconds (default: 5000). |
+| `startLedger` | `number \| 'now'` | *Optional*. `'now'` (default) sees only new events; a ledger number replays from that point. |
+| `limit` | `number` | *Optional*. Maximum events fetched per poll (default: 100). |
+
+---
+
+### Bridge Event Payloads
+
+Every payload carries `ledger` (`number`, the emitting ledger sequence) and `pagingToken` (`string`, the cursor for polling) alongside the fields below.
+
+#### `CAddressFundedEvent`
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `'CAddressFunded'` | Discriminant. |
+| `asset` | `string` | Token contract address. |
+| `source` | `string` | Account that provided the tokens. |
+| `target` | `string` | C-address that received them. |
+| `amount` | `string` | Gross amount transferred. |
+| `fee` | `string` | Fee deducted from the gross amount. |
+
+#### `FeesWithdrawnEvent`
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `'FeesWithdrawn'` | Discriminant. |
+| `feeCollector` | `string` | Address that received the fees. |
+| `amount` | `string` | Amount withdrawn. |
+| `asset` | `string` | Token contract address. |
+
+#### `AdminChangedEvent`
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `'AdminChanged'` | Discriminant. |
+| `oldAdmin` | `string` | Previous admin address. |
+| `newAdmin` | `string` | New admin address. |
+
+#### `MetaFundExecutedEvent`
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `'MetaFundExecuted'` | Discriminant. |
+| `asset` | `string` | Token contract address. |
+| `source` | `string` | Account that provided the tokens. |
+| `target` | `string` | C-address that received them. |
+| `amount` | `string` | Gross amount transferred. |
+| `fee` | `string` | Fee deducted. |
+| `nonce` | `string` | Meta-transaction nonce. |
+
+#### `GenericBridgeEvent`
+Catch-all for contract events without a dedicated type.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `string` | Event name as emitted. |
+| `topics` | `unknown[]` | Raw topics decoded to native JS values. |
+| `value` | `unknown` | Raw value decoded to a native JS value. |
+
+---
+
+## Type Aliases
+
+| Alias | Definition | Description |
+| :--- | :--- | :--- |
+| `CacheKey` | `'getFee' \| 'getFeeCollector' \| 'getAdmin' \| 'isInitialized'` | The view methods [`CachedContractClient`](#cachedcontractclient) caches. |
+| `BatchProgressCallback` | `(completed: number, total: number, txHash?: string) => void` | Progress reporter for `batchFundCAddresses`, invoked once per submitted chunk. |
+| `RetryLogger` | `(attempt: RetryAttempt) => void` | Receives one record per retry. Defaults to a no-op. |
+| `RetryableClassifier` | `(error: unknown) => boolean` | Decides whether a thrown error is worth retrying. |
+| `BridgeEventName` | `keyof BridgeEventMap` | `'CAddressFunded' \| 'FeesWithdrawn' \| 'AdminChanged' \| 'MetaFundExecuted' \| 'error' \| '*'`. |
+| `BridgeEventPayload` | Union of the five event payload interfaces | The value delivered to a `'*'` listener. |
+| `BridgeEventMap` | Interface mapping each event name to its payload | `'error'` maps to `Error`; `'*'` maps to `BridgeEventPayload`. |
+| `BridgeEventCallback<K>` | `(event: BridgeEventMap[K]) => void` | Listener signature for event name `K`. |
+| `Unsubscribe` | `() => void` | Returned by `EventSubscriber.on`; call it to remove that listener. |
+
+---
+
 ## Error Handling & Validation
 
 ### Validation Methods
@@ -602,6 +1163,53 @@ The SDK retries if it catches:
 #### Retry Policies
 - **Read-Only / Idempotent Calls (`VIEW_RETRY_POLICY`)**: Automatically retries up to 3 times (first backoff at 1s, capped at 30s) using exponential backoff + jitter.
 - **State-Changing / Write Calls (`STATE_CHANGING_RETRY_POLICY`)**: Automatically retries **only once** to prevent double-spending, keeping the transaction envelope's sequence identical.
+
+---
+
+### Cancelling Retries
+
+With the defaults, a single [`withRetry`](#retry-utilities) call can spend tens of seconds asleep between attempts. Pass an `AbortSignal` as `RetryOptions.signal` to cut that short — for example when a UI component unmounts while a request is still backing off.
+
+The signal is honoured in three places: before the first attempt (an already-aborted signal means `fn` never runs), between attempts, and **during** the backoff delay itself. Aborting therefore takes effect immediately rather than after the current sleep elapses. The returned promise rejects with the signal's `reason`, so an abort is distinguishable from an RPC failure.
+
+```ts
+import { withRetry } from '@stellar/c-address-onboarding-bridge-sdk';
+
+const controller = new AbortController();
+
+// Abandon the operation if it has not settled within 5 seconds.
+const timer = setTimeout(() => controller.abort(new Error('took too long')), 5000);
+
+try {
+  const result = await withRetry(() => server.getTransaction(hash), {
+    maxRetries: 3,
+    signal: controller.signal,
+  });
+  console.log(result);
+} catch (err) {
+  if (controller.signal.aborted) {
+    console.warn('cancelled:', err); // Error: took too long
+  } else {
+    throw err;
+  }
+} finally {
+  clearTimeout(timer);
+}
+```
+
+In React, wire the signal to the effect cleanup so an unmount stops the loop:
+
+```ts
+useEffect(() => {
+  const controller = new AbortController();
+  withRetry(() => sdk.getFee(), { signal: controller.signal })
+    .then(setFee)
+    .catch((err) => {
+      if (!controller.signal.aborted) setError(err);
+    });
+  return () => controller.abort();
+}, []);
+```
 
 ---
 

--- a/sdk/src/__tests__/bridge.test.ts
+++ b/sdk/src/__tests__/bridge.test.ts
@@ -1,6 +1,6 @@
-import { OnboardingBridgeSDK } from '../bridge';
+import { OnboardingBridgeSDK, BASE_RESERVE_STROOPS } from '../bridge';
 import { OffRampIntegration } from '../offramp';
-import { SorobanRpc, Contract, scValToNative, xdr, Address, nativeToScVal, TransactionBuilder } from '@stellar/stellar-sdk';
+import { SorobanRpc, Contract, scValToNative, xdr, Address, nativeToScVal, TransactionBuilder, Keypair } from '@stellar/stellar-sdk';
 
 jest.mock('@stellar/stellar-sdk', () => ({
   SorobanRpc: {
@@ -24,6 +24,15 @@ jest.mock('@stellar/stellar-sdk', () => ({
       scvSymbol: jest.fn().mockReturnValue({}),
     },
     ScMapEntry: jest.fn().mockImplementation(() => ({})),
+    LedgerKey: {
+      account: jest.fn().mockReturnValue({}),
+    },
+    LedgerKeyAccount: jest.fn().mockImplementation(() => ({})),
+  },
+  Keypair: {
+    fromPublicKey: jest.fn().mockReturnValue({
+      xdrAccountId: jest.fn().mockReturnValue({}),
+    }),
   },
   Address: jest.fn().mockImplementation(() => ({
     toScVal: jest.fn().mockReturnValue({}),
@@ -52,6 +61,18 @@ const CONFIG = {
 const MOCK_ADDRESS = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 const MOCK_ASSET = 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABSC4';
 
+/**
+ * A `getLedgerEntries` result shaped like a real `AccountEntry` lookup.
+ * Pass `null` to model an account that does not exist on-chain yet.
+ */
+function ledgerEntriesFor(numSubEntries: number | null) {
+  if (numSubEntries === null) return { entries: [], latestLedger: 1 };
+  return {
+    entries: [{ val: { account: () => ({ numSubEntries: () => numSubEntries }) } }],
+    latestLedger: 1,
+  };
+}
+
 describe('OnboardingBridgeSDK', () => {
   let sdk: OnboardingBridgeSDK;
   let mockProvider: any;
@@ -70,6 +91,7 @@ describe('OnboardingBridgeSDK', () => {
       prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
       sendTransaction: jest.fn().mockResolvedValue({ hash: 'mock_tx_hash', status: 'PENDING' }),
       simulateTransaction: jest.fn().mockResolvedValue({}),
+      getLedgerEntries: jest.fn().mockResolvedValue(ledgerEntriesFor(0)),
     };
 
     (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);
@@ -1216,6 +1238,73 @@ describe('OnboardingBridgeSDK', () => {
       await expect(sdk.queryIsRelayer('a'.repeat(64))).rejects.toThrow('Failed to query relayer');
     });
   });
+
+  describe('estimateCost minimum balance', () => {
+    const ESTIMATE_ARGS = {
+      source: MOCK_ADDRESS,
+      target: MOCK_ASSET,
+      asset: MOCK_ASSET,
+      amount: '100',
+    };
+
+    beforeEach(() => {
+      mockProvider.simulateTransaction.mockResolvedValue({ minResourceFee: '5000' });
+    });
+
+    it('charges two base reserves for an account with no subentries', async () => {
+      mockProvider.getLedgerEntries.mockResolvedValue(ledgerEntriesFor(0));
+
+      const estimate = await sdk.estimateCost(ESTIMATE_ARGS);
+
+      expect(estimate.minBalance).toBe(String(2 * BASE_RESERVE_STROOPS));
+    });
+
+    it('adds one base reserve per subentry', async () => {
+      mockProvider.getLedgerEntries.mockResolvedValue(ledgerEntriesFor(5));
+
+      const estimate = await sdk.estimateCost(ESTIMATE_ARGS);
+
+      // (2 + 5) * 0.5 XLM = 3.5 XLM
+      expect(estimate.minBalance).toBe(String(7 * BASE_RESERVE_STROOPS));
+      expect(estimate.minBalance).not.toBe('10000000');
+    });
+
+    it('reads the subentry count from the source account', async () => {
+      mockProvider.getLedgerEntries.mockResolvedValue(ledgerEntriesFor(3));
+
+      await sdk.estimateCost(ESTIMATE_ARGS);
+
+      expect(Keypair.fromPublicKey).toHaveBeenCalledWith(MOCK_ADDRESS);
+      expect(mockProvider.getLedgerEntries).toHaveBeenCalled();
+    });
+
+    it('treats an account that does not exist yet as having no subentries', async () => {
+      mockProvider.getLedgerEntries.mockResolvedValue(ledgerEntriesFor(null));
+
+      const estimate = await sdk.estimateCost(ESTIMATE_ARGS);
+
+      expect(estimate.minBalance).toBe(String(2 * BASE_RESERVE_STROOPS));
+    });
+
+    it('honours a configured base reserve', async () => {
+      mockProvider.getLedgerEntries.mockResolvedValue(ledgerEntriesFor(2));
+      const customSdk = new OnboardingBridgeSDK({ ...CONFIG, baseReserveStroops: 1_000_000 });
+
+      const estimate = await customSdk.estimateCost(ESTIMATE_ARGS);
+
+      expect(estimate.minBalance).toBe(String(4 * 1_000_000));
+    });
+
+    it('still reports the simulated fees alongside the minimum balance', async () => {
+      mockProvider.getLedgerEntries.mockResolvedValue(ledgerEntriesFor(1));
+
+      const estimate = await sdk.estimateCost(ESTIMATE_ARGS);
+
+      expect(estimate.resourceFee).toBe('5000');
+      expect(estimate.fee).toBe('5100'); // BASE_FEE (100) + resource fee
+      expect(estimate.minBalance).toBe(String(3 * BASE_RESERVE_STROOPS));
+    });
+  });
 });
 
 describe('address validation', () => {
@@ -1451,24 +1540,27 @@ describe('Error handling - invalid inputs', () => {
       .rejects.toThrow(/Invalid contract address for "assets\[0\]"/);
   });
 
+  // `upgrade` is a mutating method, so it reports validation failures through
+  // the returned TransactionResult rather than throwing — same as
+  // `reclaimTokens` above.
   it('upgrade rejects newWasmHash shorter than 64 hex chars', async () => {
-    await expect(sdk.upgrade({ newWasmHash: 'ab12' }, mockKeypair)).rejects.toThrow(
-      /newWasmHash must be a 64-character hex string/,
-    );
+    const result = await sdk.upgrade({ newWasmHash: 'ab12' }, mockKeypair);
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/newWasmHash must be a 64-character hex string/);
     expect(mockProvider.getAccount).not.toHaveBeenCalled();
   });
 
   it('upgrade rejects newWasmHash longer than 64 hex chars', async () => {
-    await expect(sdk.upgrade({ newWasmHash: 'a'.repeat(128) }, mockKeypair)).rejects.toThrow(
-      /newWasmHash must be a 64-character hex string/,
-    );
+    const result = await sdk.upgrade({ newWasmHash: 'a'.repeat(128) }, mockKeypair);
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/newWasmHash must be a 64-character hex string/);
     expect(mockProvider.getAccount).not.toHaveBeenCalled();
   });
 
   it('upgrade rejects newWasmHash with non-hex characters', async () => {
-    await expect(sdk.upgrade({ newWasmHash: 'g'.repeat(64) }, mockKeypair)).rejects.toThrow(
-      /newWasmHash must be a 64-character hex string/,
-    );
+    const result = await sdk.upgrade({ newWasmHash: 'g'.repeat(64) }, mockKeypair);
+    expect(result.status).toBe('failed');
+    expect(result.error).toMatch(/newWasmHash must be a 64-character hex string/);
     expect(mockProvider.getAccount).not.toHaveBeenCalled();
   });
 
@@ -1644,6 +1736,7 @@ describe('Observability hooks - onRpcCall coverage', () => {
       prepareTransaction: jest.fn().mockResolvedValue({ sign: jest.fn() }),
       sendTransaction: jest.fn().mockResolvedValue({ hash: 'h', status: 'PENDING' }),
       simulateTransaction: jest.fn().mockResolvedValue({ results: [{ retval: {} }] }),
+      getLedgerEntries: jest.fn().mockResolvedValue(ledgerEntriesFor(0)),
     };
 
     (SorobanRpc.Server as jest.Mock).mockImplementation(() => mockProvider);

--- a/sdk/src/__tests__/retry.test.ts
+++ b/sdk/src/__tests__/retry.test.ts
@@ -132,6 +132,74 @@ describe('withRetry', () => {
     expect(onRetry).toHaveBeenCalledTimes(3);
   });
 
+  it('does not run the operation at all when the signal is already aborted', async () => {
+    const { sleep } = recordingSleep();
+    const controller = new AbortController();
+    controller.abort();
+    const fn = jest.fn().mockResolvedValue('ok');
+
+    await expect(withRetry(fn, { sleep, signal: controller.signal })).rejects.toThrow();
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it('stops retrying once the signal is aborted between attempts', async () => {
+    const controller = new AbortController();
+    const fn = jest.fn().mockRejectedValue(RETRYABLE);
+    // Abort while the first backoff is pending.
+    const sleep = jest.fn(async () => {
+      controller.abort();
+    });
+
+    await expect(
+      withRetry(fn, { sleep, maxRetries: 5, signal: controller.signal }),
+    ).rejects.toThrow();
+    // Initial attempt only — the abort lands before the second one starts.
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('interrupts a long backoff instead of waiting it out', async () => {
+    const controller = new AbortController();
+    const fn = jest.fn().mockRejectedValue(RETRYABLE);
+    // A real 30s sleep: the test only finishes promptly if the abort cuts it short.
+    const start = Date.now();
+
+    const promise = withRetry(fn, {
+      maxRetries: 3,
+      baseDelayMs: 30000,
+      maxDelayMs: 30000,
+      jitter: false,
+      signal: controller.signal,
+    });
+    setTimeout(() => controller.abort(), 10);
+
+    await expect(promise).rejects.toThrow();
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects with the abort reason when one is supplied', async () => {
+    const { sleep } = recordingSleep();
+    const reason = new Error('component unmounted');
+    const controller = new AbortController();
+    const fn = jest.fn().mockRejectedValue(RETRYABLE);
+
+    const promise = withRetry(fn, { sleep, maxRetries: 5, signal: controller.signal });
+    controller.abort(reason);
+
+    await expect(promise).rejects.toThrow('component unmounted');
+  });
+
+  it('leaves unaborted retries untouched', async () => {
+    const { sleep, delays } = recordingSleep();
+    const controller = new AbortController();
+    const fn = jest.fn().mockRejectedValueOnce(RETRYABLE).mockResolvedValue('ok');
+
+    await expect(
+      withRetry(fn, { sleep, jitter: false, signal: controller.signal }),
+    ).resolves.toBe('ok');
+    expect(delays).toEqual([1000]);
+  });
+
   it('honours maxRetries: 0 (retries disabled)', async () => {
     const { sleep } = recordingSleep();
     const fn = jest.fn().mockRejectedValue(RETRYABLE);

--- a/sdk/src/bridge.ts
+++ b/sdk/src/bridge.ts
@@ -33,12 +33,10 @@ import {
   CrossChainFundOptions,
   RelayerManagementOptions,
   FundCAddressWithSwapOptions,
-  FundCTimelockedOptions,
   PaginatedResult,
   PaginationOptions,
   CostEstimate,
   TimelockEntry,
-  FundCTimelockedOptions,
 } from './types';
 import {
   type ObservabilityHooks,
@@ -57,6 +55,16 @@ import {
  * size and submits one transaction per chunk.
  */
 export const BATCH_TX_LIMIT = 100;
+
+/**
+ * Stellar's default base reserve, in stroops (0.5 XLM).
+ *
+ * An account's minimum balance is `(2 + numSubentries) * baseReserve`: two
+ * reserves for the account itself plus one for every subentry (trustline,
+ * offer, data entry, or signer). Override per-instance with
+ * `BridgeConfig.baseReserveStroops` if the network uses a different value.
+ */
+export const BASE_RESERVE_STROOPS = 5_000_000;
 import { assertAccountAddress, assertContractAddress, assertRelayerPubkey } from './validate';
 import { withRpcRetry } from './retry';
 import { toScVals, buildSimulationTx as buildSharedSimTx } from './encoding';
@@ -982,7 +990,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'withdraw_fees',
-                ...this.toScVals([options.asset, options.amount]),
+                ...toScVals([options.asset, options.amount]),
                 options.nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(options.nonce), { type: 'u64' }),
               ),
             )
@@ -1066,7 +1074,7 @@ export class OnboardingBridgeSDK {
             .addOperation(
               this.contract.call(
                 'reclaim_tokens',
-                ...this.toScVals([options.asset, options.amount, options.to]),
+                ...toScVals([options.asset, options.amount, options.to]),
                 options.nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(options.nonce), { type: 'u64' }),
               ),
             )
@@ -2616,20 +2624,14 @@ export class OnboardingBridgeSDK {
   }
 
   /**
-   * Convert an array of JavaScript values to Soroban `ScVal` XDR values.
-   *
-   * Handles strings (G-/C-addresses, numeric strings, plain strings), numbers,
-   * bigints, `Address` instances, arrays (→ `scvVec`), and `null`/`undefined`
-   * (→ `scvVoid`).
-   *
-   * @param args - Values to convert.
-   * @returns Array of `xdr.ScVal` suitable for passing to `Contract.call`.
-   * @internal
    * Estimate the transaction cost for a `fundCAddress` call without submitting
    * it to the network.
    *
    * Runs `simulateTransaction` under the hood and extracts the Soroban resource
    * fee, the base inclusion fee, and the minimum account balance required.
+   *
+   * @param options - The `fundCAddress` call to price.
+   * @returns The estimated fees plus the source account's minimum balance.
    *
    * @example
    * ```ts
@@ -2641,6 +2643,7 @@ export class OnboardingBridgeSDK {
    * });
    * console.log('Resource fee:', estimate.resourceFee, 'stroops');
    * console.log('Total fee:   ', estimate.fee, 'stroops');
+   * console.log('Min balance: ', estimate.minBalance, 'stroops');
    * ```
    */
   async estimateCost(options: FundCOptions): Promise<CostEstimate> {
@@ -2706,10 +2709,12 @@ export class OnboardingBridgeSDK {
       BigInt(inclusionFee) + BigInt(resourceFee),
     );
 
-    // Minimum balance: Stellar base reserve is 0.5 XLM per entry.
-    // For a basic funded account the minimum is 1 XLM (2 base reserves).
-    // 1 XLM = 10_000_000 stroops.
-    const minBalance = '10000000';
+    // Minimum balance = (2 + numSubentries) * baseReserve. The two fixed
+    // reserves cover the account entry itself; every trustline, offer, data
+    // entry, or extra signer on the source account adds another one.
+    const subentryCount = await this.getSubentryCount(options.source);
+    const baseReserve = BigInt(this.config.baseReserveStroops ?? BASE_RESERVE_STROOPS);
+    const minBalance = String(BigInt(2 + subentryCount) * baseReserve);
 
     return {
       fee: totalFee,
@@ -2717,6 +2722,34 @@ export class OnboardingBridgeSDK {
       resourceFee,
       executionTimeMs,
     };
+  }
+
+  /**
+   * Read the number of subentries held by an account.
+   *
+   * Reads the raw `AccountEntry` because Soroban RPC's `getAccount` only
+   * surfaces the account ID and sequence number. An account that does not exist
+   * on-chain yet has no subentries, so it reports 0.
+   *
+   * @internal
+   */
+  private async getSubentryCount(address: string): Promise<number> {
+    const ledgerKey = xdr.LedgerKey.account(
+      new xdr.LedgerKeyAccount({
+        accountId: Keypair.fromPublicKey(address).xdrAccountId(),
+      }),
+    );
+
+    const response = await withRpcHook(
+      this.hooks,
+      'getLedgerEntries',
+      { address },
+      () => this.provider.getLedgerEntries(ledgerKey),
+    );
+
+    const entry = response.entries?.[0];
+    if (!entry) return 0;
+    return entry.val.account().numSubEntries();
   }
 
   /**

--- a/sdk/src/cachedBridge.ts
+++ b/sdk/src/cachedBridge.ts
@@ -15,6 +15,7 @@ import {
   Contract,
   xdr,
   Keypair,
+  nativeToScVal,
   scValToNative,
   TransactionBuilder,
   BASE_FEE,
@@ -308,7 +309,7 @@ class ContractClient {
       networkPassphrase: this.networkPassphrase,
     })
       .addOperation(
-        this.contract.call('withdraw_fees', ...this.toScVals([options.asset, options.amount]),
+        this.contract.call('withdraw_fees', ...toScVals([options.asset, options.amount]),
           options.nonce === undefined ? xdr.ScVal.scvVoid() : nativeToScVal(BigInt(options.nonce), { type: 'u64' })),
       );
 

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -38,6 +38,8 @@
  * | `computeBackoffDelay` | Computes exponential backoff delay with optional jitter |
  * | `VIEW_RETRY_POLICY` | Default retry policy for idempotent read calls |
  * | `STATE_CHANGING_RETRY_POLICY` | Conservative retry policy for write calls |
+ * | `BATCH_TX_LIMIT` | Maximum targets per batch funding transaction |
+ * | `BASE_RESERVE_STROOPS` | Stellar base reserve used to derive minimum balances |
  *
  * All types are also re-exported; import them directly:
  *
@@ -49,7 +51,7 @@
  * @packageDocumentation
  */
 
-export { OnboardingBridgeSDK, BATCH_TX_LIMIT } from './bridge';
+export { OnboardingBridgeSDK, BATCH_TX_LIMIT, BASE_RESERVE_STROOPS } from './bridge';
 export { OffRampIntegration } from './offramp';
 export { assertAccountAddress, assertContractAddress } from './validate';
 export { CachedContractClient } from './cachedBridge';

--- a/sdk/src/retry.ts
+++ b/sdk/src/retry.ts
@@ -49,11 +49,22 @@ export interface RetryOptions {
   /** Retry logger. Default: no-op. */
   onRetry?: RetryLogger;
   /**
+   * Cancels an in-flight retry loop.
+   *
+   * The signal is checked before each attempt and interrupts the backoff delay
+   * itself, so an abort takes effect immediately rather than after the current
+   * sleep (which can be up to `maxDelayMs`) elapses. When it fires,
+   * {@link withRetry} rejects with the signal's `reason`.
+   */
+  signal?: AbortSignal;
+  /**
    * Clock seam used to wait between attempts. Injectable for tests.
-   * Default: a `setTimeout`-based sleep.
+   * Default: a `setTimeout`-based sleep. Receives {@link RetryOptions.signal}
+   * when one is set; implementations may ignore it, since `withRetry` also
+   * races the sleep against the signal.
    * @internal
    */
-  sleep?: (ms: number) => Promise<void>;
+  sleep?: (ms: number, signal?: AbortSignal) => Promise<void>;
 }
 
 /** Tunable knobs for {@link withRpcRetry}, surfaced on `BridgeConfig.retry`. */
@@ -72,8 +83,62 @@ export interface RpcRetryOptions {
 
 const noopLogger: RetryLogger = () => {};
 
-const defaultSleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+/**
+ * The value an aborted {@link withRetry} rejects with. Environments that
+ * predate `AbortSignal.reason` leave it undefined, so fall back to an
+ * equivalent error.
+ */
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new Error('The operation was aborted');
+}
+
+/**
+ * Default backoff sleep. When given a signal it clears its own timer on abort
+ * so a cancelled retry leaves nothing pending on the event loop.
+ */
+const defaultSleep = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (!signal) {
+      setTimeout(resolve, ms);
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(abortReason(signal));
+    };
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+/**
+ * Sleep for `ms`, rejecting early if `signal` aborts.
+ *
+ * Without this a single backoff can block for `maxDelayMs` after the caller has
+ * already given up. The signal is forwarded to `sleep` so a signal-aware
+ * implementation can release its timer, and raced against separately so that
+ * sleeps which ignore it are still cut short.
+ */
+function abortableSleep(
+  ms: number,
+  sleep: (ms: number, signal?: AbortSignal) => Promise<void>,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (!signal) return sleep(ms);
+  if (signal.aborted) return Promise.reject(abortReason(signal));
+
+  let onAbort: () => void = () => {};
+  const aborted = new Promise<never>((_resolve, reject) => {
+    onAbort = () => reject(abortReason(signal));
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+
+  return Promise.race([sleep(ms, signal), aborted]).finally(() => {
+    signal.removeEventListener('abort', onAbort);
+  });
+}
 
 /** Node network error codes that indicate a transient, retryable failure. */
 const RETRYABLE_ERROR_CODES = new Set([
@@ -151,6 +216,9 @@ export function computeBackoffDelay(
  * The initial call counts as attempt 0; up to `maxRetries` further attempts are
  * made. Permanent errors (per {@link isRetryableRpcError}) are re-thrown
  * immediately. The last error is re-thrown once retries are exhausted.
+ *
+ * Pass `options.signal` to cancel the loop; the pending backoff is cut short
+ * and the returned promise rejects with the signal's reason.
  */
 export async function withRetry<T>(
   fn: () => Promise<T>,
@@ -163,19 +231,24 @@ export async function withRetry<T>(
   const isRetryable = options.isRetryable ?? isRetryableRpcError;
   const onRetry = options.onRetry ?? noopLogger;
   const sleep = options.sleep ?? defaultSleep;
+  const signal = options.signal;
 
   let lastError: unknown;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (signal?.aborted) throw abortReason(signal);
     try {
       return await fn();
     } catch (error) {
       lastError = error;
+      // An abort that landed while `fn` was in flight wins over its error:
+      // the caller no longer wants the result either way.
+      if (signal?.aborted) throw abortReason(signal);
       if (attempt >= maxRetries || !isRetryable(error)) {
         throw error;
       }
       const delayMs = computeBackoffDelay(attempt, baseDelayMs, maxDelayMs, jitter);
       onRetry({ attempt: attempt + 1, maxRetries, delayMs, error });
-      await sleep(delayMs);
+      await abortableSleep(delayMs, sleep, signal);
     }
   }
   // Unreachable: the loop either returns or throws, but TS needs a terminator.

--- a/sdk/src/types.ts
+++ b/sdk/src/types.ts
@@ -117,6 +117,17 @@ export interface BridgeConfig {
    * ```
    */
   hooks?: ObservabilityHooks;
+
+  /**
+   * Network base reserve in stroops, used by
+   * {@link OnboardingBridgeSDK.estimateCost} to compute the minimum account
+   * balance.
+   *
+   * Both the public and test networks currently use 0.5 XLM (5,000,000
+   * stroops), which is the default. Override it if you run against a network
+   * configured with a different reserve.
+   */
+  baseReserveStroops?: number | string;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What problem does this solve?

Four issues across the Rust indexer and the TypeScript SDK.

**#295 — duplicate on-chain events get new random ids.** `parse_contract_event()` in `indexer/src/poller.rs` built the primary key with `uuid::Uuid::new_v4()`, so the same on-chain event parsed to a different `id` every time. `Database::insert_event` dedups with `INSERT OR IGNORE` on that `id`, so the dedup never actually fired: re-polling a range after a poller restart inserted duplicate rows and re-delivered every webhook.

**#285 — `estimateCost()` hardcoded `minBalance`.** `sdk/src/bridge.ts` returned a fixed `'10000000'` stroops regardless of how many subentries the account held, so the figure was wrong for any account with trustlines, offers, data entries, or extra signers.

**#283 — no way to cancel an in-flight retry loop.** With `maxRetries: 3` and `maxDelayMs: 30000`, `withRetry` could sleep for tens of seconds with no way for a caller — an unmounting UI component, say — to abort.

**#284 — `API_REFERENCE.md` was missing whole modules.** The caching, event-subscription, and observability modules were exported from `sdk/src/index.ts` but appeared nowhere in the reference, as were `estimateCost`/`CostEstimate`, the retry utilities, and the exported constants.

## How does it solve it?

**#295** — The event id is now derived from `(ledger, tx_hash, index of the event within its tx)`, so parsing the same raw event always yields the same key and `INSERT OR IGNORE` deduplicates as intended. The poller tracks each event's position within its transaction while iterating a batch.

Deterministic ids alone did not fix the duplicate webhooks, though: `poll_once` called `queue_webhook_deliveries` unconditionally, so a duplicate event still queued another delivery even when the row insert was ignored. `insert_event` now returns `bool` — whether a row was actually written — and the poller only fans out webhooks when it was.

**#285** — `estimateCost` reads the source account's `AccountEntry` via `getLedgerEntries` (Soroban RPC's `getAccount` only exposes the account id and sequence number) and applies the Stellar formula `(2 + numSubentries) * baseReserve`. The base reserve defaults to the new exported `BASE_RESERVE_STROOPS` (5,000,000 = 0.5 XLM, the current value on both public and test networks) and is overridable per instance with the new `BridgeConfig.baseReserveStroops`. An account that does not exist on-chain yet reports zero subentries.

**#283** — `RetryOptions` gained an optional `signal?: AbortSignal`. It is checked before the first attempt, between attempts, and **during** the backoff delay, so an abort takes effect immediately rather than after the current sleep elapses. The promise rejects with the signal's `reason`, which keeps a cancellation distinguishable from an RPC failure. The default sleep clears its own timer on abort so a cancelled retry leaves nothing pending on the event loop.

**#284** — Added reference sections for `CachedContractClient`, `InMemoryCache`, `EventSubscriber`, the retry utilities, the observability helpers, `estimateCost`/`CostEstimate`, the bridge event payloads, and the exported constants, each with a usage example, plus interface tables for `CacheOptions`, `ICacheProvider`, `RetryOptions`, `RpcRetryOptions`, `RetryAttempt`, `ObservabilityHooks`, `OpenTelemetryHooksOptions`, and `EventSubscriberConfig`, and a type-alias table covering `CacheKey`, `BatchProgressCallback`, and the event types. All signatures were read from the source rather than inferred. The new `signal` option from #283 is documented under a "Cancelling Retries" section. Two pre-existing inaccuracies are corrected along the way: `batchFundCAddresses` actually returns `TransactionResult[]` and accepts an `onProgress` callback, and `BridgeConfig` has `hooks`.

## Changes you should know about

Two things outside the four issues were prerequisites rather than choices, so flagging them explicitly:

**The SDK did not type-check on `main`.** `npx tsc --noEmit` failed with 8 errors — `FundCTimelockedOptions` imported three times in one block, two calls to a non-existent `this.toScVals` (the module-level `toScVals` is already imported and used elsewhere), and a missing `nativeToScVal` import in `cachedBridge.ts`. These broke the `bridge.test.ts` and `cachedBridge.test.ts` suites at compile time, so no test touching `bridge.ts` could run — including the one #285 asks for. Fixed here so the new tests are actually executable. This is what all six red SDK jobs on `main` are failing on.

With those suites compiling again, three `upgrade` tests surfaced as failing. They assert `.rejects.toThrow()`, but `upgrade` is a mutating method and the SDK documents that mutating methods return a `TransactionResult` and never throw. They are rewritten to the pattern the neighbouring `reclaimTokens` test already uses (`result.status === 'failed'` plus an `error` match), preserving their intent that validation happens before any RPC call.

**The indexer crate could not be built at all.** It sits outside the root Cargo workspace, which only lists `contracts/onboarding-bridge`, so `cargo build`/`cargo test` in `indexer/` failed with *"current package believes it's in a workspace when it's not"*. Declaring an empty `[workspace]` table in `indexer/Cargo.toml` makes it its own workspace root, which is the prerequisite for running the #295 tests. `indexer/Cargo.lock` is added to the existing "Lock files for sub-packages" section of `.gitignore`. Root workspace behaviour is unchanged.

## Tests

New tests, all passing:

- `indexer/src/poller.rs` — parsing the same raw event twice yields the same id; events at different positions in a transaction get distinct ids; a missing `txHash` still produces a deterministic id.
- `indexer/src/db.rs` — `insert_event` ignores a repeated id; stores distinct ids separately; reports whether the row was new; a duplicate event does not queue another webhook delivery.
- `sdk/src/__tests__/retry.test.ts` — an already-aborted signal skips the operation entirely; an abort between attempts stops the loop; a 30s backoff is interrupted rather than waited out; the rejection carries the abort reason; unaborted retries are unaffected.
- `sdk/src/__tests__/bridge.test.ts` — `estimateCost` with a mocked account at 0, 1, 2, 3, and 5 subentries, a non-existent account, and a custom `baseReserveStroops`, plus a check that the simulated fees still come through.

## Verification

| Command | Result |
|---|---|
| `cd indexer && cargo test` | 7 passed, 0 failed |
| `cd indexer && cargo clippy --all-targets -- -D warnings` | only 2 pre-existing `type_complexity` errors in untouched `db.rs` code |
| `cd indexer && cargo fmt --check` | all remaining diffs are pre-existing; the added code is rustfmt-clean |
| `cd sdk && npx tsc --noEmit` | clean (was 8 errors on `main`) |
| `cd sdk && npm run lint` | clean, also with `--max-warnings=0` |
| `cd sdk && npm run build` | clean |
| `cd sdk && npm test` | 244 passed, 0 failed, 6/6 suites (was 93 passed with 2 suites failing to compile) |
| `node scripts/check-migration-sdk-docs.js` | passes |
| `npx typedoc` | 0 errors; the `estimateCost` `@param` warning is gone |

## Pre-existing failures not addressed

CI is red on `main` — all 11 jobs. This branch turns the six SDK jobs green. The remaining five are Rust-side and untouched here:

- **Soroban Contract** / **Contract Compatibility** — `cargo build -p onboarding-bridge` fails with 8 errors in the contract crate (`E0081`, duplicate enum discriminant).
- **Format & Lint** — `cargo fmt --all --check` reports diffs in `contracts/onboarding-bridge` test files.
- **Dependency Audit** — `cargo audit --deny warnings` fails on the workspace lockfile.

All of these live in `contracts/` or the root lockfile, which this PR does not touch. They are out of scope for these four issues.

## Checklist

- [x] Tests pass locally
- [x] Code follows style guide
- [x] Commits follow Conventional Commits
- [x] Documentation updated
- [x] No unrelated changes

Closes #283
Closes #284
Closes #285
Closes #295
