### PR TITLE
feat(asset): implement remove_asset and query_is_asset_whitelisted (#489, #490)

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3127,7 +3127,16 @@ impl OnboardingBridge {
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     /// * [`BridgeError::DuplicateNonce`] — `nonce` mismatch.
     pub fn remove_asset(env: Env, asset: Address, nonce: Option<u64>) -> Result<(), BridgeError> {
-        todo!("implement: remove_asset")
+        let _guard = ReentrancyGuard::enter(&env)?;
+        check_initialized(&env)?;
+        let admin = read_admin(&env);
+        admin.require_auth();
+        consume_nonce(&env, &admin, nonce)?;
+        extend_instance_ttl(&env);
+        let mut whitelist = read_whitelist(&env);
+        whitelist.set(asset, false);
+        save_whitelist(&env, &whitelist);
+        Ok(())
     }
 
     /// Returns `true` if `asset` is currently on the whitelist.
@@ -3136,7 +3145,8 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_is_asset_whitelisted(env: Env, asset: Address) -> Result<bool, BridgeError> {
-        todo!("implement: query_is_asset_whitelisted")
+        check_initialized(&env)?;
+        Ok(read_whitelist(&env).get(asset).unwrap_or(false))
     }
 
     /// Returns a page of currently whitelisted asset addresses.


### PR DESCRIPTION
Closes #489
Closes #490

- emove_asset removes an asset from the whitelist (admin auth required).
- query_is_asset_whitelisted returns the current whitelist status of an asset.

Both follow the existing asset-whitelist patterns and cargo check -p onboarding-bridge passes.