### PR TITLE
feat(contract): implement propose_new_admin and query_minimum_amount

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1711,7 +1711,17 @@ impl OnboardingBridge {
     /// This two-step path is preferred over `set_admin` for normal operations
     /// because it prevents accidentally transferring control to an unusable key.
     pub fn propose_new_admin(env: Env, new_admin: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: propose_new_admin")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+        save_pending_admin(&env, &new_admin);
+        env.events()
+            .publish(("AdminProposed", admin, new_admin), ());
+        Ok(())
     }
 
     /// Accepts a pending admin handoff.
@@ -1756,7 +1766,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_minimum_amount(env: Env) -> Result<i128, BridgeError> {
-        todo!("implement: query_minimum_amount")
+        check_initialized(&env)?;
+        Ok(read_minimum_amount(&env))
     }
 
     /// Withdraws accrued protocol fees to the fee collector.


### PR DESCRIPTION
## Summary

Implements two `todo!()` stubs in `contracts/onboarding-bridge/src/lib.rs`:

- `propose_new_admin`: admin-authorized, nonce-guarded two-step admin handoff proposal. Requires the current admin's `require_auth()`, consumes the optional sequential nonce, stores the proposed admin via `save_pending_admin`, and emits an `AdminProposed` event. Consumed by the existing `accept_admin` implementation.
- `query_minimum_amount`: returns the stored minimum transfer amount (0 default) after verifying the contract is initialized, matching the documented contract exactly.

Closes #450
Closes #454

closes #451 (`accept_admin`) was already implemented in `main` prior to this branch, so no change was needed for it.

## Validation

No Rust toolchain is available in this environment, so `cargo check`/`cargo test` could not be run locally. Changes were written to closely mirror existing, already-implemented sibling functions (`accept_admin`, `extend_timelock_ttl`) for guard ordering, auth, nonce handling, and event conventions. Doc comments and signatures were left untouched.