### PR TITLE
feat(bridge): implement upgrade lifecycle and total fees query

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2120,7 +2120,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_total_fees_collected(env: Env, asset: Address) -> Result<i128, BridgeError> {
-        todo!("implement: query_total_fees_collected")
+        check_initialized(&env)?;
+        Ok(read_total_fees_collected(&env, &asset))
     }
 
     // -----------------------------------------------------------------------
@@ -2225,7 +2226,20 @@ impl OnboardingBridge {
     /// The `old_hash` in the event lets off-chain monitors detect unexpected
     /// upgrades. Consider using the timelocked path for mainnet deployments.
     pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: upgrade")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+
+        let old_hash = read_current_wasm_hash(&env);
+        save_current_wasm_hash(&env, &new_wasm_hash);
+        env.deployer()
+            .update_current_contract_wasm(new_wasm_hash.clone());
+
+        env.events()
+            .publish(("ContractUpgraded",), (old_hash, new_wasm_hash, admin));
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -2323,7 +2337,30 @@ impl OnboardingBridge {
         expected_hash: BytesN<32>,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        todo!("implement: execute_upgrade")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+
+        let pending = read_pending_upgrade(&env).ok_or(BridgeError::UpgradeNotScheduled)?;
+        if pending.new_wasm_hash != expected_hash {
+            return Err(BridgeError::UpgradeHashMismatch);
+        }
+        if env.ledger().sequence() < pending.executable_after_ledger {
+            return Err(BridgeError::UpgradeTimelockActive);
+        }
+
+        clear_pending_upgrade(&env);
+
+        let old_hash = read_current_wasm_hash(&env);
+        save_current_wasm_hash(&env, &expected_hash);
+        env.deployer()
+            .update_current_contract_wasm(expected_hash.clone());
+
+        env.events()
+            .publish(("ContractUpgraded",), (old_hash, expected_hash, admin));
+        Ok(())
     }
 
     /// Cancels a pending scheduled upgrade.
@@ -2349,7 +2386,18 @@ impl OnboardingBridge {
     ///
     /// * `("UpgradeCancelled",)` — data: `(cancelled_wasm_hash, admin)`
     pub fn cancel_upgrade(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: cancel_upgrade")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+
+        let pending = read_pending_upgrade(&env).ok_or(BridgeError::UpgradeNotScheduled)?;
+        clear_pending_upgrade(&env);
+
+        env.events()
+            .publish(("UpgradeCancelled",), (pending.new_wasm_hash, admin));
+        Ok(())
     }
 
     /// Returns the pending scheduled upgrade, if any.


### PR DESCRIPTION
## Summary
Implements four `todo!()` stubs in `contracts/onboarding-bridge/src/lib.rs`, all part of the seeded exercise set:

- `upgrade` — immediate untimelocked WASM upgrade, admin-authorized.
- `execute_upgrade` — executes a scheduled upgrade after its timelock, validating the expected hash and clearing the pending record before applying (re-entrant-replay safe).
- `cancel_upgrade` — clears a pending scheduled upgrade.
- `query_total_fees_collected` — returns cumulative gross fees collected for an asset.

Each function keeps its existing signature, generics, and doc comment; only the body was implemented, following the documented `# Errors` / `# Events` contracts and reusing existing helpers (`read_admin`, `consume_nonce`, `read_pending_upgrade`, `read_total_fees_collected`, etc.).

Closes #474
Closes #475
Closes #476
Closes #470

## Validation
- `cargo check` passes with 0 errors (only pre-existing warnings from other still-unimplemented `todo!()` functions elsewhere in the file, out of scope here).
- `cargo test` was not run — the crate's test target does not currently compile (tracked separately in #406–#412), as noted in each issue.