### PR TITLE
Test/query fn coverage

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1742,7 +1742,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_minimum_amount(env: Env) -> Result<i128, BridgeError> {
-        todo!("implement: query_minimum_amount")
+        check_initialized(&env)?;
+        Ok(read_minimum_amount(&env))
     }
 
     /// Withdraws accrued protocol fees to the fee collector.

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1720,9 +1720,7 @@ impl OnboardingBridge {
     }
 
     pub fn query_pending_admin(env: Env) -> Option<Address> {
-
-        todo!("implement: query_pending_admin")
-
+        read_pending_admin(&env)
     }
 
     pub fn set_minimum_amount(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1695,9 +1695,7 @@ impl OnboardingBridge {
     }
 
     pub fn query_pending_fee_collector(env: Env) -> Option<Address> {
-
-        todo!("implement: query_pending_fee_collector")
-
+        read_pending_fee_collector(&env)
     }
 
     pub fn set_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -5205,3 +5205,58 @@ fn test_query_pending_admin_cleared_after_accept() {
     assert_eq!(bridge.query_admin(), candidate);
     assert_eq!(bridge.query_pending_admin(), None);
 }
+
+/********** query_pending_fee_collector unit tests **********/
+
+#[test]
+fn test_query_pending_fee_collector_defaults_to_none() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    // No fee-collector handoff has been proposed yet.
+    assert_eq!(bridge.query_pending_fee_collector(), None);
+}
+
+#[test]
+fn test_query_pending_fee_collector_reflects_proposal() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let candidate = Address::generate(&env);
+    bridge.propose_new_fee_collector(&candidate, &None);
+    assert_eq!(bridge.query_pending_fee_collector(), Some(candidate.clone()));
+
+    // A later proposal overwrites the previously pending candidate.
+    let other_candidate = Address::generate(&env);
+    bridge.propose_new_fee_collector(&other_candidate, &None);
+    assert_eq!(bridge.query_pending_fee_collector(), Some(other_candidate));
+}
+
+#[test]
+fn test_query_pending_fee_collector_cleared_after_accept() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let candidate = Address::generate(&env);
+    bridge.propose_new_fee_collector(&candidate, &None);
+    assert_eq!(bridge.query_pending_fee_collector(), Some(candidate.clone()));
+
+    bridge.accept_fee_collector();
+
+    // Accepting promotes the candidate to fee collector and clears the
+    // pending slot back to None.
+    assert_eq!(bridge.query_fee_collector(), candidate);
+    assert_eq!(bridge.query_pending_fee_collector(), None);
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -5076,3 +5076,78 @@ fn test_query_meta_tx_nonce_used_is_scoped_per_source() {
     assert_eq!(bridge.query_meta_tx_nonce_used(&user, &nonce), true);
     assert_eq!(bridge.query_meta_tx_nonce_used(&other_user, &nonce), false);
 }
