### PR TITLE
fix(relayer): health server, graceful shutdown, lag metric, dead-lett…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       REDIS_URL: redis://redis:6379
       STELLAR_RPC_URL: http://soroban:8000/soroban/rpc
       NETWORK_PASSPHRASE: Standalone Network ; February 2017
+      HEALTH_PORT: '3000'
     env_file:
       - .env
     depends_on:
@@ -30,6 +31,12 @@ services:
       soroban:
         condition: service_healthy
     command: npx ts-node-dev --respawn --transpile-only relayer/index.ts
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sf http://localhost:3000/health | grep -q "\"status\":\"ok\""']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
 
   # -------------------------------------------------------------------
   # Indexer API — Rust event indexer and webhook delivery worker

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 
 [dependencies]
 tokio = { version = "1", features = ["full"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 reqwest = { version = "0.11", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -10,6 +10,7 @@ use axum::{
     Json, Router,
 };
 use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 use tower_http::cors::CorsLayer;
 use tracing_subscriber::EnvFilter;
 
@@ -43,14 +44,21 @@ async fn main() {
         webhook_client: reqwest::Client::new(),
     });
 
+    // Cancellation token shared across all background tasks. When triggered,
+    // the poller and webhook worker finish their current iteration and exit
+    // cleanly before the axum server drains in-flight HTTP requests.
+    let token = CancellationToken::new();
+
     let poller_state = Arc::clone(&state);
-    tokio::spawn(async move {
-        poller::run_poller(poller_state).await;
+    let poller_token = token.clone();
+    let poller_handle = tokio::spawn(async move {
+        poller::run_poller(poller_state, poller_token).await;
     });
 
     let webhook_state = Arc::clone(&state);
-    tokio::spawn(async move {
-        webhook::run_delivery_worker(webhook_state).await;
+    let webhook_token = token.clone();
+    let webhook_handle = tokio::spawn(async move {
+        webhook::run_delivery_worker(webhook_state, webhook_token).await;
     });
 
     let app = Router::new()
@@ -67,7 +75,38 @@ async fn main() {
 
     tracing::info!("Indexer listening on {}", listen_addr);
     let listener = tokio::net::TcpListener::bind(&listen_addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+
+    // Shutdown signal: wait for SIGTERM or SIGINT, then cancel background tasks.
+    let shutdown_token = token.clone();
+    let shutdown_signal = async move {
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+            let mut sigint = signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
+            tokio::select! {
+                _ = sigterm.recv() => tracing::info!("Received SIGTERM"),
+                _ = sigint.recv()  => tracing::info!("Received SIGINT"),
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            tokio::signal::ctrl_c().await.expect("failed to listen for ctrl-c");
+            tracing::info!("Received ctrl-c");
+        }
+
+        // Signal background tasks to stop after their current iteration.
+        shutdown_token.cancel();
+    };
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal)
+        .await
+        .unwrap();
+
+    // Wait for background tasks to finish their current iteration.
+    let _ = tokio::join!(poller_handle, webhook_handle);
+    tracing::info!("Indexer shut down cleanly");
 }
 
 async fn health() -> &'static str {

--- a/relayer/index.ts
+++ b/relayer/index.ts
@@ -13,6 +13,7 @@
  */
 
 import * as crypto from 'crypto';
+import * as http from 'http';
 import { Keypair } from '@stellar/stellar-sdk';
 import { OnboardingBridgeSDK } from '../sdk/src/bridge';
 import { CrossChainFundOptions, RelayerSig } from '../sdk/src/types';
@@ -61,6 +62,68 @@ export interface RelayerServiceConfig {
   threshold: number;
   /** Chain listeners to watch. */
   listeners: ChainListener[];
+}
+
+// ---------------------------------------------------------------------------
+// Dead-letter queue — retains events that failed the threshold check
+// ---------------------------------------------------------------------------
+
+/** A BridgeEvent that could not be submitted due to insufficient signers. */
+export interface DeadLetterEntry {
+  event: BridgeEvent;
+  /** ISO timestamp when the entry was added. */
+  enqueuedAt: string;
+  /** How many signers were available vs how many were required. */
+  availableSigners: number;
+  requiredSigners: number;
+}
+
+/**
+ * In-memory dead-letter store for under-threshold events.
+ * Replace with a persistent store (e.g. Redis, SQLite) in production.
+ */
+export class DeadLetterQueue {
+  private entries: DeadLetterEntry[] = [];
+
+  enqueue(event: BridgeEvent, available: number, required: number): void {
+    this.entries.push({
+      event,
+      enqueuedAt: new Date().toISOString(),
+      availableSigners: available,
+      requiredSigners: required,
+    });
+    console.warn(
+      `[relayer] dead-letter: chain=${event.chainId} tx=${event.txHash} ` +
+        `signers=${available}/${required} — stored for retry`,
+    );
+  }
+
+  /** Return all queued entries (for inspection / retry). */
+  all(): DeadLetterEntry[] {
+    return [...this.entries];
+  }
+
+  /** Remove a specific entry by tx-hash + chainId after a successful retry. */
+  remove(chainId: number, txHash: string): void {
+    this.entries = this.entries.filter(
+      (e) => !(e.event.chainId === chainId && e.event.txHash === txHash),
+    );
+  }
+
+  size(): number {
+    return this.entries.length;
+  }
+}
+
+/** Snapshot of relayer liveness reported by GET /health. */
+export interface HealthStatus {
+  status: 'ok';
+  uptime_seconds: number;
+  threshold: number;
+  node_count: number;
+  /** Last successfully submitted event per chain (chainId → ISO timestamp). */
+  last_event_per_chain: Record<string, string>;
+  dead_letter_queue_size: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,6 +222,9 @@ export class RelayerService {
   private submitterKeypair: ReturnType<typeof Keypair.fromSecret>;
   private config: RelayerServiceConfig;
   private nonces = new NonceStore();
+  private startedAt = Date.now();
+  private lastEventPerChain: Map<number, string> = new Map();
+  readonly dlq = new DeadLetterQueue();
 
   constructor(config: RelayerServiceConfig) {
     this.config = config;
@@ -184,6 +250,21 @@ export class RelayerService {
     console.log('[relayer] stopped');
   }
 
+  healthStatus(): HealthStatus {
+    const last_event_per_chain: Record<string, string> = {};
+    for (const [chainId, ts] of this.lastEventPerChain) {
+      last_event_per_chain[String(chainId)] = ts;
+    }
+    return {
+      status: 'ok',
+      uptime_seconds: Math.floor((Date.now() - this.startedAt) / 1000),
+      threshold: this.config.threshold,
+      node_count: this.config.nodes.length,
+      last_event_per_chain,
+      dead_letter_queue_size: this.dlq.size(),
+    };
+  }
+
   private async handleEvent(event: BridgeEvent): Promise<void> {
     if (this.nonces.has(event.chainId, event.txHash)) {
       console.log(`[relayer] duplicate event ignored: chain=${event.chainId} tx=${event.txHash}`);
@@ -200,7 +281,8 @@ export class RelayerService {
     );
 
     if (sigs.length < this.config.threshold) {
-      console.warn(`[relayer] not enough signers: have ${sigs.length}, need ${this.config.threshold}`);
+      // Persist to dead-letter queue instead of silently dropping
+      this.dlq.enqueue(event, sigs.length, this.config.threshold);
       return;
     }
 
@@ -223,6 +305,7 @@ export class RelayerService {
 
       // Mark nonce only after successful submission
       this.nonces.mark(event.chainId, event.txHash);
+      this.lastEventPerChain.set(event.chainId, new Date().toISOString());
       console.log(`[relayer] submitted tx=${result.hash} for chain=${event.chainId} src-tx=${event.txHash}`);
     } catch (err: any) {
       console.error(`[relayer] unexpected error: ${err.message}`);
@@ -447,6 +530,50 @@ export class SolanaChainListener implements ChainListener {
 }
 
 // ---------------------------------------------------------------------------
+// HTTP health server
+// ---------------------------------------------------------------------------
+
+/**
+ * Start a minimal HTTP server on `port` that exposes:
+ *   GET /health  — liveness + basic status (200 JSON)
+ *   GET /health/dead-letters  — dump of the dead-letter queue (200 JSON)
+ *
+ * Returns the server instance so callers can call `.close()` on shutdown.
+ */
+export function startHealthServer(service: RelayerService, port: number): http.Server {
+  const server = http.createServer((req, res) => {
+    if (req.method !== 'GET') {
+      res.writeHead(405);
+      res.end('Method Not Allowed');
+      return;
+    }
+
+    if (req.url === '/health') {
+      const body = JSON.stringify(service.healthStatus());
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    if (req.url === '/health/dead-letters') {
+      const body = JSON.stringify({ entries: service.dlq.all() });
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(body);
+      return;
+    }
+
+    res.writeHead(404);
+    res.end('Not Found');
+  });
+
+  server.listen(port, () => {
+    console.log(`[relayer] health server listening on :${port}`);
+  });
+
+  return server;
+}
+
+// ---------------------------------------------------------------------------
 // Lightweight self-tests (run with: npx ts-node relayer/index.ts --self-test)
 // ---------------------------------------------------------------------------
 
@@ -491,6 +618,9 @@ function makeTestService(params: {
   };
   (service as any).submitterKeypair = {};
   (service as any).nonces = new NonceStore();
+  (service as any).startedAt = Date.now();
+  (service as any).lastEventPerChain = new Map();
+  (service as any).dlq = new DeadLetterQueue();
   return service;
 }
 
@@ -543,6 +673,42 @@ export async function test_below_threshold_short_circuits_before_sdk_call(): Pro
   await (service as any).handleEvent(makeTestEvent());
 
   assertEqual(calls, 0, 'below-threshold event should not call SDK');
+}
+
+export async function test_below_threshold_event_is_stored_in_dlq(): Promise<void> {
+  const service = makeTestService({
+    threshold: 3,
+    nodes: [{ privateKey: '01'.repeat(32) }, { privateKey: '02'.repeat(32) }],
+  });
+
+  const event = makeTestEvent({ chainId: 42, txHash: 'de'.repeat(32) });
+  await (service as any).handleEvent(event);
+
+  const entries = service.dlq.all();
+  assertEqual(entries.length, 1, 'under-threshold event must be stored in DLQ');
+  assertEqual(entries[0].event.txHash, event.txHash, 'DLQ entry must preserve the original txHash');
+  assertEqual(entries[0].availableSigners, 2, 'DLQ entry must record available signer count');
+  assertEqual(entries[0].requiredSigners, 3, 'DLQ entry must record required signer count');
+}
+
+export async function test_health_server_responds_200(): Promise<void> {
+  const service = makeTestService();
+  const port = 19876;
+  const server = startHealthServer(service, port);
+
+  await new Promise<void>((resolve) => server.once('listening', resolve));
+
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/health`);
+    assertEqual(response.status, 200, '/health must respond 200');
+    const body: any = await response.json();
+    assertEqual(body.status, 'ok', 'health body.status must be "ok"');
+    assert(typeof body.threshold === 'number', 'health body must include threshold');
+    assert(typeof body.node_count === 'number', 'health body must include node_count');
+    assert(typeof body.dead_letter_queue_size === 'number', 'health body must include dead_letter_queue_size');
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
 }
 
 function word(hex: string): string {
@@ -709,6 +875,8 @@ async function runRelayerSelfTests(): Promise<void> {
   await test_duplicate_event_ignored_via_nonce_store();
   await test_nonce_marked_only_after_successful_submission();
   await test_below_threshold_short_circuits_before_sdk_call();
+  await test_below_threshold_event_is_stored_in_dlq();
+  await test_health_server_responds_200();
   test_eth_listener_decodes_realistic_abi_log_fixture();
   test_eth_listener_rejects_malformed_truncated_log_payload();
   test_solana_listener_rejects_bad_log_lines();
@@ -752,9 +920,17 @@ if (require.main === module) {
       ],
     });
 
+    const healthPort = parseInt(process.env.HEALTH_PORT ?? '3000', 10);
+    const healthServer = startHealthServer(service, healthPort);
+
     service.start();
 
-    process.on('SIGINT', () => { service.stop(); process.exit(0); });
-    process.on('SIGTERM', () => { service.stop(); process.exit(0); });
+    const shutdown = () => {
+      service.stop();
+      healthServer.close(() => process.exit(0));
+    };
+
+    process.on('SIGINT', shutdown);
+    process.on('SIGTERM', shutdown);
   }
 }


### PR DESCRIPTION
Summary
  
  Four operational gaps fixed across the relayer and indexer off-chain services.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Issue 1 — Relayer HTTP health server (relayer/index.ts, docker-compose.yml)
  
  The relayer service had ports: ['3000:3000'] mapped in docker-compose but nothing listening on that port. Added a minimal Node.js http.Server (no new dependencies) that exposes:
  
  - GET /health — 200 JSON with status, uptime_seconds, threshold, node_count, last_event_per_chain, and dead_letter_queue_size
  - GET /health/dead-letters — 200 JSON dump of the dead-letter queue contents
  
  Updated docker-compose.yml to add a healthcheck on the api service using curl -sf http://localhost:3000/health.
  
  Added test_health_server_responds_200 self-test asserting the endpoint returns HTTP 200 with a valid JSON body.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Issue 2 — Indexer graceful shutdown (indexer/src/main.rs, indexer/Cargo.toml)
  
  tokio::spawn calls for the poller and webhook worker had no cancellation mechanism, and axum::serve had no .with_graceful_shutdown(...). A SIGTERM mid-poll could kill the process while a DB write was in
  flight.
  
  - Added a CancellationToken (via tokio-util) shared across the poller, webhook worker, and the shutdown signal handler.
  - run_poller and run_delivery_worker now accept a CancellationToken and check it between iterations with tokio::select!, so each loop completes its current DB write before exiting.
  - axum::serve is now called with .with_graceful_shutdown(...) that triggers on SIGTERM or SIGINT.
  - tokio::join! waits for both background tasks to finish before the process exits.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Issue 3 — Indexer lag metric (indexer/src/db.rs, indexer/src/poller.rs, indexer/src/main.rs)
  
  GET /api/stats reported last_indexed_ledger but gave operators no way to tell if the poller was keeping up with the chain.
  
  - Added fetch_latest_ledger(rpc_url) in poller.rs that calls getLatestLedger on the Soroban RPC.
  - AppState now holds the latest known ledger sequence in an AtomicI64 updated after every successful poll.
  - get_stats() in db.rs now accepts the live ledger value and computes indexer_lag_ledgers = latest_ledger - last_indexed_ledger, exposed in the /api/stats response.
  - Added a unit test asserting lag = chain_head - last_indexed given known values.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Issue 4 — Relayer dead-letter queue (relayer/index.ts)
  
  Under-threshold events (where sigs.length < threshold) were silently dropped with a single console.warn. Real cross-chain deposits could be lost with no operator visibility.
  
  - Added DeadLetterQueue class that persists failed events in memory with metadata: enqueuedAt, availableSigners, requiredSigners.
  - handleEvent now calls dlq.enqueue() instead of returning silently.
  - The DLQ is exposed via GET /health/dead-letters (see Issue 1) so operators can inspect and manually retry dropped events.
  - Added test_below_threshold_event_is_stored_in_dlq self-test asserting the entry is retained with correct signer counts.
  
  ────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  What was tested
  
  - All existing relayer self-tests continue to pass (--self-test flag).
  - New self-tests: test_health_server_responds_200, test_below_threshold_event_is_stored_in_dlq.
  - Indexer builds cleanly with cargo build after adding tokio-util.
  - Lag unit test covers the arithmetic: lag = head - last_indexed.
  
  Files changed
  
  - relayer/index.ts
  - docker-compose.yml
  - indexer/src/main.rs
  - indexer/src/poller.rs
  - indexer/src/db.rs
  - indexer/Cargo.toml

closes #305, 
closes #306 ,
closes #307,
closes #309,