### PR TITLE
Test/stub fn coverage

### DIFF
--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -5313,3 +5313,50 @@ fn test_safe_sub_boundary_max_minus_max() {
 fn test_safe_sub_boundary_min_minus_min() {
     assert_eq!(crate::safe_math::safe_sub(i128::MIN, i128::MIN), Ok(0i128));
 }
+
+/********** safe_div tests **********/
+
+#[test]
+fn test_safe_div_success() {
+    assert_eq!(crate::safe_math::safe_div(10i128, 2i128), Ok(5i128));
+    assert_eq!(crate::safe_math::safe_div(-9i128, 3i128), Ok(-3i128));
+}
+
+#[test]
+fn test_safe_div_truncates_toward_zero() {
+    assert_eq!(crate::safe_math::safe_div(7i128, 2i128), Ok(3i128));
+    assert_eq!(crate::safe_math::safe_div(-7i128, 2i128), Ok(-3i128));
+}
+
+#[test]
+fn test_safe_div_zero_numerator() {
+    assert_eq!(crate::safe_math::safe_div(0i128, 5i128), Ok(0i128));
+}
+
+#[test]
+fn test_safe_div_by_zero_error() {
+    assert_eq!(
+        crate::safe_math::safe_div(10i128, 0i128),
+        Err(BridgeError::Overflow)
+    );
+}
+
+#[test]
+fn test_safe_div_min_by_negative_one_overflow_error() {
+    // i128::MIN / -1 overflows the representable range.
+    assert_eq!(
+        crate::safe_math::safe_div(i128::MIN, -1i128),
+        Err(BridgeError::Overflow)
+    );
+}
+
+#[test]
+fn test_safe_div_boundary_min_by_one() {
+    // i128::MIN / 1 is exactly representable and must not overflow.
+    assert_eq!(crate::safe_math::safe_div(i128::MIN, 1i128), Ok(i128::MIN));
+}
+
+#[test]
+fn test_safe_div_boundary_max_by_one() {
+    assert_eq!(crate::safe_math::safe_div(i128::MAX, 1i128), Ok(i128::MAX));
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -4967,3 +4967,169 @@ fn test_set_max_withdraw_per_tx_updates_limit() {
     bridge.set_max_withdraw_per_tx(&0i128, &None);
     assert_eq!(bridge.query_max_withdraw_per_tx(), 0i128);
 }
+
+/********** verify_auth_entry tests **********/
+
+#[test]
+fn test_verify_auth_entry_success() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_000);
+
+    bridge.verify_auth_entry(&user, &7u64, &900u32, &1_100u32);
+
+    assert!(bridge.query_auth_nonce_used(&user, &7u64));
+}
+
+#[test]
+fn test_verify_auth_entry_not_initialized() {
+    let env = Env::default();
+    let (_admin, user, _fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    assert_eq!(
+        bridge.try_verify_auth_entry(&user, &1u64, &0u32, &100u32),
+        Err(Ok(BridgeError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_verify_auth_entry_paused() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    bridge.pause(&None);
+    env.ledger().set_sequence_number(1_000);
+
+    assert_eq!(
+        bridge.try_verify_auth_entry(&user, &1u64, &900u32, &1_100u32),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+fn test_verify_auth_entry_expired_before_window() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(500);
+
+    assert_eq!(
+        bridge.try_verify_auth_entry(&user, &1u64, &900u32, &1_100u32),
+        Err(Ok(BridgeError::AuthNonceExpired))
+    );
+}
+
+#[test]
+fn test_verify_auth_entry_expired_at_upper_boundary() {
+    // valid_before_ledger is an exclusive upper bound, so sequence == valid_before
+    // must be rejected.
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_100);
+
+    assert_eq!(
+        bridge.try_verify_auth_entry(&user, &1u64, &900u32, &1_100u32),
+        Err(Ok(BridgeError::AuthNonceExpired))
+    );
+}
+
+#[test]
+fn test_verify_auth_entry_boundary_lower_inclusive() {
+    // valid_after_ledger is an inclusive lower bound, so sequence == valid_after
+    // must succeed.
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(900);
+
+    bridge.verify_auth_entry(&user, &1u64, &900u32, &1_100u32);
+    assert!(bridge.query_auth_nonce_used(&user, &1u64));
+}
+
+#[test]
+fn test_verify_auth_entry_boundary_upper_last_valid() {
+    // sequence == valid_before - 1 is the last ledger the window still covers.
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_099);
+
+    bridge.verify_auth_entry(&user, &1u64, &900u32, &1_100u32);
+    assert!(bridge.query_auth_nonce_used(&user, &1u64));
+}
+
+#[test]
+fn test_verify_auth_entry_already_used() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_000);
+
+    bridge.verify_auth_entry(&user, &5u64, &900u32, &1_100u32);
+
+    assert_eq!(
+        bridge.try_verify_auth_entry(&user, &5u64, &900u32, &1_100u32),
+        Err(Ok(BridgeError::AuthNonceAlreadyUsed))
+    );
+}
+
+#[test]
+fn test_verify_auth_entry_different_nonces_independent() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_000);
+
+    bridge.verify_auth_entry(&user, &1u64, &900u32, &1_100u32);
+    // A different nonce for the same source is unaffected by the first call.
+    bridge.verify_auth_entry(&user, &2u64, &900u32, &1_100u32);
+
+    assert!(bridge.query_auth_nonce_used(&user, &1u64));
+    assert!(bridge.query_auth_nonce_used(&user, &2u64));
+    assert!(!bridge.query_auth_nonce_used(&user, &3u64));
+}
+
+#[test]
+fn test_verify_auth_entry_emits_event() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_000);
+
+    bridge.verify_auth_entry(&user, &9u64, &900u32, &1_100u32);
+
+    let events = env.events().all();
+    let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
+    assert_eq!(contract_id, &bridge_id);
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -1,6 +1,6 @@
 use crate::{
     BridgeError, DataKey, FeeTier, MetaFundParams, OnboardingBridge,
-    CRITICAL_ENTRY_TTL_THRESHOLD, MAX_ALLOWED_TTL,
+    CRITICAL_ENTRY_TTL_THRESHOLD, MAX_ALLOWED_TTL, UPGRADE_TIMELOCK_LEDGERS,
 };
 
 use ed25519_dalek::{Signer, SigningKey};
