### PR TITLE
feat: implement query_current_tier (#499)

### DIFF
--- a/contracts/onboarding-bridge/src/lib.rs
+++ b/contracts/onboarding-bridge/src/lib.rs
@@ -3340,7 +3340,16 @@ impl OnboardingBridge {
     ///
     /// * [`BridgeError::NotInitialized`] — Contract not yet initialised.
     pub fn query_current_tier(env: Env, source: Address) -> Result<FeeTier, BridgeError> {
-        todo!("implement: query_current_tier")
+        check_initialized(&env)?;
+        let global_bps = read_fee_bps(&env);
+        match find_current_tier(&env, &source) {
+            Some(tier) => Ok(tier),
+            None => Ok(FeeTier {
+                min_volume: 0,
+                max_volume: i128::MAX,
+                fee_bps: global_bps,
+            }),
+        }
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
Closes #499\n\nImplements query_current_tier by looking up the source's cumulative bridged volume and returning the matching fee tier. If no tier matches, returns a synthetic default tier covering the full volume range using the global fee bps.\n\n- Uses the existing ind_current_tier, ead_fee_bps, and check_initialized helpers.\n- Keeps the public signature and doc comment unchanged.\n- cargo check -p onboarding-bridge passes (pre-existing warnings only).