### PR TITLE
implement: withdraw_fees

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1951,7 +1951,36 @@ impl OnboardingBridge {
     /// // bridge.withdraw_fees(&usdc, &5i128, &None);
     /// ```
     pub fn withdraw_fees(env: Env, asset: Address, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: withdraw_fees")
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+
+        // Only the current fee collector may withdraw accrued fees.
+        let fee_collector = read_fee_collector(&env);
+        fee_collector.require_auth();
+        consume_nonce(&env, &fee_collector, nonce)?;
+
+        if amount <= 0 {
+            return Err(BridgeError::InvalidAmount);
+        }
+
+        let accrued = read_accrued_fees(&env, &asset);
+        if amount > accrued {
+            return Err(BridgeError::InsufficientReclaimable);
+        }
+
+        // Transfer the tokens to the fee collector, then decrement the accrued
+        // fee counter so it always tracks the fee collector's entitlement.
+        let token_client = token::Client::new(&env, &asset);
+        token_client.transfer(&env.current_contract_address(), &fee_collector, &amount);
+        decrement_accrued_fees(&env, &asset, amount);
+
+        env.events().publish(
+            ("FeesWithdrawn", fee_collector.clone()),
+            (amount, asset),
+        );
+
+        extend_instance_ttl(&env);
+        Ok(())
     }
 
     pub fn set_max_withdraw_per_tx(env: Env, amount: i128, nonce: Option<u64>) -> Result<(), BridgeError> {


### PR DESCRIPTION
Closes #527
Closes #528
Closes #529

## Summary

Implements the `withdraw_fees` body in `contracts/onboarding-bridge/src/lib.rs`, replacing the seeded `todo!()`. This is one of the exercise-set functions awaiting implementation.

## Behavior

The function now:
- Rejects calls before initialization (`NotInitialized`) and while paused (`ContractPaused`).
- Enforces the registered fee collector via `read_fee_collector(...).require_auth()`.
- Enforces the optional sequential nonce (`DuplicateNonce`).
- Validates `amount > 0` (`InvalidAmount`) and `amount ≤ accrued` (`InsufficientReclaimable`).
- Transfers tokens from the contract to the fee collector through the SAC token interface.
- Decrements the on-chain accrued-fees counter so it stays in sync with the fee collector's entitlement.
- Emits `("FeesWithdrawn", fee_collector)` with data `(amount, asset)`.
- Extends the instance TTL on success.

The signature, generics, return type, and doc comment are unchanged.

## Verification

- `cargo check -p onboarding-bridge` **passes** (only pre-existing dead-code warnings).
- The crate's test target still does **not** compile — this is the pre-existing, repo-wide issue tracked in #406–#412 (the integration tests in `src/tests.rs` such as `test_withdraw_fees`, `test_withdraw_fees_decrements_accrued`, `test_withdraw_fees_exceeds_accrued`, `test_withdraw_fees_paused`, and `test_withdraw_fees_requires_fee_collector_auth` encode the expected behavior and will exercise this path once that lands).