+
+/********** query_minimum_amount unit tests **********/
+
+#[test]
+fn test_query_minimum_amount_defaults_to_zero() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    // No minimum configured yet -> 0 (no minimum enforced).
+    assert_eq!(bridge.query_minimum_amount(), 0i128);
+}
+
+#[test]
+fn test_query_minimum_amount_reflects_set_minimum_amount() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    bridge.set_minimum_amount(&100i128, &None);
+    assert_eq!(bridge.query_minimum_amount(), 100i128);
+
+    // Updating again overwrites the previous value.
+    bridge.set_minimum_amount(&1i128, &None);
+    assert_eq!(bridge.query_minimum_amount(), 1i128);
+
+    // Explicitly restoring to zero disables the minimum again.
+    bridge.set_minimum_amount(&0i128, &None);
+    assert_eq!(bridge.query_minimum_amount(), 0i128);
+}
+
+#[test]
+fn test_query_minimum_amount_without_initialize_fails() {
+    let env = Env::default();
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    assert_eq!(
+        bridge.try_query_minimum_amount(),
+        Err(Ok(BridgeError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_query_minimum_amount_boundary_enforced_by_fund_c_address() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+    bridge.set_minimum_amount(&200i128, &None);
+    assert_eq!(bridge.query_minimum_amount(), 200i128);
+
+    let target = Address::generate(&env);
+
+    // Strictly below the configured minimum is rejected.
+    assert_eq!(
+        bridge.try_fund_c_address(&user, &target, &token_id, &199i128, &None, &None),
+        Err(Ok(BridgeError::InvalidAmount))
+    );
+
+    // Exactly at the minimum boundary succeeds.
+    bridge.fund_c_address(&user, &target, &token_id, &200i128, &None, &None);
+    assert_eq!(check_balance(&env, &token_id, &target), 200i128);
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -5151,3 +5151,57 @@ fn test_query_minimum_amount_boundary_enforced_by_fund_c_address() {
     bridge.fund_c_address(&user, &target, &token_id, &200i128, &None, &None);
     assert_eq!(check_balance(&env, &token_id, &target), 200i128);
 }
+
+/********** query_pending_admin unit tests **********/
+
+#[test]
+fn test_query_pending_admin_defaults_to_none() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    // No admin handoff has been proposed yet.
+    assert_eq!(bridge.query_pending_admin(), None);
+}
+
+#[test]
+fn test_query_pending_admin_reflects_proposal() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let candidate = Address::generate(&env);
+    bridge.propose_new_admin(&candidate, &None);
+    assert_eq!(bridge.query_pending_admin(), Some(candidate.clone()));
+
+    // A later proposal overwrites the previously pending candidate.
+    let other_candidate = Address::generate(&env);
+    bridge.propose_new_admin(&other_candidate, &None);
+    assert_eq!(bridge.query_pending_admin(), Some(other_candidate));
+}
+
+#[test]
+fn test_query_pending_admin_cleared_after_accept() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+
+    let candidate = Address::generate(&env);
+    bridge.propose_new_admin(&candidate, &None);
+    assert_eq!(bridge.query_pending_admin(), Some(candidate.clone()));
+
+    bridge.accept_admin();
+
+    // Accepting promotes the candidate to admin and clears the pending slot.
+    assert_eq!(bridge.query_admin(), candidate);
+    assert_eq!(bridge.query_pending_admin(), None);
+}

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -4967,3 +4967,112 @@ fn test_set_max_withdraw_per_tx_updates_limit() {
     bridge.set_max_withdraw_per_tx(&0i128, &None);
     assert_eq!(bridge.query_max_withdraw_per_tx(), 0i128);
 }
+
+/********** query_meta_tx_nonce_used unit tests **********/
+
+#[test]
+fn test_query_meta_tx_nonce_used_false_before_use() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+
+    // A nonce that has never been consumed reports as unused, including at
+    // the documented boundaries (zero and the max representable nonce).
+    assert_eq!(bridge.query_meta_tx_nonce_used(&user, &0u64), false);
+    assert_eq!(bridge.query_meta_tx_nonce_used(&user, &u64::MAX), false);
+}
+
+#[test]
+fn test_query_meta_tx_nonce_used_true_after_execute_meta_fund() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &100u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let target = Address::generate(&env);
+
+    let seed = [0x11u8; 32];
+    let signing_key = SigningKey::from_bytes(&seed);
+    let pubkey = BytesN::from_array(&env, signing_key.verifying_key().as_bytes());
+    bridge.register_meta_signer(&user, &pubkey);
+
+    let amount: i128 = 500;
+    let nonce: u64 = 7;
+    let deadline: u64 = 2_000_000;
+
+    let payload_hash = build_meta_fund_payload_hash(
+        &env, &user, &target, &token_id, amount, nonce, deadline,
+    );
+    let signature = sign_meta_fund_payload(&env, &signing_key, &payload_hash);
+
+    let params = MetaFundParams {
+        source: user.clone(),
+        target,
+        asset: token_id.clone(),
+        amount,
+        nonce,
+        deadline,
+    };
+
+    // Unused before the meta-tx executes.
+    assert_eq!(bridge.query_meta_tx_nonce_used(&user, &nonce), false);
+
+    bridge.execute_meta_fund(&params, &pubkey, &signature);
+
+    // Used once the meta-tx has been consumed.
+    assert_eq!(bridge.query_meta_tx_nonce_used(&user, &nonce), true);
+}
+
+#[test]
+fn test_query_meta_tx_nonce_used_is_scoped_per_source() {
+    let env = Env::default();
+    let (admin, user, fee_collector) = create_test_users(&env);
+    let (bridge_id, token_id) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    init_token(&env, &token_id, &admin);
+
+    bridge.initialize(&admin, &fee_collector, &0u32, &None);
+    bridge.add_asset(&token_id, &None);
+    mint_tokens(&env, &token_id, &user, 1000i128);
+
+    let other_user = Address::generate(&env);
+    let target = Address::generate(&env);
+
+    let seed = [0x22u8; 32];
+    let signing_key = SigningKey::from_bytes(&seed);
+    let pubkey = BytesN::from_array(&env, signing_key.verifying_key().as_bytes());
+    bridge.register_meta_signer(&user, &pubkey);
+
+    let amount: i128 = 100;
+    let nonce: u64 = 3;
+    let deadline: u64 = 2_000_000;
+
+    let payload_hash = build_meta_fund_payload_hash(
+        &env, &user, &target, &token_id, amount, nonce, deadline,
+    );
+    let signature = sign_meta_fund_payload(&env, &signing_key, &payload_hash);
+
+    let params = MetaFundParams {
+        source: user.clone(),
+        target,
+        asset: token_id.clone(),
+        amount,
+        nonce,
+        deadline,
+    };
+
+    bridge.execute_meta_fund(&params, &pubkey, &signature);
+
+    // The same nonce value is untouched for a different source address —
+    // usage is scoped to (source, nonce), not the nonce alone.
+    assert_eq!(bridge.query_meta_tx_nonce_used(&user, &nonce), true);
+    assert_eq!(bridge.query_meta_tx_nonce_used(&other_user, &nonce), false);
+}


### PR DESCRIPTION
1. test: add coverage for query_meta_tx_nonce_used — added 3 tests (unused-nonce default, nonce flips to used after execute_meta_fund, per-source scoping + u64 boundary values). No lib.rs change needed — it was already implemented.
2. feat: implement query_minimum_amount and add test coverage — this query was stubbed with todo!(); wired it to the existing check_initialized/read_minimum_amount helpers. Added 4 tests: default zero, reflects set_minimum_amount updates, NotInitialized error, and the minimum-amount boundary as enforced by fund_c_address.
3. feat: implement query_pending_admin and add test coverage — wired the stub to read_pending_admin. Added 3 tests: defaults to None, reflects/overwrites proposals, cleared after accept_admin.
4. feat: implement query_pending_fee_collector and add test coverage — wired the stub to read_pending_fee_collector. Added 3 tests: defaults to None, reflects/overwrites proposals, cleared after accept_fee_collector.


Closes #429
Closes #430 
Closes #431
Closes #432