### PR TITLE
feat(onboarding-bridge): implement query stub bodies

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1982,7 +1982,16 @@ impl OnboardingBridge {
         env: Env,
         assets: Vec<Address>,
     ) -> Result<Map<Address, i128>, BridgeError> {
-        todo!("implement: query_all_balances")
+        if assets.len() > MAX_BATCH_SIZE {
+            return Err(BridgeError::BatchTooLarge);
+        }
+        let contract_addr = env.current_contract_address();
+        let mut balances = Map::new(&env);
+        for asset in assets.iter() {
+            let token_client = token::Client::new(&env, &asset);
+            balances.set(asset.clone(), token_client.balance(&contract_addr));
+        }
+        Ok(balances)
     }
 
     /// Returns the contract's total token balance for `asset`.
@@ -2000,7 +2009,7 @@ impl OnboardingBridge {
 
     /// Returns `true` if the contract has been initialised.
     pub fn query_is_initialized(env: Env) -> bool {
-        todo!("implement: query_is_initialized")
+        read_initialized(&env)
     }
 
     /// Returns the current sequential nonce value for `caller`.
@@ -2013,7 +2022,7 @@ impl OnboardingBridge {
     ///
     /// * `caller` (`Address`) — The address whose nonce is queried.
     pub fn query_nonce(env: Env, caller: Address) -> u64 {
-        todo!("implement: query_nonce")
+        read_nonce(&env, &caller)
     }
 
     /// Simulates the fee and net amount for a given gross amount at the current
@@ -2040,7 +2049,10 @@ impl OnboardingBridge {
     /// // assert_eq!(net, 990i128);
     /// ```
     pub fn query_calculate_fee(env: Env, gross_amount: i128) -> Result<(i128, i128), BridgeError> {
-        todo!("implement: query_calculate_fee")
+        let fee_bps = read_fee_bps(&env);
+        let fee = calculate_fee(gross_amount, fee_bps)?;
+        let net = safe_math::safe_sub(gross_amount, fee)?;
+        Ok((fee, net))
     }
 
     /// Returns the real effective fee that would be charged for a specific


### PR DESCRIPTION
## Summary
Implements four `todo!()` query stubs in `contracts/onboarding-bridge/src/lib.rs`, each using existing storage/config helpers already present in the contract:

- `query_all_balances` — reads the bridge contract's own token balance for each asset via `token::Client`, enforcing `MAX_BATCH_SIZE`.
- `query_is_initialized` — delegates to existing `read_initialized`.
- `query_nonce` — delegates to existing `read_nonce`.
- `query_calculate_fee` — computes `(fee, net)` via existing `calculate_fee` + `safe_math::safe_sub`.

Signatures, generics, and doc comments are unchanged; only function bodies were modified.

Closes #468
Closes #467
Closes #466
Closes #464

## Validation
- Rust toolchain (`cargo`) is not available in this environment, so `cargo check`/`cargo test` could not be run locally. Implementations were manually verified against existing helper functions (`read_initialized`, `read_nonce`, `read_fee_bps`, `calculate_fee`, `safe_math::safe_sub`) and equivalent balance-query patterns already used elsewhere in the file (`token::Client::new` + `env.current_contract_address()`).
- Per the issue notes, the crate's test target does not currently compile independent of this change (tracked separately in #406–#412).