### PR TITLE
Fix/test suite compile and coverage

### DIFF
--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -13,6 +13,7 @@
 extern crate std;
 use std::{format, println};
 
+use crate::tests::{advance_ledger_sequence, advance_ledger_time};
 use crate::OnboardingBridge;
 
 use soroban_sdk::{
@@ -297,7 +298,7 @@ fn bench_claim_timelocked() {
     );
 
     // Advance past release_time so the claim succeeds.
-    env.ledger().set_timestamp(release_time + 1);
+    advance_ledger_time(&env, release_time + 1);
 
     measure(&env, "claim_timelocked", || {
         bridge.claim_timelocked(&id);
@@ -417,7 +418,7 @@ fn bench_reveal_fund() {
     let id = bridge.commit_fund(&user, &target, &token_id, &amount_hash, &deadline);
 
     // Advance past the minimum delay.
-    env.ledger().set_sequence_number(env.ledger().sequence() + crate::COMMIT_REVEAL_MIN_DELAY_LEDGERS + 1);
+    advance_ledger_sequence(&env, env.ledger().sequence() + crate::COMMIT_REVEAL_MIN_DELAY_LEDGERS + 1);
 
     measure(&env, "reveal_fund", || {
         bridge.reveal_fund(&id, &user, &target, &token_id, &amount, &nonce);

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -729,6 +729,154 @@ fn test_upgrade_non_admin_rejected() {
     bridge.upgrade(&wasm_hash, &None);
 }
 
+/********** Timelocked upgrade tests (execute_upgrade) **********/
+
+#[test]
+fn test_execute_upgrade_succeeds_at_timelock_boundary_and_clears_pending() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    // Uploading a real compiled wasm costs far more than the default test
+    // budget allows; lift the limit so the test exercises logic, not gas.
+    env.cost_estimate().budget().reset_unlimited();
+    let wasm_bytes = Bytes::from_slice(&env, V2_WASM);
+    let wasm_hash: BytesN<32> = env.deployer().upload_contract_wasm(wasm_bytes);
+
+    let executable_after_ledger = bridge.schedule_upgrade(&wasm_hash, &None);
+    assert_eq!(
+        bridge.query_pending_upgrade(),
+        Some(crate::PendingUpgrade {
+            new_wasm_hash: wasm_hash.clone(),
+            executable_after_ledger,
+        })
+    );
+
+    // Exactly at the boundary: docs specify `sequence >= scheduled + timelock`,
+    // so landing exactly on `executable_after_ledger` must already succeed.
+    advance_ledger_sequence(&env, executable_after_ledger);
+    bridge.execute_upgrade(&wasm_hash, &None);
+
+    // The pending record is cleared before the wasm swap, so a second
+    // execute now reports "not scheduled" rather than replaying the upgrade.
+    assert_eq!(bridge.query_pending_upgrade(), None);
+    assert_eq!(
+        bridge.try_execute_upgrade(&wasm_hash, &None),
+        Err(Ok(BridgeError::UpgradeNotScheduled))
+    );
+
+    assert_eq!(count_events_with_topic(&env, &bridge_id, "ContractUpgraded"), 1);
+}
+
+#[test]
+fn test_execute_upgrade_not_initialized_fails() {
+    let env = Env::default();
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    assert_eq!(
+        bridge.try_execute_upgrade(&BytesN::from_array(&env, &[0u8; 32]), &None),
+        Err(Ok(BridgeError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_execute_upgrade_not_scheduled_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    assert_eq!(
+        bridge.try_execute_upgrade(&BytesN::from_array(&env, &[1u8; 32]), &None),
+        Err(Ok(BridgeError::UpgradeNotScheduled))
+    );
+}
+
+#[test]
+fn test_execute_upgrade_hash_mismatch_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let scheduled_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let wrong_hash = BytesN::from_array(&env, &[2u8; 32]);
+    let executable_after_ledger = bridge.schedule_upgrade(&scheduled_hash, &None);
+    advance_ledger_sequence(&env, executable_after_ledger);
+
+    // Never reaches the wasm swap, so a synthetic (non-uploaded) hash is fine here.
+    assert_eq!(
+        bridge.try_execute_upgrade(&wrong_hash, &None),
+        Err(Ok(BridgeError::UpgradeHashMismatch))
+    );
+}
+
+#[test]
+fn test_execute_upgrade_before_timelock_elapses_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+    bridge.schedule_upgrade(&wasm_hash, &None);
+
+    // No ledgers have elapsed since scheduling.
+    assert_eq!(
+        bridge.try_execute_upgrade(&wasm_hash, &None),
+        Err(Ok(BridgeError::UpgradeTimelockActive))
+    );
+}
+
+#[test]
+fn test_execute_upgrade_one_ledger_before_boundary_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let executable_after_ledger = bridge.schedule_upgrade(&wasm_hash, &None);
+    advance_ledger_sequence(&env, executable_after_ledger - 1);
+
+    assert_eq!(
+        bridge.try_execute_upgrade(&wasm_hash, &None),
+        Err(Ok(BridgeError::UpgradeTimelockActive))
+    );
+}
+
+#[test]
+fn test_execute_upgrade_duplicate_nonce_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+    let executable_after_ledger = bridge.schedule_upgrade(&wasm_hash, &None);
+    advance_ledger_sequence(&env, executable_after_ledger);
+
+    // The admin's nonce is still 0; passing 1 must be rejected.
+    assert_eq!(
+        bridge.try_execute_upgrade(&wasm_hash, &Some(1u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
 // --------- Blocklist / Allowlist Tests ---------
 
 fn setup_bridge(env: &Env) -> (crate::OnboardingBridgeClient<'_>, Address, Address, Address) {

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -53,6 +53,23 @@ fn check_balance(env: &Env, token_id: &Address, addr: &Address) -> i128 {
     token.balance(addr)
 }
 
+/// Advances the ledger's timestamp to `timestamp`.
+///
+/// soroban-sdk 22 mutates ledger state through `testutils::Ledger` trait
+/// methods (`set_timestamp` / `set_sequence_number`) rather than inherent
+/// methods on `env.ledger()`. Centralizing the call here means the many
+/// time-dependent tests below (and the benchmarks) don't each need to
+/// import that trait or hand-roll the read-then-write.
+pub(crate) fn advance_ledger_time(env: &Env, timestamp: u64) {
+    env.ledger().set_timestamp(timestamp);
+}
+
+/// Advances the ledger's sequence number to `sequence`. See
+/// [`advance_ledger_time`] for why this indirection exists.
+pub(crate) fn advance_ledger_sequence(env: &Env, sequence: u32) {
+    env.ledger().set_sequence_number(sequence);
+}
+
 #[test]
 fn test_initialize() {
     let env = Env::default();
@@ -959,7 +976,7 @@ fn test_reclaim_cannot_drain_active_timelocks() {
 
     // Once claimed, the timelocked amount leaves the contract balance and is
     // no longer ring-fenced: freshly accidental tokens are reclaimable again.
-    env.ledger().set_timestamp(release_time + 1);
+    advance_ledger_time(&env, release_time + 1);
     bridge.claim_timelocked(&id);
     mint_tokens(&env, &token_id, &bridge.address, 50i128);
     bridge.reclaim_tokens(&token_id, &50i128, &destination, &None);
@@ -2677,7 +2694,7 @@ mod timelocked_tests {
             &None,
         );
 
-        env.ledger().set_timestamp(release_time + 1);
+        advance_ledger_time(&env, release_time + 1);
         bridge.claim_timelocked(&id);
 
         assert_eq!(check_balance(&env, &token_id, &target), 495i128);
@@ -2771,7 +2788,7 @@ mod timelocked_tests {
             &None,
         );
 
-        env.ledger().set_timestamp(release_time + 1);
+        advance_ledger_time(&env, release_time + 1);
         bridge.claim_timelocked(&id);
 
         assert_eq!(
@@ -2849,8 +2866,7 @@ mod commit_reveal_tests {
 
     /// Advances the ledger past the commit-reveal minimum delay.
     fn advance_past_min_delay(env: &Env) {
-        let seq = env.ledger().sequence();
-        env.ledger().set_sequence_number(seq + MIN_DELAY_LEDGERS);
+        advance_ledger_sequence(env, env.ledger().sequence() + MIN_DELAY_LEDGERS);
     }
 
     #[test]
@@ -4848,7 +4864,7 @@ fn test_daily_limit_resets_next_day() {
     );
 
     // Advance to the next UTC day (86 400 seconds later).
-    env.ledger().set_timestamp(env.ledger().timestamp() + 86_400);
+    advance_ledger_time(&env, env.ledger().timestamp() + 86_400);
 
     // After the day rolls over the limit should reset, allowing a fresh transfer.
     let target2 = Address::generate(&env);

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -2830,6 +2830,8 @@ mod timelocked_tests {
             &500i128,
             &release_time,
             &0u64,
+            &None,
+            &None,
         );
 
         assert_eq!(check_balance(&env, &loyalty_token_id, &user), 4i128);

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -4884,6 +4884,122 @@ fn test_extend_persistent_ttl_extends_asset_keys() {
     }
 }
 
+/********** extend_source_persistent_ttl tests **********/
+
+#[test]
+fn test_extend_source_persistent_ttl_extends_source_keys() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    bridge.set_source_daily_limit(&user, &token_id, &10_000i128, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    bridge.fund_c_address(
+        &user,
+        &Address::generate(&env),
+        &token_id,
+        &500i128,
+        &Some(0u64),
+        &None,
+    );
+
+    let seq = env.ledger().sequence();
+    bridge.verify_auth_entry(&user, &0u64, &0u32, &(seq + 100));
+
+    // The daily-usage key is scoped by calendar day, derived the same way
+    // `check_daily_limit` derives it internally.
+    let day = env.ledger().timestamp() / 86_400;
+
+    env.ledger().set_sequence_number(MAX_ALLOWED_TTL - 10);
+    bridge.extend_source_persistent_ttl(&user, &token_id, &200_000u32);
+
+    let expected_keys = [
+        DataKey::SourceDailyLimit(user.clone(), token_id.clone()),
+        DataKey::DailyUsage(user.clone(), token_id.clone(), day),
+        DataKey::UserDeposit(user.clone(), token_id.clone()),
+        DataKey::SourceBridgedVolume(user.clone()),
+        DataKey::Nonce(user.clone()),
+        DataKey::AuthNonce(user.clone()),
+    ];
+    for key in expected_keys.iter() {
+        let ttl = env.as_contract(&bridge_id, || env.storage().persistent().get_ttl(key));
+        assert!(ttl >= 200_000);
+    }
+
+    assert_eq!(
+        count_events_with_topic(&env, &bridge_id, "SourcePersistentTtlExtended"),
+        1
+    );
+}
+
+#[test]
+fn test_extend_source_persistent_ttl_not_initialized_fails() {
+    let env = Env::default();
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    let source = Address::generate(&env);
+    let asset = Address::generate(&env);
+
+    assert_eq!(
+        bridge.try_extend_source_persistent_ttl(&source, &asset, &200_000u32),
+        Err(Ok(BridgeError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_extend_source_persistent_ttl_skips_missing_keys() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    // This (source, asset) pair has never touched storage; none of the six
+    // keys exist, so the call must succeed rather than erroring on a
+    // missing entry, mirroring `extend_persistent_ttl`.
+    let source = Address::generate(&env);
+    let asset = Address::generate(&env);
+    bridge.extend_source_persistent_ttl(&source, &asset, &200_000u32);
+}
+
+#[test]
+fn test_extend_source_persistent_ttl_caps_at_max_allowed_ttl() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    bridge.fund_c_address(
+        &user,
+        &Address::generate(&env),
+        &token_id,
+        &500i128,
+        &None,
+        &None,
+    );
+
+    env.ledger().set_sequence_number(MAX_ALLOWED_TTL - 10);
+    // Requesting far beyond the hard ceiling must silently clamp to
+    // `MAX_ALLOWED_TTL` rather than erroring or exceeding it.
+    bridge.extend_source_persistent_ttl(&user, &token_id, &(MAX_ALLOWED_TTL * 10));
+
+    let ttl = env.as_contract(&bridge_id, || {
+        env.storage()
+            .persistent()
+            .get_ttl(&DataKey::UserDeposit(user.clone(), token_id.clone()))
+    });
+    assert!(ttl <= MAX_ALLOWED_TTL);
+}
+
 #[test]
 fn test_set_max_ttl_updates_config() {
     let env = Env::default();


### PR DESCRIPTION
Closes #409 
Closes #410 
Closes #416 
Closes #419 

SUMMARY

1. Ledger time/sequence advances** — `env.ledger().set_timestamp()` / `set_sequence_number()` are `testutils::Ledger` trait methods in soroban-sdk 22, not inherent methods; calling them without the trait in scope was an `E0599` in `benchmarks.rs`. Fixed the import gap and factored the recurring "read, advance, write back" pattern into shared `advance_ledger_time` / `advance_ledger_sequence` helpers used by both `benchmarks.rs` and `tests.rs`.
2. Stale `fund_c_address_timelocked` call** — the loyalty test (`test_timelocked_fund_mints_loyalty_at_deposit`) still called the function with its pre-signature 6-argument form, tripping `E0061` (8 args expected). Updated the call site to pass `nonce`/`deadline` as `None`, matching every sibling call in the module.
3. execute_upgrade` test coverage** — the function had no test anywhere in the suite. Added tests for the success path (pending record populated then cleared, `ContractUpgraded` event fires, replay reports "not scheduled"), each documented error (`NotInitialized`, `UpgradeNotScheduled`, `UpgradeHashMismatch`, `UpgradeTimelockActive`, `DuplicateNonce`), and the timelock boundary (`sequence >= scheduled + timelock`).
4. `extend_source_persistent_ttl` test coverage** — likewise untested. Added tests for the success path (all six documented per-source keys — `SourceDailyLimit`, the current day's `DailyUsage`, `UserDeposit`, `SourceBridgedVolume`, `Nonce`, `AuthNonce` — get their TTL extended and the `SourcePersistentTtlExtended` event fires), the `NotInitialized` error, the silently-skipped-missing-keys behavior, and the `MAX_ALLOWED_TTL` clamping boundary.