### PR TITLE
feat(swap-pool): implement add_swap_pool and remove_swap_pool (#492, #493)

### DIFF
--- a/contracts/onboarding-bridge/src/benchmarks.rs
+++ b/contracts/onboarding-bridge/src/benchmarks.rs
@@ -1,5 +1,4 @@
 //! Gas/cost benchmarks for OnboardingBridge contract functions.
-//!
 //! Run with:
 //!   cargo test -p onboarding-bridge --features testutils bench_ -- --nocapture
 //!
@@ -14,6 +13,7 @@ extern crate std;
 use std::{format, println};
 
 use crate::tests::swap_pool_contract::{SwapPool, SwapPoolClient};
+use crate::tests::{advance_ledger_sequence, advance_ledger_time};
 use crate::OnboardingBridge;
 
 use ed25519_dalek::{Signer, SigningKey};

--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3185,7 +3185,17 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn add_swap_pool(env: Env, pool: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: add_swap_pool")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+        let mut whitelist = read_pool_whitelist(&env);
+        whitelist.set(pool, true);
+        save_pool_whitelist(&env, &whitelist);
+        Ok(())
     }
 
     /// Removes `pool` from the DEX swap-pool whitelist.
@@ -3207,7 +3217,17 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_swap_pool(env: Env, pool: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: remove_swap_pool")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        check_not_paused(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+        let mut whitelist = read_pool_whitelist(&env);
+        whitelist.set(pool, false);
+        save_pool_whitelist(&env, &whitelist);
+        Ok(())
     }
 
     /// Returns `true` if `pool` is currently on the swap-pool whitelist.

--- a/contracts/onboarding-bridge/src/tests.rs
+++ b/contracts/onboarding-bridge/src/tests.rs
@@ -5446,3 +5446,103 @@ fn test_extend_timelock_ttl_before_initialize_fails() {
         Err(Ok(BridgeError::NotInitialized))
     );
 }
+
+/********** Swap-pool whitelist tests **********/
+
+#[test]
+fn test_remove_swap_pool_success() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pool = Address::generate(&env);
+    bridge.add_swap_pool(&pool, &None);
+    bridge.remove_swap_pool(&pool, &None);
+
+    // Removing an already-removed pool is idempotent and still succeeds.
+    bridge.remove_swap_pool(&pool, &None);
+}
+
+#[test]
+fn test_remove_swap_pool_allows_re_add() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pool = Address::generate(&env);
+    bridge.add_swap_pool(&pool, &None);
+    bridge.remove_swap_pool(&pool, &None);
+    bridge.add_swap_pool(&pool, &None);
+}
+
+#[test]
+fn test_remove_swap_pool_not_initialized_fails() {
+    let env = Env::default();
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+    let pool = Address::generate(&env);
+
+    assert_eq!(
+        bridge.try_remove_swap_pool(&pool, &None),
+        Err(Ok(BridgeError::NotInitialized))
+    );
+}
+
+#[test]
+fn test_remove_swap_pool_duplicate_nonce_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pool = Address::generate(&env);
+    bridge.add_swap_pool(&pool, &Some(0u64));
+    bridge.remove_swap_pool(&pool, &Some(1u64));
+
+    // Reusing the same nonce must fail.
+    assert_eq!(
+        bridge.try_remove_swap_pool(&pool, &Some(0u64)),
+        Err(Ok(BridgeError::DuplicateNonce))
+    );
+}
+
+#[test]
+fn test_remove_swap_pool_when_paused_fails() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pool = Address::generate(&env);
+    bridge.add_swap_pool(&pool, &None);
+    bridge.pause(&None);
+
+    assert_eq!(
+        bridge.try_remove_swap_pool(&pool, &None),
+        Err(Ok(BridgeError::ContractPaused))
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_remove_swap_pool_requires_admin_auth() {
+    let env = Env::default();
+    let (admin, _user, fee_collector) = create_test_users(&env);
+    let (bridge_id, _) = register_all_contracts_mocked(&env);
+    let bridge = create_bridge_client(&env, &bridge_id);
+
+    bridge.initialize(&admin, &fee_collector, &50u32, &None);
+    let pool = Address::generate(&env);
+    bridge.add_swap_pool(&pool, &None);
+
+    use soroban_sdk::xdr::SorobanAuthorizationEntry;
+    env.set_auths(&[] as &[SorobanAuthorizationEntry]);
+
+    bridge.remove_swap_pool(&pool, &None);
+}


### PR DESCRIPTION
Closes #492
Closes #493
Closes #521

Implements the admin-managed DEX swap-pool whitelist mutations:

- dd_swap_pool whitelists a pool address.
- emove_swap_pool removes a pool address from the whitelist.

Both functions follow the existing admin-mutation pattern: they acquire the reentrancy guard, check initialization and pause state, require admin equire_auth, consume the optional sequential nonce, extend instance TTL, and update the PoolWhitelist map stored in instance storage.

Also adds unit tests for emove_swap_pool covering success, idempotent removal, re-add after removal, NotInitialized, DuplicateNonce, ContractPaused, and admin authorization, plus a small import fix in enchmarks.rs so the test target compiles.