### PR TITLE
feat(onboarding-bridge): implement query_admin, query_balance, query_fee_balance, fund_c_address_with_referral

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1915,7 +1915,66 @@ impl OnboardingBridge {
         amount: i128,
         referrer: Option<Address>,
     ) -> Result<(), BridgeError> {
-        todo!("implement: fund_c_address_with_referral")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        source.require_auth();
+
+        if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        let minimum_amount = read_minimum_amount(&env);
+        if amount < minimum_amount {
+            return Err(BridgeError::InvalidAmount);
+        }
+
+        check_access(&env, &target)?;
+        check_asset_whitelisted(&env, &asset)?;
+        check_daily_limit(&env, &source, &asset, amount)?;
+
+        let token_client = token::Client::new(&env, &asset);
+        let contract_addr = env.current_contract_address();
+        token_client.transfer(&source, &contract_addr, &amount);
+
+        let global_fee_bps = read_fee_bps(&env);
+        let tiered_fee_bps = get_tiered_fee_bps(&env, &source, global_fee_bps);
+        let effective_fee_bps = get_effective_fee_bps(&env, &asset, tiered_fee_bps);
+        let fee = calculate_fee(amount, effective_fee_bps)?;
+        let net_amount = safe_math::safe_sub(amount, fee)?;
+
+        if net_amount > 0 {
+            token_client.transfer(&contract_addr, &target, &net_amount);
+        }
+
+        let mut protocol_fee = fee;
+        if let Some(ref referrer_addr) = referrer {
+            let referral_rate = read_referral_rate(&env);
+            let referral_fee = calculate_fee(fee, referral_rate)?;
+            if referral_fee > 0 {
+                token_client.transfer(&contract_addr, referrer_addr, &referral_fee);
+                protocol_fee = safe_math::safe_sub(fee, referral_fee)?;
+                env.events().publish(
+                    ("ReferralPaid", source.clone(), referrer_addr.clone()),
+                    (referral_fee, asset.clone()),
+                );
+            }
+        }
+
+        increment_user_deposit(&env, &source, &asset, amount)?;
+        increment_accrued_fees(&env, &asset, protocol_fee)?;
+        increment_total_bridged(&env, &asset, net_amount)?;
+        increment_total_fees_collected(&env, &asset, protocol_fee)?;
+        increment_source_bridged_volume(&env, &source, amount)?;
+
+        extend_instance_ttl(&env);
+
+        mint_loyalty_tokens(&env, &source);
+
+        env.events().publish(
+            ("CAddressFunded", asset, source, target),
+            (amount, fee),
+        );
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -1937,7 +1996,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_admin(env: Env) -> Result<Address, BridgeError> {
-        todo!("implement: query_admin")
+        check_initialized(&env)?;
+        Ok(read_admin(&env))
     }
 
     /// Returns the token balance of `c_address` for `asset`.
@@ -1950,7 +2010,8 @@ impl OnboardingBridge {
     /// * `c_address` (`Address`) — The address whose balance is queried.
     /// * `asset` (`Address`) — The token contract address.
     pub fn query_balance(env: Env, c_address: Address, asset: Address) -> i128 {
-        todo!("implement: query_balance")
+        let token_client = token::Client::new(&env, &asset);
+        token_client.balance(&c_address)
     }
 
     /// Returns the bridge contract's own balance for each asset in `assets`.
@@ -1995,7 +2056,9 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_fee_balance(env: Env, asset: Address) -> Result<i128, BridgeError> {
-        todo!("implement: query_fee_balance")
+        check_initialized(&env)?;
+        let token_client = token::Client::new(&env, &asset);
+        Ok(token_client.balance(&env.current_contract_address()))
     }
 
     /// Returns `true` if the contract has been initialised.


### PR DESCRIPTION
## Summary

Implements four `todo!()` contract function bodies in `contracts/onboarding-bridge/src/lib.rs`, per their documented contracts:

- `query_admin` — returns the stored admin address after an initialization check.
- `query_balance` — pure read-through to the token contract's `balance` for `c_address`.
- `query_fee_balance` — returns the contract's total token balance for `asset` after an initialization check.
- `fund_c_address_with_referral` — same transfer/fee flow as `fund_c_address` (tiered + capped effective fee, daily limit, access/whitelist checks, loyalty mint), plus a referral-fee split: when `referrer` is `Some` and the computed referral cut is > 0, it is transferred directly to the referrer and a `ReferralPaid` event is emitted; the remainder accrues to the contract as usual, followed by a `CAddressFunded` event.

Signatures, generics, and doc comments are unchanged — only function bodies were implemented.

Closes #462
Closes #463
Closes #465
Closes #460

## Validation

- `cargo` is unavailable in this environment, so `cargo check`/`cargo test` could not be run locally. All helper functions and their signatures (`token::Client`, `check_initialized`, `check_access`, `check_asset_whitelisted`, `check_daily_limit`, `get_tiered_fee_bps`, `get_effective_fee_bps`, `calculate_fee`, `safe_math::safe_sub`, `read_referral_rate`, `increment_*`, `mint_loyalty_tokens`, `ReentrancyGuard`) were verified against their existing definitions and usages elsewhere in the file (in particular `execute_meta_fund`, which implements the same transfer/fee flow as `fund_c_address`).