### PR TITLE
feat: implement allowlist queries, reclaim and asset whitelist

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -2707,12 +2707,12 @@ impl OnboardingBridge {
 
     /// Returns `true` if `address` is on the allowlist.
     pub fn query_is_allowlisted(env: Env, address: Address) -> bool {
-        todo!("implement: query_is_allowlisted")
+        is_allowlisted(&env, &address)
     }
 
     /// Returns `true` if allowlist mode is currently enabled.
     pub fn query_allowlist_mode(env: Env) -> bool {
-        todo!("implement: query_allowlist_mode")
+        allowlist_mode(&env)
     }
 
     // -----------------------------------------------------------------------
@@ -2768,7 +2768,29 @@ impl OnboardingBridge {
         destination: Address,
         nonce: Option<u64>,
     ) -> Result<(), BridgeError> {
-        todo!("implement: reclaim_tokens")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+
+        let token_client = token::Client::new(&env, &asset);
+        let contract_balance = token_client.balance(&env.current_contract_address());
+        let counters = read_asset_counters(&env, &asset);
+        let reclaimable = contract_balance - counters.accrued_fees - counters.locked_timelock;
+
+        if reclaimable < amount {
+            return Err(BridgeError::InsufficientReclaimable);
+        }
+
+        token_client.transfer(&env.current_contract_address(), &destination, &amount);
+        env.events()
+            .publish(("TokensReclaimed", admin, asset), (amount, destination));
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -2795,7 +2817,16 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: add_asset")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+        let mut whitelist = read_whitelist(&env);
+        whitelist.set(asset, true);
+        save_whitelist(&env, &whitelist);
+        Ok(())
     }
 
     /// Removes `asset` from the token whitelist.


### PR DESCRIPTION
## PR Description:
Implements 4 seeded exercises.

- `query_is_allowlisted` returns persistent allowlist state
- `query_allowlist_mode` returns instance allowlist mode flag
- `reclaim_tokens` ring-fences accrued_fees + locked_timelock
- `add_asset` admin-gated whitelist insert (idempotent)

Closes #485
Closes #486
Closes #487
Closes #488

**Checklist:**

- Implement body of query_is_allowlisted in contracts/onboarding-bridge/src/lib.rs keep signature/doc unchanged
- Implement body of query_allowlist_mode in contracts/onboarding-bridge/src/lib.rs keep signature/doc unchanged
- Implement body of reclaim_tokens in contracts/onboarding-bridge/src/lib.rs keep signature/doc unchanged return documented BridgeError variants
- Implement body of add_asset in contracts/onboarding-bridge/src/lib.rs keep signature/doc unchanged
- Confirm cargo check passes