### PR TITLE
feat: implement query_timelocked (#508)

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3637,7 +3637,7 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::TimelockNotFound`] — No entry exists for `id`.
     pub fn query_timelocked(env: Env, id: u64) -> Result<TimelockEntry, BridgeError> {
-        todo!("implement: query_timelocked")
+        read_timelock_entry(&env, id).ok_or(BridgeError::TimelockNotFound)
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #508\n\nImplements query_timelocked by reading the persistent storage entry for the requested ID and returning BridgeError::TimelockNotFound when it is missing.\n\n- Uses the existing ead_timelock_entry helper.\n- Keeps the public signature and doc comment unchanged.\n- cargo check -p onboarding-bridge passes (pre-existing warnings only).