### PR TITLE
feat(onboarding-bridge): implement pause, unpause, query_is_paused, query_effective_fee

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2094,7 +2094,14 @@ impl OnboardingBridge {
         asset: Address,
         amount: i128,
     ) -> Result<(u32, i128, i128), BridgeError> {
-        todo!("implement: query_effective_fee")
+        check_initialized(&env)?;
+        let global_fee_bps = read_fee_bps(&env);
+        let tiered_fee_bps = get_tiered_fee_bps(&env, &source, global_fee_bps);
+        let cap = read_asset_fee_cap(&env, &asset);
+        let effective_fee_bps = tiered_fee_bps.min(cap);
+        let fee = calculate_fee(amount, effective_fee_bps)?;
+        let net = safe_math::safe_sub(amount, fee)?;
+        Ok((effective_fee_bps, fee, net))
     }
 
     /// Returns the cumulative net amount of `asset` that has been delivered to
@@ -2158,7 +2165,15 @@ impl OnboardingBridge {
     /// scheduling or executing upgrades, which are intentionally not pause-gated
     /// so that an upgrade can fix whatever condition required the pause.
     pub fn pause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: pause")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        set_paused(&env, true);
+
+        env.events().publish(("ContractPaused",), (admin,));
+        Ok(())
     }
 
     /// Resumes normal contract operation after a pause.
@@ -2180,12 +2195,20 @@ impl OnboardingBridge {
     ///
     /// * `("ContractUnpaused",)` — data: `(admin,)`
     pub fn unpause(env: Env, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: unpause")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+
+        set_paused(&env, false);
+
+        env.events().publish(("ContractUnpaused",), (admin,));
+        Ok(())
     }
 
     /// Returns `true` if the contract is currently paused.
     pub fn query_is_paused(env: Env) -> bool {
-        todo!("implement: query_is_paused")
+        read_paused(&env)
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements four `todo!()` stubs in `contracts/onboarding-bridge/src/lib.rs`, following each function's documented contract exactly (signature, doc comments, and documented error/event behavior unchanged):

- `query_is_paused` — returns stored pause state.
- `pause` — admin-authorized, nonce-checked, sets paused flag, emits `ContractPaused`.
- `unpause` — admin-authorized, nonce-checked, clears paused flag, emits `ContractUnpaused`.
- `query_effective_fee` — resolves fee via global rate → volume tier → asset cap pipeline, returns `(effective_fee_bps, fee, net)`.

## Validation
No Rust toolchain (`cargo`/`rustc`) was available in this environment, so `cargo check` could not be run. Implementations reuse existing helper functions (`read_admin`, `consume_nonce`, `set_paused`, `read_paused`, `read_fee_bps`, `get_tiered_fee_bps`, `read_asset_fee_cap`, `calculate_fee`, `safe_math::safe_sub`) with matching signatures/types, mirroring patterns used elsewhere in the file (e.g. event publishing at `mint_loyalty_tokens`). Per the issues, the crate's test target currently doesn't compile pending #406–#412, so `cargo test` is not expected to run yet either.

Closes #473
Closes #472
Closes #471
Closes #469