### PR TITLE
test(sdk): add edge case tests for scval encoding

### DIFF
--- a/sdk/src/__tests__/scval-encoding.test.ts
+++ b/sdk/src/__tests__/scval-encoding.test.ts
@@ -67,4 +67,29 @@ describe('toScVals / toSingleScVal encoding', () => {
     expect(scValToNative(results[3])).toBe(true);
     expect(scValToNative(results[4])).toBe('symbol');
   });
+
+  it('encodes negative numbers as i128', () => {
+    const result = toSingleScVal(-42);
+    expect(scValToNative(result).toString()).toBe('-42');
+  });
+
+  it('encodes zero as i128', () => {
+    const result = toSingleScVal(0);
+    expect(scValToNative(result).toString()).toBe('0');
+  });
+
+  it('encodes empty string as Symbol', () => {
+    const result = toSingleScVal('');
+    expect(scValToNative(result)).toBe('');
+  });
+
+  it('encodes nested arrays correctly', () => {
+    const result = toSingleScVal([['nested', 'array'], 'top-level']);
+    const native = scValToNative(result) as any[];
+    expect(native).toHaveLength(2);
+    expect(native[0]).toHaveLength(2);
+    expect(native[0][0]).toBe('nested');
+    expect(native[0][1]).toBe('array');
+    expect(native[1]).toBe('top-level');
+  });
 });


### PR DESCRIPTION
**Enhancement: Add edge case tests for scval encoding**

This PR adds additional test coverage for the [toSingleScVal](cci:1://file:///c:/Users/BILLYBASZ/C-Address-Onboarding-Bridge--Contract/sdk/src/encoding.ts:26:0-62:1) and [toScVals](cci:1://file:///c:/Users/BILLYBASZ/C-Address-Onboarding-Bridge--Contract/sdk/src/encoding.ts:64:0-86:1) encoding functions in [encoding.ts](cci:7://file:///c:/Users/BILLYBASZ/C-Address-Onboarding-Bridge--Contract/sdk/src/encoding.ts:0:0-0:0).

**Changes:**
- Added test for negative numbers as i128
- Added test for zero as i128
- Added test for empty string as Symbol
- Added test for nested arrays

**Note:** The main fix for issue #286 (exporting encoding helpers from [encoding.ts](cci:7://file:///c:/Users/BILLYBASZ/C-Address-Onboarding-Bridge--Contract/sdk/src/encoding.ts:0:0-0:0) instead of having duplicate implementations in the test) is already present in the main branch. This PR adds supplementary test coverage for edge cases to further strengthen the test suite.

Closes #286