### PR TITLE
feat(onboarding-bridge): implement blocklist/allowlist admin functions

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2404,7 +2404,14 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_to_blocklist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: add_to_blocklist")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Blocked(address), &true);
+        Ok(())
     }
 
     /// Removes `address` from the blocklist, restoring its ability to receive funds.
@@ -2446,7 +2453,14 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_to_allowlist(env: Env, address: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: add_to_allowlist")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Allowlisted(address), &true);
+        Ok(())
     }
 
     /// Removes `address` from the allowlist.
@@ -2493,12 +2507,17 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn set_allowlist_mode(env: Env, enabled: bool, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: set_allowlist_mode")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        set_allowlist_mode_flag(&env, enabled);
+        Ok(())
     }
 
     /// Returns `true` if `address` is on the blocklist.
     pub fn query_is_blocked(env: Env, address: Address) -> bool {
-        todo!("implement: query_is_blocked")
+        is_blocked(&env, &address)
     }
 
     /// Returns `true` if `address` is on the allowlist.


### PR DESCRIPTION
## Summary
Implements the four seeded-exercise stubs for blocklist/allowlist management, following the existing admin-auth/nonce/storage helper patterns already in the file:
- `add_to_blocklist` — sets `DataKey::Blocked(address)` after admin auth + nonce check
- `add_to_allowlist` — sets `DataKey::Allowlisted(address)` after admin auth + nonce check
- `set_allowlist_mode` — toggles allowlist mode via existing `set_allowlist_mode_flag` helper after admin auth + nonce check
- `query_is_blocked` — returns `is_blocked(address)`

Closes #479
Closes #481
Closes #483
Closes #484

## Validation
- `cargo check` / `cargo test` could not be run in this environment (no Rust toolchain available); implementation mirrors the existing `consume_nonce` / `read_admin` / `check_initialized` patterns used throughout the file for identical admin+nonce-gated setters.