### PR TITLE
Feat/implement fee and batch funding config

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1627,7 +1627,19 @@ impl OnboardingBridge {
         max_fee_bps: u32,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        todo!("implement: set_asset_fee_cap")
+        check_initialized(&env)?;
+        if max_fee_bps > MAX_FEE_BPS {
+            return Err(BridgeError::FeeTooHigh);
+        }
+
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        save_asset_fee_cap(&env, &asset, max_fee_bps);
+        extend_instance_ttl(&env);
+
+        Ok(())
     }
 
     /// Returns the fee cap configured for `asset`.

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1530,7 +1530,24 @@ impl OnboardingBridge {
     /// // assert_eq!(bridge.query_fee_bps(), 200u32);
     /// ```
     pub fn set_fee_bps(env: Env, new_fee_bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: set_fee_bps")
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        if new_fee_bps > MAX_FEE_BPS {
+            return Err(BridgeError::FeeTooHigh);
+        }
+
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        let old_fee_bps = read_fee_bps(&env);
+        save_fee_bps(&env, &new_fee_bps);
+        extend_instance_ttl(&env);
+
+        env.events()
+            .publish(("FeeBpsChanged", old_fee_bps, new_fee_bps), (admin,));
+
+        Ok(())
     }
 
     /// Sets a maximum daily transfer limit for a specific `(source, asset)` pair.

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1569,7 +1569,16 @@ impl OnboardingBridge {
         limit_amount: i128,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        todo!("implement: set_source_daily_limit")
+        check_initialized(&env)?;
+
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        save_source_daily_limit(&env, &source, &asset, limit_amount);
+        extend_instance_ttl(&env);
+
+        Ok(())
     }
 
     /// Returns the daily transfer limit for a `(source, asset)` pair.

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1490,7 +1490,98 @@ impl OnboardingBridge {
         nonce: Option<u64>,
         deadline: Option<u64>,
     ) -> Result<(), BridgeError> {
-        todo!("implement: batch_fund_c_address")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+
+        if targets.len() > MAX_BATCH_SIZE {
+            return Err(BridgeError::BatchTooLarge);
+        }
+        if let Some(dl) = deadline {
+            if env.ledger().timestamp() > dl {
+                return Err(BridgeError::TransactionExpired);
+            }
+        }
+        if targets.len() != amounts.len() {
+            return Err(BridgeError::MismatchedArrays);
+        }
+
+        check_asset_whitelisted(&env, &asset)?;
+
+        // Validate every amount before any tokens move.
+        let minimum_amount = read_minimum_amount(&env);
+        let mut total: i128 = 0;
+        for amount in amounts.iter() {
+            if amount <= 0 || amount < minimum_amount {
+                return Err(BridgeError::InvalidAmount);
+            }
+            total = safe_math::safe_add(total, amount)?;
+        }
+
+        check_daily_limit(&env, &source, &asset, total)?;
+
+        source.require_auth();
+        consume_nonce(&env, &source, nonce)?;
+
+        let token_client = token::Client::new(&env, &asset);
+        let contract_addr = env.current_contract_address();
+        token_client.transfer(&source, &contract_addr, &total);
+
+        // Aggregate amounts per unique target to minimize transfer count.
+        let mut aggregated: Map<Address, i128> = Map::new(&env);
+        for i in 0..targets.len() {
+            let target = targets.get(i).unwrap();
+            let amount = amounts.get(i).unwrap();
+            let updated = safe_math::safe_add(aggregated.get(target.clone()).unwrap_or(0), amount)?;
+            aggregated.set(target, updated);
+        }
+
+        let global_fee_bps = read_fee_bps(&env);
+        let tiered_fee_bps = get_tiered_fee_bps(&env, &source, global_fee_bps);
+        let effective_fee_bps = get_effective_fee_bps(&env, &asset, tiered_fee_bps);
+
+        let mut num_success: u32 = 0;
+        let mut num_failures: u32 = 0;
+        let mut refund_total: i128 = 0;
+
+        for (target, amount) in aggregated.iter() {
+            if check_access(&env, &target).is_err() {
+                num_failures += 1;
+                refund_total = safe_math::safe_add(refund_total, amount)?;
+                env.events().publish(
+                    ("BatchTransferFailed", source.clone(), target.clone()),
+                    (amount, soroban_sdk::Symbol::new(&env, "access_denied")),
+                );
+                continue;
+            }
+
+            let fee = calculate_fee(amount, effective_fee_bps)?;
+            let net_amount = safe_math::safe_sub(amount, fee)?;
+
+            if net_amount > 0 {
+                token_client.transfer(&contract_addr, &target, &net_amount);
+            }
+            update_asset_counters(&env, &asset, fee, net_amount)?;
+
+            num_success += 1;
+            env.events().publish(
+                ("CAddressFunded", asset.clone(), source.clone(), target.clone()),
+                (amount, fee),
+            );
+        }
+
+        if refund_total > 0 {
+            token_client.transfer(&contract_addr, &source, &refund_total);
+        }
+
+        increment_source_bridged_volume(&env, &source, total)?;
+        extend_instance_ttl(&env);
+        mint_loyalty_tokens(&env, &source);
+
+        env.events()
+            .publish(("BatchCompleted", source), (num_success, num_failures));
+
+        Ok(())
     }
 
     // -----------------------------------------------------------------------

--- a/docs/implementation-notes/batch-fund-c-address.md
+++ b/docs/implementation-notes/batch-fund-c-address.md
@@ -1,0 +1,50 @@
+# `batch_fund_c_address` implementation
+
+## What was implemented
+
+`batch_fund_c_address` in `contracts/onboarding-bridge/src/lib.rs` previously
+had a `todo!()` body. It now implements the full documented flow:
+
+1. **Guards, in the documented error order**: reentrancy guard, initialized,
+   not-paused, `targets.len() > MAX_BATCH_SIZE` → `BatchTooLarge`, past
+   `deadline` → `TransactionExpired`, `targets.len() != amounts.len()` →
+   `MismatchedArrays`, then `AssetNotWhitelisted` via the existing
+   `check_asset_whitelisted` helper.
+2. **Pre-transfer validation**: a loop over `amounts` rejects any element that
+   is `<= 0` or below the configured minimum transfer amount
+   (`InvalidAmount`) *before* any tokens move, matching the "Security
+   Considerations" note in the doc comment. The loop also accumulates the
+   batch total.
+3. **Daily limit check** against the aggregate batch total via the existing
+   `check_daily_limit` helper, then `source.require_auth()` and the optional
+   nonce is consumed via `consume_nonce`.
+4. **Single upfront pull**: `sum(amounts)` is transferred from `source` to the
+   contract in one `token_client.transfer` call.
+5. **Aggregation**: amounts for duplicate targets are summed into a
+   `Map<Address, i128>` first, so each unique target receives at most one
+   outbound transfer and one `CAddressFunded`/`BatchTransferFailed` event,
+   per the "aggregated into a single token transfer" requirement in the doc.
+6. **Per-target processing**: blocked/non-allowlisted targets (checked via the
+   existing `check_access` helper) are skipped — their amount is accumulated
+   into a refund total and a `BatchTransferFailed` event is emitted with
+   `(amount, "access_denied")`. Allowed targets have the fee deducted (via the
+   existing `calculate_fee`, using the effective fee rate from
+   `get_tiered_fee_bps` + `get_effective_fee_bps`, same resolution order used
+   elsewhere in the contract), receive the net transfer, and emit
+   `CAddressFunded`.
+7. **End of batch**: any refund total is transferred back to `source` in one
+   call, `source`'s bridged volume is incremented once, instance TTL is
+   extended, loyalty tokens are minted once to `source` (matching the
+   existing comment stating batch funding mints "once per call, not per
+   recipient"), and a single `BatchCompleted` event reports
+   `(num_success, num_failures)`.
+
+No new storage keys were introduced. All per-asset counters, daily-limit,
+fee-tier, fee-cap, and loyalty helpers already existed in the file (used by
+other funding paths such as `reveal_fund`) and are reused here.
+
+## Verification
+
+`cargo check -p onboarding-bridge` passes with no new errors. As noted in the
+issue, the crate's test target does not currently compile for unrelated,
+pre-existing reasons, so `cargo test` could not be run.

--- a/docs/implementation-notes/set-asset-fee-cap.md
+++ b/docs/implementation-notes/set-asset-fee-cap.md
@@ -1,0 +1,28 @@
+# `set_asset_fee_cap` implementation
+
+## What was implemented
+
+`set_asset_fee_cap` in `contracts/onboarding-bridge/src/lib.rs` previously had a
+`todo!()` body. It now:
+
+1. Confirms the contract is initialized (`BridgeError::NotInitialized`).
+2. Rejects `max_fee_bps` values above `MAX_FEE_BPS` (1 000) with
+   `BridgeError::FeeTooHigh`.
+3. Requires the current admin's authorization via `require_auth()`.
+4. Consumes the optional sequential admin nonce via the existing
+   `consume_nonce` helper, returning `BridgeError::DuplicateNonce` on mismatch.
+5. Persists the cap with the pre-existing `save_asset_fee_cap` storage helper
+   (already used by `get_effective_fee_bps` to compute `min(global_fee_bps, cap)`).
+6. Extends instance TTL via the existing `extend_instance_ttl` helper, matching
+   every other mutating admin setter in the contract.
+
+No new storage keys, helpers, or public signatures were introduced — the
+function only wires together helpers that already existed for this exact
+purpose (`save_asset_fee_cap`, `read_asset_fee_cap`, `get_effective_fee_bps`).
+
+## Verification
+
+`cargo check -p onboarding-bridge` passes with no new errors. The crate's test
+target does not currently compile for unrelated, pre-existing reasons (see the
+open issues covering the seeded test-target breakage), so `cargo test` could
+not be run as part of this change, per the issue's own note.

--- a/docs/implementation-notes/set-fee-bps.md
+++ b/docs/implementation-notes/set-fee-bps.md
@@ -1,0 +1,29 @@
+# `set_fee_bps` implementation
+
+## What was implemented
+
+`set_fee_bps` in `contracts/onboarding-bridge/src/lib.rs` previously had a
+`todo!()` body. It now:
+
+1. Confirms the contract is initialized (`BridgeError::NotInitialized`).
+2. Rejects mutating calls while the contract is paused
+   (`BridgeError::ContractPaused`), via the existing `check_not_paused` helper.
+3. Rejects `new_fee_bps` values above `MAX_FEE_BPS` (1 000) with
+   `BridgeError::FeeTooHigh`.
+4. Requires the current admin's authorization via `require_auth()`.
+5. Consumes the optional sequential admin nonce via the existing
+   `consume_nonce` helper, returning `BridgeError::DuplicateNonce` on mismatch.
+6. Reads the previous rate, persists the new rate via the existing
+   `save_fee_bps` helper, and extends instance TTL.
+7. Emits the documented `("FeeBpsChanged", old_fee_bps, new_fee_bps)` event
+   with `(admin,)` as the event data, matching the doc comment exactly.
+
+No new storage keys or helpers were introduced — `read_fee_bps` and
+`save_fee_bps` already existed and back `query_fee_bps` and every funding
+path's fee calculation.
+
+## Verification
+
+`cargo check -p onboarding-bridge` passes with no new errors. As noted in the
+issue, the crate's test target does not currently compile for unrelated,
+pre-existing reasons, so `cargo test` could not be run.

--- a/docs/implementation-notes/set-source-daily-limit.md
+++ b/docs/implementation-notes/set-source-daily-limit.md
@@ -1,0 +1,27 @@
+# `set_source_daily_limit` implementation
+
+## What was implemented
+
+`set_source_daily_limit` in `contracts/onboarding-bridge/src/lib.rs` previously
+had a `todo!()` body. It now:
+
+1. Confirms the contract is initialized (`BridgeError::NotInitialized`).
+2. Requires the current admin's authorization via `require_auth()`.
+3. Consumes the optional sequential admin nonce via the existing
+   `consume_nonce` helper, returning `BridgeError::DuplicateNonce` on mismatch.
+4. Persists the per-`(source, asset)` limit with the pre-existing
+   `save_source_daily_limit` storage helper. Passing `0` disables the limit,
+   which matches `check_daily_limit`'s existing "0 means unlimited" behaviour
+   used by `fund_c_address`.
+5. Extends instance TTL via the existing `extend_instance_ttl` helper.
+
+No new storage keys or helpers were introduced — the daily-limit storage and
+enforcement helpers (`save_source_daily_limit`, `read_source_daily_limit`,
+`check_daily_limit`) already existed; this function was simply the missing
+admin-facing setter that wires into them.
+
+## Verification
+
+`cargo check -p onboarding-bridge` passes with no new errors. As noted in the
+issue, the crate's test target does not currently compile for unrelated,
+pre-existing reasons, so `cargo test` could not be run.


### PR DESCRIPTION
┌─────────┬────────────────────────┬──────────────────────┐
│ Commit  │        Function        │      Diff size       │
├─────────┼────────────────────────┼──────────────────────┤
│ a361519 │ set_asset_fee_cap      │ 41 lines (+ README)  │
├─────────┼────────────────────────┼──────────────────────┤
│ bbaffd3 │ set_source_daily_limit │ 37 lines (+ README)  │
├─────────┼────────────────────────┼──────────────────────┤
│ 84c9b3b │ set_fee_bps            │ 47 lines (+ README)  │
├─────────┼────────────────────────┼──────────────────────┤
│ f07fb49 │ batch_fund_c_address   │ 142 lines (+ README) │
└─────────┴────────────────────────┴──────────────────────┘

Each implementation reuses existing storage/helper functions already in lib.rs (save_asset_fee_cap, save_source_daily_limit, save_fee_bps, check_daily_limit, check_access, get_effective_fee_bps, etc.) — no new storage keys or signatures. batch_fund_c_address follows the documented skip-and-refund-blocked-targets behavior, aggregates duplicate targets into single transfers, and emits all three documented events.

Closes #441
Closes #442
Closes #443 
Closes #444