### PR TITLE
Fix/ci and benchmark compile errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,16 +70,28 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown,wasm32v1-none
 
       - name: Cache cargo dependencies
         uses: Swatinem/rust-cache@v2
+
+      # Fast fail on type errors (including the test target) before paying for
+      # a full release build. A red main here is exactly what this job exists
+      # to catch — see the "Soroban Contract" checklist in the CI issue.
+      - name: cargo check
+        run: cargo check -p onboarding-bridge --all-targets --features testutils
 
       - name: Build contract
         run: cargo build -p onboarding-bridge --release
 
       - name: Build WASM (release)
         run: cargo build -p onboarding-bridge --release --target wasm32-unknown-unknown
+
+      # wasm32v1-none is the current canonical Soroban deployment target; build
+      # it too so CI actually exercises the artifact that gets deployed, not
+      # just the legacy wasm32-unknown-unknown target the hash below is pinned to.
+      - name: Build WASM (wasm32v1-none)
+        run: cargo build -p onboarding-bridge --release --target wasm32v1-none
 
       - name: Verify WASM Hash
         run: |
@@ -212,6 +224,40 @@ jobs:
 
       - name: Run contract tests
         run: cargo test -p onboarding-bridge --features testutils
+
+  indexer:
+    name: Indexer
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: indexer
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: indexer
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: cargo check
+        run: cargo check --all-targets
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Run tests
+        run: cargo test
 
   sdk:
     name: TypeScript SDK

--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -337,17 +337,8 @@ fn bench_fund_c_address_crosschain() {
     let nonce_hash: BytesN<32> = env.crypto().sha256(&nonce_pre).into();
 
     let mut addr_buf = [0u8; 64];
-    let tstr = target.to_string();
-    let tlen = tstr.len();
-    tstr.copy_into_slice(&mut addr_buf[..tlen]);
-    let target_hash: BytesN<32> =
-        env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..tlen])).into();
-
-    let astr = token_id.to_string();
-    let alen = astr.len();
-    astr.copy_into_slice(&mut addr_buf[..alen]);
-    let asset_hash: BytesN<32> =
-        env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..alen])).into();
+    let target_hash = hash_address(&env, &mut addr_buf, &target);
+    let asset_hash = hash_address(&env, &mut addr_buf, &token_id);
 
     let mut payload = Bytes::new(&env);
     payload.extend_from_array(&chain_id.to_be_bytes());
@@ -374,6 +365,17 @@ fn bench_fund_c_address_crosschain() {
     });
 
     let _ = admin;
+}
+
+/// Copies a Soroban `Address`'s strkey into `buf` and returns its SHA-256 hash,
+/// matching the contract's on-chain address-hashing scheme.
+fn hash_address(env: &Env, buf: &mut [u8; 64], addr: &Address) -> BytesN<32> {
+    let s = addr.to_string();
+    let len = s.len() as usize;
+    s.copy_into_slice(&mut buf[..len]);
+    env.crypto()
+        .sha256(&Bytes::from_slice(env, &buf[..len]))
+        .into()
 }
 
 // ── commit_fund / reveal_fund ─────────────────────────────────────────────────
@@ -484,20 +486,9 @@ fn bench_execute_meta_fund() {
     let domain = Bytes::from_slice(&env, b"meta_fund");
     let mut addr_buf = [0u8; 64];
 
-    let src_str = source.to_string();
-    let slen = src_str.len();
-    src_str.copy_into_slice(&mut addr_buf[..slen]);
-    let src_hash: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..slen])).into();
-
-    let tgt_str = target.to_string();
-    let tlen = tgt_str.len();
-    tgt_str.copy_into_slice(&mut addr_buf[..tlen]);
-    let tgt_hash: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..tlen])).into();
-
-    let ast_str = token_id.to_string();
-    let alen = ast_str.len();
-    ast_str.copy_into_slice(&mut addr_buf[..alen]);
-    let ast_hash: BytesN<32> = env.crypto().sha256(&Bytes::from_slice(&env, &addr_buf[..alen])).into();
+    let src_hash = hash_address(&env, &mut addr_buf, &source);
+    let tgt_hash = hash_address(&env, &mut addr_buf, &target);
+    let ast_hash = hash_address(&env, &mut addr_buf, &token_id);
 
     let nonce = 1u64;
     let deadline = env.ledger().timestamp() + 86_400;

