### PR TITLE
feat(onboarding-bridge): implement admin fee/limit accessors

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1721,13 +1721,19 @@ impl OnboardingBridge {
 
     pub fn query_pending_admin(env: Env) -> Option<Address> {
 
-        todo!("implement: query_pending_admin")
+        read_pending_admin(&env)
 
     }
 
     pub fn set_minimum_amount(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
 
-        todo!("implement: set_minimum_amount")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        save_minimum_amount(&env, &amount);
+        extend_instance_ttl(&env);
+        Ok(())
 
     }
 
@@ -1792,7 +1798,13 @@ impl OnboardingBridge {
 
     pub fn set_max_withdraw_per_tx(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
 
-        todo!("implement: set_max_withdraw_per_tx")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        save_max_withdraw_per_tx(&env, amount);
+        extend_instance_ttl(&env);
+        Ok(())
 
     }
 
@@ -1804,7 +1816,8 @@ impl OnboardingBridge {
 
     pub fn query_fee_bps(env: Env) -> Result<u32, BridgeError> {
 
-        todo!("implement: query_fee_bps")
+        check_initialized(&env)?;
+        Ok(read_fee_bps(&env))
 
     }
 


### PR DESCRIPTION
## Summary
Implements four `todo!()` stub functions in `contracts/onboarding-bridge/src/lib.rs`, following the existing admin-auth + nonce + TTL-extension pattern used by sibling setters/getters in the file:

- `query_fee_bps` — returns the configured fee in basis points (after an initialized check).
- `set_minimum_amount` — admin-gated setter for the minimum transfer amount.
- `set_max_withdraw_per_tx` — admin-gated setter for the per-tx withdrawal cap.
- `query_pending_admin` — returns the pending admin handoff address, if any.

Closes #457
Closes #455
Closes #453
Closes #452

## Validation
`cargo` is not available in this sandbox environment, so `cargo check`/`cargo test` could not be run locally. Each implementation was manually verified against the exact signatures of the existing private helpers it calls (`check_initialized`, `read_admin`, `consume_nonce`, `save_minimum_amount`, `save_max_withdraw_per_tx`, `read_fee_bps`, `read_pending_admin`, `extend_instance_ttl`), matching parameter types, ownership, and return types exactly. No signatures, generics, or doc comments were modified.