### PR TITLE
feat: implement query_asset_fee_cap

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -1796,7 +1796,8 @@ impl OnboardingBridge {
         env: Env,
         asset: Address,
     ) -> Result<u32, BridgeError> {
-        todo!("implement: query_asset_fee_cap")
+        check_initialized(&env)?;
+        Ok(read_asset_fee_cap(&env, &asset))
     }
 
     /// Changes the address that is entitled to call `withdraw_fees`.


### PR DESCRIPTION
Closes #445

Implements `query_asset_fee_cap` in `contracts/onboarding-bridge/src/lib.rs`.

- Returns `BridgeError::NotInitialized` when the contract has not been initialized.
- Otherwise returns the per-asset fee cap stored in persistent storage, falling back to the contract-wide `MAX_FEE_BPS` (1 000) when no cap has been set.

The implementation reuses the existing `check_initialized` and `read_asset_fee_cap` helpers.