--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -13,11 +13,12 @@
 extern crate std;
 use std::{format, println};
 
+use crate::tests::swap_pool_contract::{SwapPool, SwapPoolClient};
 use crate::OnboardingBridge;
 
 use soroban_sdk::{
     contract, contractimpl, contracttype,
-    testutils::Address as _,
+    testutils::{Address as _, Ledger as _},
     Address, Bytes, BytesN, Env, Vec,
 };
 
@@ -443,8 +444,7 @@ fn bench_fund_c_address_with_swap() {
 
     // Deploy a minimal swap pool.
     let pool_id = env.register(SwapPool, ());
-    crate::benchmarks::SwapPoolClient::new(&env, &pool_id)
-        .initialize(&src_token_id, &dst_token_id, &1i128);
+    SwapPoolClient::new(&env, &pool_id).initialize(&src_token_id, &dst_token_id, &1i128);
 
     // Fund the swap pool with destination tokens.
     mint(&env, &dst_token_id, &pool_id, 10_000i128);
@@ -556,40 +556,4 @@ fn bench_tiered_fee_lookup() {
     });
 
     let _ = (admin, fee_collector);
-}
-
-// ═══ Minimal swap pool for bench_fund_c_address_with_swap ═════════════════════
-
-#[contracttype]
-pub enum SwapPoolKey {
-    InputToken,
-    OutputToken,
-    Rate,
-}
-
-#[contract]
-pub struct SwapPool;
-
-#[contractimpl]
-impl SwapPool {
-    pub fn initialize(e: Env, input_token: Address, output_token: Address, rate: i128) {
-        e.storage().instance().set(&SwapPoolKey::InputToken, &input_token);
-        e.storage().instance().set(&SwapPoolKey::OutputToken, &output_token);
-        e.storage().instance().set(&SwapPoolKey::Rate, &rate);
-    }
-
-    pub fn swap(e: Env, min_amount_out: i128, to: Address) -> i128 {
-        let rate: i128 = e.storage().instance().get(&SwapPoolKey::Rate).unwrap();
-        let input_token: Address = e.storage().instance().get(&SwapPoolKey::InputToken).unwrap();
-        let input_client = soroban_sdk::token::Client::new(&e, &input_token);
-        let amount_in = input_client.balance(&e.current_contract_address());
-        let amount_out = amount_in.checked_mul(rate).unwrap_or(0);
-        if amount_out < min_amount_out {
-            return amount_out;
-        }
-        let output_token: Address = e.storage().instance().get(&SwapPoolKey::OutputToken).unwrap();
-        let output_client = soroban_sdk::token::Client::new(&e, &output_token);
-        output_client.transfer(&e.current_contract_address(), &to, &amount_out);
-        amount_out
-    }
 }

--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -16,6 +16,7 @@ use std::{format, println};
 use crate::tests::swap_pool_contract::{SwapPool, SwapPoolClient};
 use crate::OnboardingBridge;
 
