### PR TITLE
feat(bridge): implement fee collector, referral rate, and max withdraw queries

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1812,7 +1812,8 @@ impl OnboardingBridge {
 
     pub fn query_max_withdraw_per_tx(env: Env) -> Result<i128, BridgeError> {
 
-        todo!("implement: query_max_withdraw_per_tx")
+        check_initialized(&env)?;
+        Ok(read_max_withdraw_per_tx(&env))
 
     }
 
@@ -1848,7 +1849,17 @@ impl OnboardingBridge {
     ///
     /// * `("ReferralRateChanged", bps)` — no additional data.
     pub fn set_referral_rate(env: Env, bps: u32, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: set_referral_rate")
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        if bps > FEE_DENOMINATOR as u32 {
+            return Err(BridgeError::FeeTooHigh);
+        }
+        extend_instance_ttl(&env);
+        save_referral_rate(&env, bps);
+        env.events().publish(("ReferralRateChanged", bps), ());
+        Ok(())
     }
 
     /// Returns the current referral rate in basis points.
@@ -1859,7 +1870,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_referral_rate(env: Env) -> Result<u32, BridgeError> {
-        todo!("implement: query_referral_rate")
+        check_initialized(&env)?;
+        Ok(read_referral_rate(&env))
     }
 
     /// Funds a C-address with an optional referrer that receives a share of the fee.
@@ -1942,7 +1954,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_fee_collector(env: Env) -> Result<Address, BridgeError> {
-        todo!("implement: query_fee_collector")
+        check_initialized(&env)?;
+        Ok(read_fee_collector(&env))
     }
 
     /// Returns the current admin address.


### PR DESCRIPTION
## Summary
Implements four `todo!()` stub functions in `contracts/onboarding-bridge/src/lib.rs`:
- `query_fee_collector` — returns the stored fee collector address after checking initialization.
- `query_referral_rate` — returns the stored referral rate (bps).
- `set_referral_rate` — validates admin auth, nonce, and `bps <= 10_000`, then persists the rate and emits `ReferralRateChanged`.
- `query_max_withdraw_per_tx` — returns the stored max-withdraw-per-tx amount.

All function signatures, generics, and doc comments were left unchanged; only bodies were implemented, following the same patterns used by existing implemented functions (e.g. `set_fee_bps`, `accept_admin`) for storage access, nonce handling, and event emission.

Closes #456
Closes #458
Closes #459
Closes #461

## Validation
- `cargo check` was not available in this environment (no Rust toolchain installed), so the change was validated by manual review against existing implemented functions' patterns for storage helpers, auth/nonce handling, and error variants documented on each function.