@@ -5128,6 +5128,140 @@ fn test_verify_auth_entry_emits_event() {
     env.ledger().set_sequence_number(1_000);
 
     bridge.verify_auth_entry(&user, &9u64, &900u32, &1_100u32);
+
+    let events = env.events().all();
+    let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
+    assert_eq!(contract_id, &bridge_id);
+}
+
+/********** schedule_upgrade tests **********/
+
+#[test]
+fn test_schedule_upgrade_success() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(1_000);
+
+    let new_hash = BytesN::from_array(&env, &[7; 32]);
+    let executable_after = bridge.schedule_upgrade(&new_hash, &None);
+
+    assert_eq!(executable_after, 1_000 + UPGRADE_TIMELOCK_LEDGERS);
+
+    let pending = bridge.query_pending_upgrade().expect("pending upgrade set");
+    assert_eq!(pending.new_wasm_hash, new_hash);
+    assert_eq!(pending.executable_after_ledger, executable_after);
+}
+
+#[test]
+fn test_schedule_upgrade_not_initialized() {
+    let env = Env::default();
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    let new_hash = BytesN::from_array(&env, &[1; 32]);
+    assert_eq!(
+        bridge.try_schedule_upgrade(&new_hash, &None),
+        Err(Ok(BridgeError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_schedule_upgrade_duplicate_nonce() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let new_hash = BytesN::from_array(&env, &[1; 32]);
+    // Passing a non-zero nonce on the first call mismatches the expected
+    // starting value.
+    assert_eq!(
+        bridge.try_schedule_upgrade(&new_hash, &Some(1u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
+#[test]
+fn test_schedule_upgrade_nonce_replay_rejected() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let hash1 = BytesN::from_array(&env, &[1; 32]);
+    bridge.schedule_upgrade(&hash1, &Some(0u64));
+
+    let hash2 = BytesN::from_array(&env, &[2; 32]);
+    assert_eq!(
+        bridge.try_schedule_upgrade(&hash2, &Some(0u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
+#[test]
+fn test_schedule_upgrade_none_skips_nonce_check() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let hash1 = BytesN::from_array(&env, &[1; 32]);
+    bridge.schedule_upgrade(&hash1, &None);
+
+    // Calling again with None still succeeds since the nonce check is skipped.
+    let hash2 = BytesN::from_array(&env, &[2; 32]);
+    bridge.schedule_upgrade(&hash2, &None);
+
+    let pending = bridge.query_pending_upgrade().expect("pending upgrade set");
+    assert_eq!(pending.new_wasm_hash, hash2);
+}
+
+#[test]
+fn test_schedule_upgrade_timelock_boundary() {
+    // The upgrade should not be executable one ledger before the timelock
+    // elapses, but should become executable exactly at the boundary.
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    env.ledger().set_sequence_number(2_000);
+
+    let new_hash = BytesN::from_array(&env, &[3; 32]);
+    let executable_after = bridge.schedule_upgrade(&new_hash, &None);
+
+    env.ledger().set_sequence_number(executable_after - 1);
+    assert_eq!(
+        bridge.try_execute_upgrade(&new_hash, &None),
+        Err(Ok(BridgeError::UpgradeTimelockActive))
+    );
+
+    env.ledger().set_sequence_number(executable_after);
+    bridge.execute_upgrade(&new_hash, &None);
+}
+
+#[test]
+fn test_schedule_upgrade_emits_event() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let new_hash = BytesN::from_array(&env, &[4; 32]);
+    bridge.schedule_upgrade(&new_hash, &None);
 
     let events = env.events().all();
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -5267,3 +5267,49 @@ fn test_schedule_upgrade_emits_event() {
     let (contract_id, _topics, _data) = &events.get(events.len() - 1).unwrap();
     assert_eq!(contract_id, &bridge_id);
 }
+
+/********** safe_sub tests **********/
+
+#[test]
+fn test_safe_sub_success() {
+    assert_eq!(crate::safe_math::safe_sub(10i128, 3i128), Ok(7i128));
+    assert_eq!(crate::safe_math::safe_sub(-5i128, -5i128), Ok(0i128));
+}
+
+#[test]
+fn test_safe_sub_negative_result() {
+    assert_eq!(crate::safe_math::safe_sub(3i128, 10i128), Ok(-7i128));
+}
+
+#[test]
+fn test_safe_sub_zero_identity() {
+    assert_eq!(crate::safe_math::safe_sub(42i128, 0i128), Ok(42i128));
+}
+
+#[test]
+fn test_safe_sub_underflow_error() {
+    // i128::MIN - 1 underflows the representable range.
+    assert_eq!(
+        crate::safe_math::safe_sub(i128::MIN, 1i128),
+        Err(BridgeError::Overflow)
+    );
+}
+
+#[test]
+fn test_safe_sub_overflow_error() {
+    // i128::MAX - (-1) overflows the representable range.
+    assert_eq!(
+        crate::safe_math::safe_sub(i128::MAX, -1i128),
+        Err(BridgeError::Overflow)
+    );
+}
+
+#[test]
+fn test_safe_sub_boundary_max_minus_max() {
+    assert_eq!(crate::safe_math::safe_sub(i128::MAX, i128::MAX), Ok(0i128));
+}
+
+#[test]
+fn test_safe_sub_boundary_min_minus_min() {
+    assert_eq!(crate::safe_math::safe_sub(i128::MIN, i128::MIN), Ok(0i128));
+}


### PR DESCRIPTION
- bfdae02 — tests for verify_auth_entry: success path, NotInitialized, ContractPaused, AuthNonceExpired (below window + exact exclusive upper bound), inclusive lower boundary, last-valid upper boundary, AuthNonceAlreadyUsed replay, per-nonce independence, and the AuthUsed event.
- 1b9d998 — tests for schedule_upgrade: success path (checks executable_after_ledger = seq + UPGRADE_TIMELOCK_LEDGERS), NotInitialized, DuplicateNonce (bad first nonce + replay), None skipping the nonce check, the exclusive timelock boundary against execute_upgrade, and the UpgradeScheduled event. Also had to add UPGRADE_TIMELOCK_LEDGERS to the use crate::{...} import — folded into the same commit since it was needed for that test to even reference the constant.
- bf37b24 — tests for safe_sub: normal/negative results, zero identity, i128::MIN - 1 underflow, i128::MAX - (-1) overflow, and the MAX-MAX/MIN-MIN boundary.
- 63203c3 — tests for safe_div: normal division, truncation toward zero, zero numerator, divide-by-zero, i128::MIN / -1 overflow, and MIN/1/MAX/1 boundaries.


Closes #437 
Closes #438 
Closes #439
Closes #440