### PR TITLE
feat(onboarding-bridge): implement allowlist/blocklist removal, emergency migrate, pending upgrade query

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2357,7 +2357,7 @@ impl OnboardingBridge {
     /// Returns `None` if no upgrade has been scheduled or if a previous
     /// upgrade has already been executed or cancelled.
     pub fn query_pending_upgrade(env: Env) -> Option<PendingUpgrade> {
-        todo!("implement: query_pending_upgrade")
+        read_pending_upgrade(&env)
     }
 
     /// Migrates the contract state to a new contract address in case of emergency.
@@ -2375,7 +2375,27 @@ impl OnboardingBridge {
         new_contract: Address,
         migrate_data: bool,
     ) -> Result<(), BridgeError> {
-        todo!("implement: emergency_migrate")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+
+        if migrate_data {
+            let config = read_config(&env);
+            env.events().publish(
+                ("EmergencyMigrate", "config"),
+                (config.fee_bps, config.paused, config.allowlist_mode),
+            );
+            env.events().publish(
+                ("EmergencyMigrate", "collector"),
+                (read_fee_collector(&env),),
+            );
+        }
+
+        env.storage().instance().set(&DataKey::Deactivated, &true);
+        env.events()
+            .publish(("EmergencyMigrated", admin), (new_contract,));
+
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -2423,7 +2443,16 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_from_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: remove_from_blocklist")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Blocked(address));
+
+        Ok(())
     }
 
     /// Adds `address` to the allowlist.
@@ -2468,7 +2497,16 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_from_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: remove_from_allowlist")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        env.storage()
+            .persistent()
+            .remove(&DataKey::Allowlisted(address));
+
+        Ok(())
     }
 
     /// Enables or disables allowlist mode.


### PR DESCRIPTION
## Summary
Implements the four `todo!()` stubbed function bodies assigned to me in `contracts/onboarding-bridge/src/lib.rs`:

- `remove_from_allowlist` — removes the address's `Allowlisted` persistent-storage entry, gated by admin auth + nonce.
- `remove_from_blocklist` — removes the address's `Blocked` persistent-storage entry, gated by admin auth + nonce.
- `emergency_migrate` — requires admin auth, optionally emits contract-state events when `migrate_data` is true, and marks the contract `Deactivated`.
- `query_pending_upgrade` — returns the existing `read_pending_upgrade` helper's result.

Signatures, generics, and doc comments were left unchanged as instructed; only function bodies were filled in, following the admin-auth/nonce/storage conventions already used elsewhere in the contract.

Closes #482
Closes #480
Closes #478
Closes #477

## Validation performed
- Manual review against existing patterns (`consume_nonce`, `check_initialized`, `read_admin`, `is_blocked`/`is_allowlisted`, `read_pending_upgrade`, `env.events().publish`) used by sibling functions in the same file.
- `cargo check` could not be run — no Rust toolchain is available in this environment, and per the seeded-exercise notes (#406–#412), the crate's test target does not currently compile regardless.