### PR TITLE
Implement set_max_persistent_ttl in onboarding-bridge

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3603,7 +3603,22 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::InvalidTtl`] — `ttl` is below `MIN_ALLOWED_TTL`.
     pub fn set_max_persistent_ttl(env: Env, ttl: u32) -> Result<(), BridgeError> {
-        todo!("implement: set_max_persistent_ttl")
+        check_initialized(&env)?;
+
+        if ttl < MIN_ALLOWED_TTL {
+            return Err(BridgeError::InvalidTtl);
+        }
+
+        let admin = read_admin(&env);
+        admin.require_auth();
+
+        let capped = ttl.min(MAX_ALLOWED_TTL);
+        env.storage()
+            .instance()
+            .set(&DataKey::MaxPersistentTtl, &capped);
+        extend_instance_ttl(&env);
+
+        Ok(())
     }
 
     /// Returns the four TTL configuration values.


### PR DESCRIPTION
Closes #516
Closes #517
Closes #518
Closes #519

## Summary

Implements `set_max_persistent_ttl` in `contracts/onboarding-bridge/src/lib.rs`, replacing the `todo!()` stub with the behavior documented on the function.

The body now:

1. Returns `BridgeError::NotInitialized` via `check_initialized` when the contract isn't initialized.
2. Returns `BridgeError::InvalidTtl` when `ttl < MIN_ALLOWED_TTL` — validated **before** `require_auth` so the error surfaces immediately without needing an admin signature (matches the convention in implemented setters like `set_fee_bps`).
3. Requires the current admin's `require_auth()`.
4. Silently caps values above `MAX_ALLOWED_TTL` (`ttl.min(MAX_ALLOWED_TTL)`).
5. Persists the new maximum under `DataKey::MaxPersistentTtl` in instance storage, then calls `extend_instance_ttl` like the other config setters.

Signature, generics, return type, and doc comment are unchanged.

## Motivation

This is one of the seeded `todo!()` exercise stubs in the repo. The implementation follows the exact pattern of the already-implemented admin setters (e.g. `set_fee_bps`, `set_source_daily_limit`) and the shared `read_max_persistent_ttl` helper, keeping storage-key usage and TTL-extension semantics consistent with the rest of the contract.

## Verification

- `cargo check -p onboarding-bridge` passes (run inside a `rust:latest` container since Rust isn't installed on the host). Only pre-existing dead-code warnings from the remaining `todo!()` stubs are emitted.
- Matches the expectations in the existing `test_set_max_ttl_updates_config` test (`set_max_persistent_ttl(&300_000)` is read back as `300_000` by `query_ttl_config`).

## Checklist

- [x] Implemented the body of `set_max_persistent_ttl`
- [x] Kept signature, generics, and return type unchanged
- [x] Doc comment untouched
- [x] Returns the documented `BridgeError` variants (`NotInitialized`, `InvalidTtl`)
- [x] `cargo check` passes