+use ed25519_dalek::{Signer, SigningKey};
 use soroban_sdk::{
     contract, contractimpl, contracttype,
     testutils::{Address as _, Ledger as _},
@@ -314,7 +315,8 @@ fn bench_fund_c_address_crosschain() {
 
     // Register a single relayer and set threshold to 1.
     let relayer_secret: [u8; 32] = [1u8; 32];
-    let relayer_pubkey = BytesN::from_array(&env, &[1u8; 32]);
+    let relayer_signing_key = SigningKey::from_bytes(&relayer_secret);
+    let relayer_pubkey = BytesN::from_array(&env, relayer_signing_key.verifying_key().as_bytes());
     bridge.add_relayer(&relayer_pubkey);
     bridge.set_relayer_threshold(&1u32);
 
@@ -349,8 +351,8 @@ fn bench_fund_c_address_crosschain() {
     payload.append(&Bytes::from(nonce_hash));
     let payload_hash: BytesN<32> = env.crypto().sha256(&payload).into();
 
-    // Create a relayer signature using the env's Ed25519.
-    let sig = env.crypto().ed25519_sign(&relayer_secret, &payload_hash);
+    // Create a relayer signature off-host (the host `Crypto` interface only verifies).
+    let sig = ed25519_sign_payload(&env, &relayer_signing_key, &payload_hash);
 
     let sigs = Vec::from_array(
         &env,
@@ -365,6 +367,27 @@ fn bench_fund_c_address_crosschain() {
     });
 
     let _ = admin;
+}
+
+// ── ed25519 signing helper ─────────────────────────────────────────────────────
+//
+// The host `Crypto` interface only exposes signature *verification*; producing
+// a signature is something done off-host by whoever holds the secret key (a
+// relayer, a meta-tx sender). Benchmarks stand in for that off-host signer
+// using ed25519-dalek directly, mirroring the pattern already used in
+// `tests.rs` (see `make_relayer_sig` / `sign_meta_fund_payload`).
+fn ed25519_sign_payload(
+    env: &Env,
+    signing_key: &SigningKey,
+    payload_hash: &BytesN<32>,
+) -> BytesN<64> {
+    let hash_bytes: Bytes = payload_hash.clone().into();
+    let mut hash_arr = [0u8; 32];
+    for i in 0..32 {
+        hash_arr[i] = hash_bytes.get(i as u32).unwrap();
+    }
+    let sig = signing_key.sign(&hash_arr);
+    BytesN::from_array(env, &sig.to_bytes())
 }
 
 /// Copies a Soroban `Address`'s strkey into `buf` and returns its SHA-256 hash,
@@ -478,7 +501,8 @@ fn bench_execute_meta_fund() {
 
     // Generate a keypair and register it as the meta signer for source.
     let secret: [u8; 32] = [7u8; 32];
-    let pubkey = BytesN::from_array(&env, &[7u8; 32]);
+    let signing_key = SigningKey::from_bytes(&secret);
+    let pubkey = BytesN::from_array(&env, signing_key.verifying_key().as_bytes());
     bridge.register_meta_signer(&source, &pubkey);
 
     // Build the canonical meta-fund payload and sign it.
@@ -503,7 +527,7 @@ fn bench_execute_meta_fund() {
     payload.extend_from_array(&deadline.to_be_bytes());
     let payload_hash: BytesN<32> = env.crypto().sha256(&payload).into();
 
-    let signature = env.crypto().ed25519_sign(&secret, &payload_hash);
+    let signature = ed25519_sign_payload(&env, &signing_key, &payload_hash);
 
     let params = crate::MetaFundParams {
         source: source.clone(),

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1466,7 +1466,7 @@ impl TestToken {
     }
 }
 
-mod swap_pool_contract {
+pub(crate) mod swap_pool_contract {
     use super::*;
 
     #[contracttype]


### PR DESCRIPTION
Closes #405 
Closes #406 
Closes #407 
Closes #408 

SUMMARY
1. ci: add contract check/build/test gate and cover the indexer crate
  Added cargo check as a fast-fail step to the existing "Soroban Contract" CI job, added a wasm32v1-none build (the real Soroban deployment
  target) alongside the existing wasm32-unknown-unknown build, and added a whole new indexer job (check/build/test/clippy/fmt) since the indexer
  crate had no CI coverage at all. Clippy/fmt and Swatinem caching were already present in the existing lint job, so those parts were already
  satisfied. "Required for merge" is a GitHub branch-protection setting, not something a workflow file can express — my token doesn't have admin
  rights on the repo to set it via API, so a repo admin needs to enable it in Settings → Branches once this merges.

  2. fix: dedupe #[contractimpl] collision between benchmarks' SwapPool and BenchToken
  The real collision was between benchmarks.rs's own BenchToken::initialize and SwapPool::initialize (both #[contractimpl]-generated items land in
  the enclosing module's namespace) — not against lib.rs as the original bug report guessed. tests.rs already solved this exact problem by
  nesting its SwapPool in a private submodule; I reused that (via pub(crate)) instead of keeping a second copy. Also added the missing
  testutils::Ledger import, a separate compile error in the same file blocking the whole test binary.

  3. fix: cast soroban String len to usize before slice indexing in benchmarks
  Added a hash_address() helper that does the u32 → usize cast once, replacing all 5 duplicated call sites (10 error sites) that were slicing [u8]
  with a u32 range.

  4. fix: sign benchmark payloads off-host with ed25519-dalek
  Replaced the nonexistent env.crypto().ed25519_sign(...) calls with off-host signing via ed25519-dalek (already a dev-dependency, matching the
  pattern tests.rs already uses). Also fixed the relayer/meta-signer pubkeys to be derived from the real signing key instead of hardcoded
  placeholder bytes that didn't correspond to any actual key — those would have produced signatures that fail verification even once the code
  compiled.